### PR TITLE
fix: codebuild failing because of yarn version

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -167,12 +167,12 @@ phases:
     #If you use the Ubuntu standard image 2.0 or later, you must specify runtime-versions.
     #If you specify runtime-versions and use an image other than Ubuntu standard image 2.0, the build fails.
     runtime-versions:
-      nodejs: 18
+      nodejs: 20
       # name: version
     commands:
       - npm install -g yarn
       - corepack enable
-      - yarn set version 3.4.1
+      - yarn set version stable
       - yarn install
   pre_build:
     commands:


### PR DESCRIPTION
### Acceptance Criteria
- We should use the same version on codebuild as we're using on the project
- We should use nodejs 20 on codebuild


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
