### PR TITLE
feat: daemon healthcheck

### DIFF
--- a/packages/daemon/__tests__/actors/HealthCheckActor.test.ts
+++ b/packages/daemon/__tests__/actors/HealthCheckActor.test.ts
@@ -1,0 +1,195 @@
+import HealthCheckActor from '../../src/actors/HealthCheckActor';
+import axios from 'axios';
+import logger from '../../src/logger';
+import { EventTypes } from '../../src/types/event';
+import getConfig from '../../src/config';
+import { get } from 'lodash';
+
+jest.useFakeTimers();
+jest.spyOn(global, 'setInterval');
+jest.spyOn(global, 'clearInterval');
+
+describe('HealthCheckActor', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    afterAll(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should not start pinging on initialization', () => {
+        const config = getConfig();
+
+        config['HEALTHCHECK_ENABLED'] = true;
+
+        // Mock axios and logger
+        const mockAxios = jest.spyOn(axios, 'post');
+        const mockLogger = jest.spyOn(logger, 'info');
+
+        // Mock the callback and receive functions
+        const mockCallback = jest.fn();
+
+        let receiveCallback: any;
+
+        const mockReceive = jest.fn().mockImplementation((callback) => {
+            receiveCallback = callback;
+        });
+
+        // Call the HealthCheckActor function
+        HealthCheckActor(mockCallback, mockReceive, config);
+
+        expect(setInterval).not.toHaveBeenCalled();
+    });
+
+    it('should start pinging when receiving a START event and stop when receiving a STOP event', () => {
+        const config = getConfig();
+
+        config['HEALTHCHECK_ENABLED'] = true;
+        config['HEALTHCHECK_SERVER_URL'] = 'http://localhost:3000';
+
+        // Mock axios and logger
+        const mockAxios = jest.spyOn(axios, 'post');
+        const mockLogger = jest.spyOn(logger, 'info');
+
+        // Mock the callback and receive functions
+        const mockCallback = jest.fn();
+
+        let receiveCallback: any;
+
+        const mockReceive = jest.fn().mockImplementation((callback) => {
+            receiveCallback = callback;
+        });
+
+        // Call the HealthCheckActor function
+        HealthCheckActor(mockCallback, mockReceive, config);
+
+        // Call the receive callback with a START event
+        receiveCallback({
+            type: EventTypes.HEALTHCHECK_EVENT,
+            event: {
+                type: 'START',
+            },
+        });
+
+        expect(setInterval).toHaveBeenCalledTimes(1);
+
+        // Call the receive callback with a STOP event
+        receiveCallback({
+            type: EventTypes.HEALTHCHECK_EVENT,
+            event: {
+                type: 'STOP',
+            },
+        });
+
+        expect(clearInterval).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop pinging when the actor is stopped', () => {
+        const config = getConfig();
+        config['HEALTHCHECK_ENABLED'] = true;
+        config['HEALTHCHECK_SERVER_URL'] = 'http://localhost:3000';
+
+        // Mock axios and logger
+        const mockAxios = jest.spyOn(axios, 'post');
+        const mockLogger = jest.spyOn(logger, 'info');
+
+        // Mock the callback and receive functions
+        const mockCallback = jest.fn();
+
+        let receiveCallback: any;
+
+        const mockReceive = jest.fn().mockImplementation((callback) => {
+            receiveCallback = callback;
+        });
+
+        // Call the HealthCheckActor function
+        const stopHealthCheckActor = HealthCheckActor(mockCallback, mockReceive, config);
+
+        // Call the receive callback with a START event
+        receiveCallback({
+            type: EventTypes.HEALTHCHECK_EVENT,
+            event: {
+                type: 'START',
+            },
+        });
+
+        expect(setInterval).toHaveBeenCalledTimes(1);
+
+        // Call the stop function
+        stopHealthCheckActor();
+
+        expect(clearInterval).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not start pinging when HEALTHCHECK_ENABLED is false', () => {
+        const config = getConfig();
+        config['HEALTHCHECK_ENABLED'] = false;
+
+        // Mock axios and logger
+        const mockAxios = jest.spyOn(axios, 'post');
+        const mockLogger = jest.spyOn(logger, 'info');
+
+        // Mock the callback and receive functions
+        const mockCallback = jest.fn();
+
+        let receiveCallback: any;
+
+        const mockReceive = jest.fn().mockImplementation((callback) => {
+            receiveCallback = callback;
+        });
+
+        // Call the HealthCheckActor function
+        HealthCheckActor(mockCallback, mockReceive, config);
+
+        expect(mockReceive).not.toHaveBeenCalled();
+    });
+
+    it('should send ping after the configured interval', () => {
+        const config = getConfig();
+        config['HEALTHCHECK_ENABLED'] = true;
+        config['HEALTHCHECK_SERVER_URL'] = 'http://localhost:3000';
+        config['HEALTHCHECK_SERVER_API_KEY'] = 'test-api-key';
+
+        // Mock axios and logger
+        const mockAxios = jest.spyOn(axios, 'post').mockResolvedValue({ status: 200 });
+        const mockLogger = jest.spyOn(logger, 'info');
+
+        // Mock the callback and receive functions
+        const mockCallback = jest.fn();
+
+        let receiveCallback: any;
+
+        const mockReceive = jest.fn().mockImplementation((callback) => {
+            receiveCallback = callback;
+        });
+
+        // Call the HealthCheckActor function
+        HealthCheckActor(mockCallback, mockReceive, config);
+
+        // Call the receive callback with a START event
+        receiveCallback({
+            type: EventTypes.HEALTHCHECK_EVENT,
+            event: {
+                type: 'START',
+            },
+        });
+
+        expect(setInterval).toHaveBeenCalledTimes(1);
+
+        // Fast-forward until all timers have been executed
+        jest.runOnlyPendingTimers();
+
+        expect(mockAxios).toHaveBeenCalledTimes(1);
+        expect(mockAxios).toHaveBeenCalledWith(
+            'http://localhost:3000',
+            {},
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Api-Key': 'test-api-key',
+                },
+            },
+        );
+    });
+});

--- a/packages/daemon/__tests__/machines/SyncMachine.test.ts
+++ b/packages/daemon/__tests__/machines/SyncMachine.test.ts
@@ -272,6 +272,7 @@ describe('Event handling', () => {
     }).withContext({
       event: null,
       socket: null,
+      healthcheck: null,
       retryAttempt: 0,
       initialEventId: 0,
       txCache: TxCache,

--- a/packages/daemon/src/actions/index.ts
+++ b/packages/daemon/src/actions/index.ts
@@ -57,7 +57,7 @@ export const increaseRetry = assign({
  */
 export const getSocketRefFromContext = (context: Context) => {
   if (!context.socket) {
-    throw new Error('No socket');
+    throw new Error('No socket in context');
   }
 
   return context.socket;
@@ -69,7 +69,7 @@ export const getSocketRefFromContext = (context: Context) => {
  */
 export const getHealthcheckRefFromContext = (context: Context) => {
   if (!context.healthcheck) {
-    throw new Error('No healthcheck');
+    throw new Error('No healthcheck in context');
   }
 
   return context.healthcheck;

--- a/packages/daemon/src/actions/index.ts
+++ b/packages/daemon/src/actions/index.ts
@@ -179,7 +179,7 @@ export const updateCache = (context: Context) => {
 */
 export const startHealthcheckPing = sendTo(
   getHealthcheckRefFromContext,
-  { type: 'START_HEALTHCHECK_PING_EVENT' },
+  { type: EventTypes.HEALTHCHECK_EVENT, event: { type: 'START' } },
 );
 
 /*
@@ -187,7 +187,7 @@ export const startHealthcheckPing = sendTo(
 */
 export const stopHealthcheckPing = sendTo(
   getHealthcheckRefFromContext,
-  { type: 'STOP_HEALTHCHECK_PING_EVENT' },
+  { type: EventTypes.HEALTHCHECK_EVENT, event: { type: 'STOP' } },
 );
 
 /*

--- a/packages/daemon/src/actions/index.ts
+++ b/packages/daemon/src/actions/index.ts
@@ -64,6 +64,18 @@ export const getSocketRefFromContext = (context: Context) => {
 };
 
 /*
+ * This is a helper to get the healthcheck ref from the context and throw if it's not
+ * found.
+ */
+export const getHealthcheckRefFromContext = (context: Context) => {
+  if (!context.healthcheck) {
+    throw new Error('No healthcheck');
+  }
+
+  return context.healthcheck;
+};
+
+/*
  * This action sends an event to the socket actor
  */
 export const startStream = sendTo(
@@ -163,6 +175,22 @@ export const updateCache = (context: Context) => {
 };
 
 /*
+ * Starts the ping timer in the healthcheck actor
+*/
+export const startHealthcheckPing = sendTo(
+  getHealthcheckRefFromContext,
+  { type: 'START_HEALTHCHECK_PING_EVENT' },
+);
+
+/*
+ * Stops the ping timer in the healthcheck actor
+*/
+export const stopHealthcheckPing = sendTo(
+  getHealthcheckRefFromContext,
+  { type: 'STOP_HEALTHCHECK_PING_EVENT' },
+);
+
+/*
  * Logs the event as an error log
  */
-export const logEventError = (_context: Context, event: Event) => logger.error(event);
+export const logEventError = (_context: Context, event: Event) => logger.error(JSON.stringify(event));

--- a/packages/daemon/src/actors/HealthCheckActor.ts
+++ b/packages/daemon/src/actors/HealthCheckActor.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import axios from 'axios';
+import logger from '../logger';
+import getConfig from '../config';
+import { clear } from 'console';
+
+const sendPing = async () => {
+  const { HEALTHCHECK_SERVER_URL, HEALTHCHECK_SERVER_API_KEY } = getConfig();
+
+  if (!HEALTHCHECK_SERVER_URL) {
+    logger.warning('Health-monitor server URL not set. Skipping ping');
+    return;
+  }
+
+  try {
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Api-Key': HEALTHCHECK_SERVER_API_KEY
+    };
+    // TODO Get this URL from params/config
+    const response = await axios.post(
+      HEALTHCHECK_SERVER_URL,
+      {},
+      { headers }
+    );
+
+    if (response.status > 399) {
+      logger.warning(`Health-monitor returned status ${response.status}`);
+    }
+  } catch (err) {
+    logger.warning(`Error sending ping to health-monitor: ${err}`);
+  }
+}
+
+export default (callback: any, receive: any) => {
+  const { HEALTHCHECK_ENABLED, HEALTHCHECK_PING_INTERVAL } = getConfig();
+
+  if (!HEALTHCHECK_ENABLED) {
+    logger.info('Healthcheck feature is disabled. Not starting healthcheck actor');
+
+    return () => {};
+  }
+
+  logger.info('Starting healthcheck actor');
+
+  let pingTimer: NodeJS.Timer | null = null;
+
+  const createPingTimer = () => {
+    if (pingTimer) {
+      clearPingTimer();
+    }
+
+    pingTimer = setInterval(async () => {
+      logger.info('Sending ping to health-monitor server');
+      await sendPing();
+    }, HEALTHCHECK_PING_INTERVAL);
+  };
+
+  const clearPingTimer = () => {
+    if (pingTimer) {
+      clearInterval(pingTimer);
+      pingTimer = null;
+    }
+  };
+
+  receive((event: Event) => {
+    if (event.type === 'STOP_HEALTHCHECK_PING_EVENT') {
+      logger.info('Stopping healthcheck ping');
+      clearPingTimer();
+    }
+
+    if (event.type === 'START_HEALTHCHECK_PING_EVENT') {
+      logger.info('Starting healthcheck ping');
+      createPingTimer();
+    }
+  });
+
+  // Clear the interval when the actor is stopped just to be sure
+  return () => {
+    logger.info('Stopping healthcheck actor');
+    clearPingTimer();
+  };
+};

--- a/packages/daemon/src/actors/HealthCheckActor.ts
+++ b/packages/daemon/src/actors/HealthCheckActor.ts
@@ -8,7 +8,7 @@
 import axios from 'axios';
 import logger from '../logger';
 import getConfig from '../config';
-import { clear } from 'console';
+import { Event, EventTypes } from '../types';
 
 const sendPing = async () => {
   const { HEALTHCHECK_SERVER_URL, HEALTHCHECK_SERVER_API_KEY } = getConfig();
@@ -70,12 +70,18 @@ export default (callback: any, receive: any) => {
   };
 
   receive((event: Event) => {
-    if (event.type === 'STOP_HEALTHCHECK_PING_EVENT') {
+    if (event.type !== EventTypes.HEALTHCHECK_EVENT) {
+      logger.warn('Event of a different type than HEALTHCHECK_EVENT reached the healthcheck actor');
+
+      return;
+    }
+
+    if (event.event.type === 'STOP') {
       logger.info('Stopping healthcheck ping');
       clearPingTimer();
     }
 
-    if (event.type === 'START_HEALTHCHECK_PING_EVENT') {
+    if (event.event.type === 'START') {
       logger.info('Starting healthcheck ping');
       createPingTimer();
     }

--- a/packages/daemon/src/actors/index.ts
+++ b/packages/daemon/src/actors/index.ts
@@ -6,4 +6,5 @@
  */
 
 export { default as WebSocketActor } from './WebSocketActor';
+export { default as HealthCheckActor } from './HealthCheckActor';
 export * from './helpers';

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -68,6 +68,12 @@ export const ACCOUNT_ID = process.env.ACCOUNT_ID;
 export const ALERT_MANAGER_REGION = process.env.ALERT_MANAGER_REGION;
 export const ALERT_MANAGER_TOPIC  = process.env.ALERT_MANAGER_TOPIC;
 
+// Healthcheck configuration
+export const HEALTHCHECK_ENABLED = process.env.HEALTHCHECK_ENABLED === 'true';
+export const HEALTHCHECK_SERVER_URL = process.env.HEALTHCHECK_SERVER_URL;
+export const HEALTHCHECK_SERVER_API_KEY = process.env.HEALTHCHECK_SERVER_API_KEY;
+export const HEALTHCHECK_PING_INTERVAL = parseInt(process.env.HEALTHCHECK_PING_INTERVAL ?? '10000', 10);  // 10 seconds
+
 // Other
 export const USE_SSL = process.env.USE_SSL;
 
@@ -93,4 +99,8 @@ export default () => ({
   ALERT_MANAGER_REGION,
   ALERT_MANAGER_TOPIC,
   ON_TX_PUSH_NOTIFICATION_REQUESTED_FUNCTION_NAME,
+  HEALTHCHECK_ENABLED,
+  HEALTHCHECK_SERVER_URL,
+  HEALTHCHECK_SERVER_API_KEY,
+  HEALTHCHECK_PING_INTERVAL,
 });

--- a/packages/daemon/src/guards/index.ts
+++ b/packages/daemon/src/guards/index.ts
@@ -9,6 +9,7 @@ import { Context, Event, EventTypes, FullNodeEventTypes } from '../types';
 import { hashTxData } from '../utils';
 import { METADATA_DIFF_EVENT_TYPES } from '../services';
 import getConfig from '../config';
+import logger from '../logger';
 
 /*
  * This guard is used during the `handlingMetadataChanged` to check if
@@ -110,7 +111,13 @@ export const invalidPeerId = (_context: Context, event: Event) => {
   const { FULLNODE_PEER_ID } = getConfig();
 
   // @ts-ignore
-  return event.event.peer_id !== FULLNODE_PEER_ID;
+  const isInvalid = event.event.peer_id !== FULLNODE_PEER_ID;
+
+  if (isInvalid) {
+    logger.error(`Invalid peer id. Expected ${FULLNODE_PEER_ID}, got ${event.event.peer_id}`);
+  }
+
+  return isInvalid;
 };
 
 /*
@@ -123,7 +130,13 @@ export const invalidNetwork = (_context: Context, event: Event) => {
   }
   const { NETWORK } = getConfig();
 
-  return event.event.network !== NETWORK;
+  const isInvalid = event.event.network !== NETWORK;
+
+  if (isInvalid) {
+    logger.error(`Invalid network. Expected ${NETWORK}, got ${event.event.network}`);
+  }
+
+  return isInvalid;
 };
 
 /*
@@ -137,7 +150,13 @@ export const invalidStreamId = (_context: Context, event: Event) => {
   }
   const { STREAM_ID } = getConfig();
 
-  return event.event.stream_id !== STREAM_ID;
+  const isInvalid = event.event.stream_id !== STREAM_ID;
+
+  if (isInvalid) {
+    logger.error(`Invalid stream id. Expected ${STREAM_ID}, got ${event.event.stream_id}`);
+  }
+
+  return isInvalid;
 }
 
 export const websocketDisconnected = (_context: Context, event: Event) => {

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -502,7 +502,7 @@ export const updateLastSyncedEvent = async (context: Context) => {
 
 export const fetchMinRewardBlocks = async () => {
   const fullnodeUrl = getFullnodeHttpUrl();
-  const response = await axios.get(`${fullnodeUrl}version`);
+  const response = await axios.get(`${fullnodeUrl}/version`);
 
   if (response.status !== 200) {
     throw new Error('Request to version API failed');

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -26,11 +26,16 @@ export type WebSocketSendEvent =
       ack_event_id?: number;
   };
 
+export type HealthCheckEvent =
+  | { type: 'START' }
+  | { type: 'STOP' };
+
 export enum EventTypes {
   WEBSOCKET_EVENT = 'WEBSOCKET_EVENT',
   FULLNODE_EVENT = 'FULLNODE_EVENT',
   METADATA_DECIDED = 'METADATA_DECIDED',
   WEBSOCKET_SEND_EVENT = 'WEBSOCKET_SEND_EVENT',
+  HEALTHCHECK_EVENT = 'HEALTHCHECK_EVENT',
 }
 
 export enum FullNodeEventTypes {
@@ -45,7 +50,8 @@ export type Event =
   | { type: EventTypes.WEBSOCKET_EVENT, event: WebSocketEvent }
   | { type: EventTypes.FULLNODE_EVENT, event: FullNodeEvent }
   | { type: EventTypes.METADATA_DECIDED, event: MetadataDecidedEvent }
-  | { type: EventTypes.WEBSOCKET_SEND_EVENT, event: WebSocketSendEvent };
+  | { type: EventTypes.WEBSOCKET_SEND_EVENT, event: WebSocketSendEvent }
+  | { type: EventTypes.HEALTHCHECK_EVENT, event: HealthCheckEvent};
 
 export type FullNodeEvent = {
   stream_id: string;

--- a/packages/daemon/src/types/machine.ts
+++ b/packages/daemon/src/types/machine.ts
@@ -11,6 +11,7 @@ import { FullNodeEvent } from './event';
 
 export interface Context {
   socket: ActorRef<any, any> | null;
+  healthcheck: ActorRef<any, any> | null;
   retryAttempt: number;
   event?: FullNodeEvent | null;
   initialEventId: null | number;


### PR DESCRIPTION
### Acceptance Criteria
- The daemon should send periodic requests (pings) to the configured healthcheck server to advertise it's alive.
- In case the daemon is in an Error state, or in case it has lost connection to the fullnode, the pings shouldn't be sent, because in these cases the daemon is not healthy


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
