### PR TITLE
fix: no authorities in init wallet

### DIFF
--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -498,7 +498,9 @@ export const initWalletBalance = async (mysql: ServerlessMysql, walletId: string
             SUM(\`total_received\`) AS \`total_received\`,
             SUM(\`unlocked_balance\`) AS \`unlocked_balance\`,
             SUM(\`locked_balance\`) AS \`locked_balance\`,
-            MIN(\`timelock_expires\`) AS \`timelock_expires\`
+            MIN(\`timelock_expires\`) AS \`timelock_expires\`,
+            BIT_OR(\`unlocked_authorities\`) AS \`unlocked_authorities\`,
+            BIT_OR(\`locked_authorities\`) AS \`locked_authorities\`
        FROM \`address_balance\`
       WHERE \`address\`
          IN (?)
@@ -536,6 +538,8 @@ export const initWalletBalance = async (mysql: ServerlessMysql, walletId: string
       row1.unlocked_balance,
       row1.locked_balance,
       row1.timelock_expires,
+      row1.locked_authorities,
+      row1.unlocked_authorities,
       row2.transactions,
     ]);
   }
@@ -544,7 +548,8 @@ export const initWalletBalance = async (mysql: ServerlessMysql, walletId: string
       `INSERT INTO \`wallet_balance\`(\`wallet_id\`, \`token_id\`,
                                       \`total_received\`,
                                       \`unlocked_balance\`, \`locked_balance\`,
-                                      \`timelock_expires\`, \`transactions\`)
+                                      \`timelock_expires\`, \`locked_authorities\`,
+                                      \`unlocked_authorities\`, \`transactions\`)
             VALUES ?`,
       [balanceEntries],
     );

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -479,10 +479,10 @@ test('initWalletBalance', async () => {
     { address: addr3, txId: tx3, tokenId: token2, balance: 11, timestamp: ts3 },
   ];
   const addressEntries = [
-    // address, tokenId, unlocked, locked, lockExpires, transactions
-    [addr1, token1, 2, 0, null, 2, 0, 0, 4],
-    [addr1, token2, 1, 4, timelock, 1, 0, 0, 5],
-    [addr2, token1, 5, 2, null, 2, 0, 0, 20],
+    // address, tokenId, unlocked, locked, lockExpires, unlocked_authorities, locked_authorities, transactions
+    [addr1, token1, 2, 0, null, 2, 1, 0, 4],
+    [addr1, token2, 1, 4, timelock, 1, 2, 0, 5],
+    [addr2, token1, 5, 2, null, 2, 2, 0, 20],
     [addr2, token2, 0, 2, null, 1, 0, 0, 2],
     [addr3, token1, 0, 1, null, 1, 0, 0, 1],
     [addr3, token2, 10, 1, null, 1, 0, 0, 11],
@@ -494,8 +494,8 @@ test('initWalletBalance', async () => {
   await initWalletBalance(mysql, walletId, [addr1, addr2]);
 
   // check balance entries
-  await expect(checkWalletBalanceTable(mysql, 2, walletId, token1, 7, 2, null, 3)).resolves.toBe(true);
-  await expect(checkWalletBalanceTable(mysql, 2, walletId, token2, 1, 6, timelock, 2)).resolves.toBe(true);
+  await expect(checkWalletBalanceTable(mysql, 2, walletId, token1, 7, 2, null, 3, 3)).resolves.toBe(true);
+  await expect(checkWalletBalanceTable(mysql, 2, walletId, token2, 1, 6, timelock, 2, 2)).resolves.toBe(true);
 });
 
 test('updateWalletTablesWithTx', async () => {

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -479,7 +479,7 @@ test('initWalletBalance', async () => {
     { address: addr3, txId: tx3, tokenId: token2, balance: 11, timestamp: ts3 },
   ];
   const addressEntries = [
-    // address, tokenId, unlocked, locked, lockExpires, unlocked_authorities, locked_authorities, transactions
+    // address, tokenId, unlocked, locked, lockExpires, transactions, unlocked_authorities, locked_authorities, total_received
     [addr1, token1, 2, 0, null, 2, 1, 0, 4],
     [addr1, token2, 1, 4, timelock, 1, 2, 0, 5],
     [addr2, token1, 5, 2, null, 2, 2, 0, 20],


### PR DESCRIPTION
### Motivation

This bug was captured by the QA on an empty wallet-service database, the init wallet was not aggregating authorities.

It was not captured before because the QA wallet was already initialized on the database when the QA token was created

### Acceptance Criteria

- We should aggregate the unlocked and locked authorities

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
