### PR TITLE
feat: added handler to handle DLQ messages from loadWalletAsync

### DIFF
--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -74,6 +74,7 @@ export const PUSH_NOTIFICATION_LAMBDA_REGION = process.env.PUSH_NOTIFICATION_LAM
 export const ACCOUNT_ID = process.env.ACCOUNT_ID;
 export const ALERT_MANAGER_REGION = process.env.ALERT_MANAGER_REGION;
 export const ALERT_MANAGER_TOPIC  = process.env.ALERT_MANAGER_TOPIC;
+export const AWS_REGION = process.env.AWS_REGION;
 
 // Healthcheck configuration
 export const HEALTHCHECK_ENABLED = process.env.HEALTHCHECK_ENABLED === 'true';
@@ -104,6 +105,7 @@ export default () => ({
   WALLET_SERVICE_LAMBDA_ENDPOINT,
   STAGE,
   ACCOUNT_ID,
+  AWS_REGION,
   ALERT_MANAGER_REGION,
   ALERT_MANAGER_TOPIC,
   ON_TX_PUSH_NOTIFICATION_REQUESTED_FUNCTION_NAME,

--- a/packages/daemon/src/utils/aws.ts
+++ b/packages/daemon/src/utils/aws.ts
@@ -61,8 +61,17 @@ export const invokeOnTxPushNotificationRequestedLambda = async (walletBalanceVal
  * @param messageBody - A string with the message body
  * @param queueUrl - The queue URL
  */
-export const sendMessageSQS = async (messageBody: string, queueUrl: string, messageAttributes?: Record<string, MessageAttributeValue>): Promise<SendMessageCommandOutput> => {
-  const client = new SQSClient({});
+export const sendMessageSQS = async (messageBody: string, queueUrl: string, messageAttributes?: Record<string, MessageAttributeValue>, region?: string): Promise<SendMessageCommandOutput> => {
+  const { AWS_REGION } = getConfig();
+
+  if (!region) {
+    region = AWS_REGION;
+  }
+
+  const client = new SQSClient({
+    endpoint: queueUrl,
+    region,
+  });
   const command = new SendMessageCommand({
     QueueUrl: queueUrl,
     MessageBody: messageBody,

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -120,6 +120,11 @@ resources:
       Properties:
         QueueName:
             WalletServiceNewTxQueue_${self:custom.stage}
+    WalletServiceLoadAsyncFailedTopic:
+        Type: "AWS::SNS::Topic"
+        Properties:
+          DisplayName: 'Messages published when the loadWalletAsync lambda fails'
+          TopicName: WalletServiceLoadAsyncFailed_${self:custom.stage}
 
 provider:
   name: aws
@@ -247,9 +252,33 @@ functions:
     # average memory usage of the largest test wallet we have is 800mb.
     memorySize: 1024
     timeout: 600 # 10 minutes should be enough for most wallets
+    onError: arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
     warmup:
       walletWarmer:
         enabled: false
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - SNS:Publish
+        Resource:
+          arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
+  handleLoadWalletFailed:
+    handler: src/api/wallet.loadWalletFailed
+    events:
+      - sns: arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
+    warmup:
+      walletWarmer:
+        enabled: false
+    iamRoleStatementsInherit: true
+    iamRoleStatementsName: hathor-wallet-service-${self:custom.stage}-handleLoadFailed-snsRole
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - SNS:Publish
+          - SNS:Subscribe
+          - SNS:Unsubscribe
+        Resource:
+          arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
   loadWalletApi:
     role: arn:aws:iam::${self:provider.environment.ACCOUNT_ID}:role/WalletServiceLoadWalletLambda
     handler: src/api/wallet.load

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -36,10 +36,10 @@ custom:
     topics: # SNS Topics to send alerts to
       major:
         alarm:
-          topic: arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:opsgenie-cloudwatch-integration-production-major
+          topic: arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:opsgenie-cloudwatch-integration-production-major
       minor:
         alarm:
-          topic: arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:opsgenie-cloudwatch-integration-production-minor
+          topic: arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:opsgenie-cloudwatch-integration-production-minor
     definitions: # Definition of alarms
       majorFunctionErrors:
         description: "Too many errors in hathor-wallet-service. Runbook: https://github.com/HathorNetwork/ops-tools/blob/master/docs/runbooks/wallet-service/errors-in-logs.md"
@@ -129,6 +129,7 @@ resources:
 provider:
   name: aws
   runtime: nodejs18.x
+  region: ${opt:region, 'eu-central-1'}
   # In MB. This is the memory allocated for the Lambdas, they cannot use more than this
   # and will break if they try.
   memorySize: 256
@@ -244,7 +245,7 @@ functions:
           - lambda:InvokeFunction
           - lambda:InvokeAsync
         Resource:
-          arn:aws:lambda:eu-central-1:${self:provider.environment.ACCOUNT_ID}:function:hathor-explorer-service-${self:custom.explorerServiceStage}-create_or_update_dag_metadata
+          arn:aws:lambda:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:function:hathor-explorer-service-${self:custom.explorerServiceStage}-create_or_update_dag_metadata
   loadWalletAsync:
     handler: src/api/wallet.loadWallet
     # This lambda is currently running out of memory when wallets with a big
@@ -252,7 +253,7 @@ functions:
     # average memory usage of the largest test wallet we have is 800mb.
     memorySize: 1024
     timeout: 600 # 10 minutes should be enough for most wallets
-    onError: arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
+    onError: arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
     warmup:
       walletWarmer:
         enabled: false
@@ -261,11 +262,11 @@ functions:
         Action:
           - SNS:Publish
         Resource:
-          arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
+          arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
   handleLoadWalletFailed:
     handler: src/api/wallet.loadWalletFailed
     events:
-      - sns: arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
+      - sns: arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
     warmup:
       walletWarmer:
         enabled: false
@@ -277,7 +278,7 @@ functions:
           - SNS:Subscribe
           - SNS:Unsubscribe
         Resource:
-          arn:aws:sns:eu-central-1:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
+          arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
   loadWalletApi:
     role: arn:aws:iam::${self:provider.environment.ACCOUNT_ID}:role/WalletServiceLoadWalletLambda
     handler: src/api/wallet.load

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -274,7 +274,6 @@ functions:
     iamRoleStatements:
       - Effect: Allow
         Action:
-          - SNS:Publish
           - SNS:Subscribe
           - SNS:Unsubscribe
         Resource:

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -393,7 +393,7 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
   try {
     for (let i = 0; i < records.length; i++) {
       const snsEvent = records[i].Sns;
-      const { RequestId, ErrorMessage } = snsEvent.MessageAttributes;
+      const { RequestID, ErrorMessage } = snsEvent.MessageAttributes;
 
       // Process each failed load wallet event
       const loadEvent: LoadEvent = JSON.parse(snsEvent.Message) as unknown as LoadEvent;
@@ -412,7 +412,7 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
       logger.error({
         xpubkey: loadEvent.xpubkey,
         walletId,
-        RequestId,
+        RequestID: RequestID.Value,
         ErrorMessage: ErrorMessage.Value,
       });
 
@@ -423,8 +423,8 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
         {
           xpubkey: loadEvent.xpubkey,
           walletId,
-          RequestId,
-          ErrorMessage,
+          RequestID: RequestID.Value,
+          ErrorMessage: ErrorMessage.Value,
         },
       );
     }

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -400,6 +400,15 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
 
       if (!loadEvent.xpubkey) {
         logger.error('Received wallet load fail message from SNS but no xpubkey received');
+        await addAlert(
+          'Wallet failed to load, but no xpubkey received.',
+          `A event reached loadWalletFailed lambda but the xpubkey was not sent. This indicates that wallets failed to load and we wasn't able to recover, please check the logs as soon as possible.`,
+          Severity.MAJOR,
+          {
+            RequestID: RequestID.Value,
+            ErrorMessage: ErrorMessage.Value,
+          },
+        );
         continue;
       }
 

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -405,7 +405,7 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
         logger.error('Received wallet load fail message from SNS but no xpubkey received');
         await addAlert(
           'Wallet failed to load, but no xpubkey received.',
-          `A event reached loadWalletFailed lambda but the xpubkey was not sent. This indicates that wallets failed to load and we wasn't able to recover, please check the logs as soon as possible.`,
+          `A event reached loadWalletFailed lambda but the xpubkey was not sent. This indicates that wallets failed to load and we weren't able to recover, please check the logs as soon as possible.`,
           Severity.MAJOR,
           {
             RequestID: RequestID.Value,
@@ -442,7 +442,7 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
   } catch (e) {
     await addAlert(
       'Failed to handle loadWalletFailed event',
-      `Failed to process the loadWalletFailed event. This indicates that wallets failed to load and we wasn't able to recover, please check the logs as soon as possible.`,
+      `Failed to process the loadWalletFailed event. This indicates that wallets failed to load and we weren't able to recover, please check the logs as soon as possible.`,
       // This is major because the user will be stuck in a loading cycle
       Severity.MAJOR,
       { event },

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -405,8 +405,9 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
 
       const walletId = getWalletId(loadEvent.xpubkey);
 
-      // update wallet status to 'error'
-      await updateWalletStatus(mysql, walletId, WalletStatus.ERROR);
+      // update wallet status to 'error' and set the number of retries to MAX so
+      // it doesn't get retried
+      await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, MAX_LOAD_WALLET_RETRIES);
 
       logger.error(`${walletId} failed to load.`);
       logger.error({

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -385,6 +385,9 @@ interface LoadResult {
  * This lambda will be started by a SNSMessage on the load failed SNS configured
  * in serverless.yml. It will receive all wallet load failed events published on
  * the loadWalletAsync DLQ SNS topic
+ *
+ * The event will be a SNSEvent, here is an example of the Message attribute:
+ * {"xpubkey":"xpub","maxGap":20}
  */
 export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
   const logger = createDefaultLogger();

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -432,7 +432,7 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
   } catch (e) {
     await addAlert(
       'Failed to handle loadWalletFailed event',
-      `Failed to process the loadWalletFailed event. Please check the logs.`,
+      `Failed to process the loadWalletFailed event. This indicates that wallets failed to load and we wasn't able to recover, please check the logs as soon as possible.`,
       // This is major because the user will be stuck in a loading cycle
       Severity.MAJOR,
       { event },

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -405,7 +405,7 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
         logger.error('Received wallet load fail message from SNS but no xpubkey received');
         await addAlert(
           'Wallet failed to load, but no xpubkey received.',
-          `A event reached loadWalletFailed lambda but the xpubkey was not sent. This indicates that wallets failed to load and we weren't able to recover, please check the logs as soon as possible.`,
+          `An event reached loadWalletFailed lambda but the xpubkey was not sent. This indicates that a wallet has failed to load and we weren't able to recover, please check the logs as soon as possible.`,
           Severity.MAJOR,
           {
             RequestID: RequestID.Value,

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -411,7 +411,6 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
 
       logger.error(`${walletId} failed to load.`);
       logger.error({
-        xpubkey: loadEvent.xpubkey,
         walletId,
         RequestID: RequestID.Value,
         ErrorMessage: ErrorMessage.Value,
@@ -422,7 +421,6 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
         `The wallet with id ${walletId} failed to load on the wallet-service. Please check the logs.`,
         Severity.MINOR,
         {
-          xpubkey: loadEvent.xpubkey,
           walletId,
           RequestID: RequestID.Value,
           ErrorMessage: ErrorMessage.Value,

--- a/packages/wallet-service/src/utils/alerting.utils.ts
+++ b/packages/wallet-service/src/utils/alerting.utils.ts
@@ -48,7 +48,10 @@ export const addAlert = async (
 
   const QUEUE_URL = `https://sqs.${ALERT_MANAGER_REGION}.amazonaws.com/${ACCOUNT_ID}/${ALERT_MANAGER_TOPIC}`;
 
-  const client = new SQSClient({});
+  const client = new SQSClient({
+    endpoint: QUEUE_URL,
+    region: ALERT_MANAGER_REGION,
+  });
   const command = new SendMessageCommand({
     QueueUrl: QUEUE_URL,
     MessageBody: JSON.stringify(preparedMessage),

--- a/packages/wallet-service/tests/integration.test.ts
+++ b/packages/wallet-service/tests/integration.test.ts
@@ -185,7 +185,7 @@ test('load wallet, and simulate DLQ event', async () => {
    * create wallet
    */
   await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, maxGap);
-  await loadWallet({ xpubkey: XPUBKEY, maxGap }, null, null);
+
   const REQUEST_ID = 'b45d912a-d392-4680-babf-c0caa6208a5f';
 
   const event: SNSEvent = {
@@ -220,11 +220,12 @@ test('load wallet, and simulate DLQ event', async () => {
       ]
   };
 
+  await expect(checkWalletTable(mysql, 1, walletId, WalletStatus.CREATING)).resolves.toBe(true);
+
   await loadWalletFailed(event, null, null);
 
-  await expect(checkWalletTable(mysql, 1, walletId, WalletStatus.READY)).resolves.toBe(true);
+  await expect(checkWalletTable(mysql, 1, walletId, WalletStatus.ERROR)).resolves.toBe(true);
 
-  expect(mockedAddAlert).toHaveBeenCalledTimes(1);
   expect(mockedAddAlert).toHaveBeenCalledWith(
     'A wallet failed to load in the wallet-service',
     `The wallet with id ${walletId} failed to load on the wallet-service. Please check the logs.`,

--- a/packages/wallet-service/tests/integration.test.ts
+++ b/packages/wallet-service/tests/integration.test.ts
@@ -239,7 +239,6 @@ test('load wallet, and simulate DLQ event', async () => {
     `The wallet with id ${walletId} failed to load on the wallet-service. Please check the logs.`,
     Severity.MINOR,
     {
-      xpubkey: XPUBKEY,
       walletId,
       RequestID: REQUEST_ID,
       ErrorMessage: 'The lambda exploded',

--- a/packages/wallet-service/tests/integration.test.ts
+++ b/packages/wallet-service/tests/integration.test.ts
@@ -134,6 +134,14 @@ beforeAll(async () => {
   jest.resetModules();
   process.env = { ...OLD_ENV };
   process.env.BLOCK_REWARD_LOCK = '1';
+
+  const actualUtils = jest.requireActual('@src/utils');
+  jest.mock('@src/utils', () => {
+    return {
+      ...actualUtils,
+      assertEnvVariablesExistence: jest.fn()
+    }
+  });
 });
 
 afterAll(async () => {

--- a/packages/wallet-service/tests/integration.test.ts
+++ b/packages/wallet-service/tests/integration.test.ts
@@ -233,7 +233,7 @@ test('load wallet, and simulate DLQ event', async () => {
     {
       xpubkey: XPUBKEY,
       walletId,
-      RequestId: REQUEST_ID,
+      RequestID: REQUEST_ID,
       ErrorMessage: 'The lambda exploded',
     },
   );

--- a/packages/wallet-service/tests/integration.test.ts
+++ b/packages/wallet-service/tests/integration.test.ts
@@ -1,9 +1,10 @@
+import { mockedAddAlert } from '@tests/utils/alerting.utils.mock';
 import { initFirebaseAdminMock } from '@tests/utils/firebase-admin.mock';
 import eventTemplate from '@events/eventTemplate.json';
-import { loadWallet } from '@src/api/wallet';
+import { loadWallet, loadWalletFailed } from '@src/api/wallet';
 import { createWallet, getMinersList } from '@src/db';
 import * as txProcessor from '@src/txProcessor';
-import { Transaction, WalletStatus, TxInput } from '@src/types';
+import { Transaction, WalletStatus, TxInput, Severity } from '@src/types';
 import { closeDbConnection, getDbConnection, getUnixTimestamp, getWalletId } from '@src/utils';
 import {
   ADDRESSES,
@@ -21,6 +22,7 @@ import {
   createInput,
   addToUtxoTable,
 } from '@tests/utils';
+import { SNSEvent } from 'aws-lambda';
 
 const mysql = getDbConnection();
 
@@ -176,6 +178,64 @@ test('receive blocks and txs and then start wallet', async () => {
   await loadWallet({ xpubkey: XPUBKEY, maxGap }, null, null);
 
   await checkAfterReceivingTx2(true);
+}, 60000);
+
+test('load wallet, and simulate DLQ event', async () => {
+  /*
+   * create wallet
+   */
+  await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, maxGap);
+  await loadWallet({ xpubkey: XPUBKEY, maxGap }, null, null);
+  const REQUEST_ID = 'b45d912a-d392-4680-babf-c0caa6208a5f';
+
+  const event: SNSEvent = {
+      'Records': [
+          {
+              'EventSource': 'aws:sns',
+              'EventVersion': '1.0',
+              'EventSubscriptionArn': 'arn:aws:sns:eu-central-1:769498303037:',
+              'Sns': {
+                  'Type': 'Notification',
+                  'MessageId': '1',
+                  'TopicArn': 'arn',
+                  'Subject': null,
+                  'Message': `{\"xpubkey\":\"${XPUBKEY}\",\"maxGap\":20}`,
+                  'Timestamp': '2024-03-19T15:12:24.741Z',
+                  'SignatureVersion': '1',
+                  'Signature': '',
+                  'SigningCertUrl': '',
+                  'UnsubscribeUrl': '',
+                  'MessageAttributes': {
+                      'RequestID': {
+                          'Type': 'String',
+                          'Value': REQUEST_ID,
+                      },
+                      'ErrorMessage': {
+                          'Type': "String",
+                          'Value': 'The lambda exploded',
+                      },
+                  },
+              },
+          },
+      ]
+  };
+
+  await loadWalletFailed(event);
+
+  await expect(checkWalletTable(mysql, 1, walletId, WalletStatus.READY)).resolves.toBe(true);
+
+  expect(mockedAddAlert).toHaveBeenCalledTimes(1);
+  expect(mockedAddAlert).toHaveBeenCalledWith(
+    'A wallet failed to load in the wallet-service',
+    `The wallet with id ${walletId} failed to load on the wallet-service. Please check the logs.`,
+    Severity.MINOR,
+    {
+      xpubkey: XPUBKEY,
+      walletId,
+      RequestId: REQUEST_ID,
+      ErrorMessage: 'The lambda exploded',
+    },
+  );
 }, 60000);
 
 // eslint-disable-next-line jest/prefer-expect-assertions, jest/expect-expect

--- a/packages/wallet-service/tests/integration.test.ts
+++ b/packages/wallet-service/tests/integration.test.ts
@@ -220,7 +220,7 @@ test('load wallet, and simulate DLQ event', async () => {
       ]
   };
 
-  await loadWalletFailed(event);
+  await loadWalletFailed(event, null, null);
 
   await expect(checkWalletTable(mysql, 1, walletId, WalletStatus.READY)).resolves.toBe(true);
 

--- a/packages/wallet-service/tests/utils/alerting.utils.mock.ts
+++ b/packages/wallet-service/tests/utils/alerting.utils.mock.ts
@@ -1,3 +1,11 @@
+export const mockedAssertEnvVariblesExistence = jest.fn();
+const actualUtils = jest.requireActual('@src/utils');
+jest.mock('@src/utils', () => {
+  return {
+    ...actualUtils,
+    assertEnvVariablesExistence: mockedAssertEnvVariblesExistence
+  }
+});
 export const mockedAddAlert = jest.fn();
 export default jest.mock('@src/utils/alerting.utils', () => ({
   addAlert: mockedAddAlert.mockReturnValue(Promise.resolve()),

--- a/packages/wallet-service/tests/utils/alerting.utils.mock.ts
+++ b/packages/wallet-service/tests/utils/alerting.utils.mock.ts
@@ -1,11 +1,3 @@
-export const mockedAssertEnvVariblesExistence = jest.fn();
-const actualUtils = jest.requireActual('@src/utils');
-jest.mock('@src/utils', () => {
-  return {
-    ...actualUtils,
-    assertEnvVariablesExistence: mockedAssertEnvVariblesExistence
-  }
-});
 export const mockedAddAlert = jest.fn();
 export default jest.mock('@src/utils/alerting.utils', () => ({
   addAlert: mockedAddAlert.mockReturnValue(Promise.resolve()),


### PR DESCRIPTION
### Motivation

Currently, if the `loadWalletAsync` lambda is terminated, we never set the wallet state to `error` in the database, causing the wallets to never fallback to the fullnode facade.

This PR will introduce a DLQ on the `loadWalletAsync` lambda and a handler to handle its messages

### Acceptance Criteria

- We should send a message to the DLQ SNS topic when the lambda fails to execute for whatever reason
- We should send an alert to our alerting SQS with metadata on what caused the fail
- We should fix the sqs client on both wallet-service and the daemon

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
