### PR TITLE
chore: bump v1.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "hathor-wallet-service",
+  "version": "1.4.3-beta",
   "workspaces": [
     "packages/daemon",
     "packages/wallet-service"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-service",
-  "version": "1.4.3-beta",
+  "version": "1.4.3+beta",
   "workspaces": [
     "packages/daemon",
     "packages/wallet-service"

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,5 +1,4 @@
 {
-  "version": "1.4.2-beta",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/wallet-service/package.json
+++ b/packages/wallet-service/package.json
@@ -1,6 +1,5 @@
 {
   "name": "wallet-service",
-  "version": "1.27.0+beta",
   "description": "",
   "scripts": {
     "jest": "jest --runInBand --collectCoverage --detectOpenHandles --forceExit",


### PR DESCRIPTION
### Acceptance Criteria
- We should bump the version to `v1.4.3+beta`
- We should have a single version for both projects from now on, so the version should be removed on the specific packages

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
