### PR TITLE
fix: missing walletservice env

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -13,6 +13,7 @@ env:
     BLOCK_REWARD_LOCK: 300
     CONFIRM_FIRST_ADDRESS: true
     VOIDED_TX_OFFSET: 20
+    TX_HISTORY_MAX_COUNT: 50
     dev_DEFAULT_SERVER: "https://wallet-service.private-nodes.testnet.hathor.network/v1a/"
     dev_WS_DOMAIN: "ws.dev.wallet-service.testnet.hathor.network"
     dev_NETWORK: "testnet"


### PR DESCRIPTION
### Acceptance Criteria
- We should add the `TX_HISTORY_MAX_COUNT` env that is missing in the wallet-service codebuild


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
