### PR TITLE
fix: getAddresses failing when no parameters are sent

### DIFF
--- a/packages/wallet-service/src/api/addresses.ts
+++ b/packages/wallet-service/src/api/addresses.ts
@@ -125,7 +125,7 @@ export const get: APIGatewayProxyHandler = middy(
       return closeDbAndGetError(mysql, ApiError.WALLET_NOT_READY);
     }
 
-    const { value: body, error } = AddressAtIndexValidator.validate(event.pathParameters);
+    const { value: body, error } = AddressAtIndexValidator.validate(event.pathParameters || {});
 
     if (error) {
       const details = error.details.map((err) => ({


### PR DESCRIPTION
### Motivation

The request to get all addresses is failing on the wallet-desktop 

### Acceptance Criteria
- We should fix a validation error when `pathParameters` is `null`

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
