### PR TITLE
chore: bump to v1.4.6 (not beta)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-service",
-  "version": "1.4.5+beta",
+  "version": "1.4.6",
   "workspaces": [
     "packages/daemon",
     "packages/wallet-service"


### PR DESCRIPTION
## Acceptance Criteria

- We should stop using `beta` for our versions
