### PR TITLE
feat: using the new first_block_height attribute from meta

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -296,6 +296,7 @@ export interface Meta {
   height: number;
   validation?: string;
   first_block?: string | null;
+  first_block_height?: number | null;
 }
 
 export interface RawTxResponse {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,7 +139,8 @@ export const recursivelyDownloadTx = async (
     let firstBlockHeight = meta.first_block_height;
 
     // We need a fallback for old fullnodes as the first_block_height attribute was only introduced
-    // on v0.49.0
+    // on v0.49.0.
+    // Using == to include `undefined` on this check
     if (firstBlockHeight == null) {
       const firstBlockResponse = await downloadTx(meta.first_block);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,16 +138,8 @@ export const recursivelyDownloadTx = async (
   if (meta.first_block && meta.first_block !== blockId) {
     let firstBlockHeight = meta.first_block_height;
 
-    // We need a fallback for old fullnodes as the first_block_height attribute was only introduced
-    // on v0.49.0.
-    // Using == to include `undefined` on this check
-    if (firstBlockHeight == null) {
-      const firstBlockResponse = await downloadTx(meta.first_block);
-
-      firstBlockHeight = firstBlockResponse.tx.height;
-    }
-
     // This should never happen
+    // Using == to include `undefined` on this check
     if (firstBlockHeight == null) {
       throw new Error('Transaction was confirmed by a block but we were unable to detect its height');
     }


### PR DESCRIPTION
### Acceptance Criteria
- We should use the `first_block_height` attribute from the transaction details instead of re-downloading the transaction to check what height confirmed it


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
