### PR TITLE
fix: invalid build script on testnet and mainnet

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           timestamp=`date +%s`;
           export DOCKER_IMAGE_TAG="testnet-$commit-$timestamp";
 
-          make build-and-push-docker
+          make build-and-push-daemon
 
           echo "deployed_environment=testnet" >> $GITHUB_ENV
 
@@ -40,7 +40,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           export DOCKER_IMAGE_TAG=${GITHUB_REF#refs/*/}
-          make build-and-push-docker
+          make build-and-push-daemon
 
           echo "deployed_environment=mainnet" >> $GITHUB_ENV
       - name: Slack Notification


### PR DESCRIPTION
### Acceptance Criteria
- Script ran by the CD had an invalid name for `testnet` and `mainnet` 


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
