### PR TITLE
chore: increased memory and lambda timeout

### DIFF
--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -242,6 +242,11 @@ functions:
           arn:aws:lambda:eu-central-1:${self:provider.environment.ACCOUNT_ID}:function:hathor-explorer-service-${self:custom.explorerServiceStage}-create_or_update_dag_metadata
   loadWalletAsync:
     handler: src/api/wallet.loadWallet
+    # This lambda is currently running out of memory when wallets with a big
+    # number of transactions (> 300k) is being loaded. I chose 1024 because the
+    # average memory usage of the largest test wallet we have is 800mb.
+    memorySize: 1024
+    timeout: 600 # 10 minutes should be enough for most wallets
     warmup:
       walletWarmer:
         enabled: false


### PR DESCRIPTION
### Motivation

Wallets with a large number of transactions cause the `loadWalletAsync` lambda to run out of memory, this is yet to be investigated, so this is a short-term solution until we fully investigate and solve the increased use of memory

1gb of memory is a safe margin on the average use of memory used while loading a wallet with 380k transactions.

### Acceptance Criteria

- We should increase the memory limit of the `loadWalletAsync` lambda to 1gb
- We should increase the `loadWalletAsync` lambda timeout to 10 minutes

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
