### PR TITLE
fix: fixed invalid 'local' being passed to lambda client on multiple …

### DIFF
--- a/packages/wallet-service/src/utils/nft.utils.ts
+++ b/packages/wallet-service/src/utils/nft.utils.ts
@@ -85,7 +85,7 @@ export class NftUtils {
   static async _updateMetadata(nftUid: string, metadata: Record<string, unknown>): Promise<unknown> {
     const client = new LambdaClient({
       endpoint: process.env.EXPLORER_SERVICE_LAMBDA_ENDPOINT,
-      region: 'local',
+      region: process.env.AWS_REGION,
     });
    const command = new InvokeCommand({
       FunctionName: `hathor-explorer-service-${process.env.EXPLORER_SERVICE_STAGE}-create_or_update_dag_metadata`,
@@ -141,7 +141,7 @@ export class NftUtils {
   static async invokeNftHandlerLambda(txId: string): Promise<void> {
     const client = new LambdaClient({
       endpoint: process.env.WALLET_SERVICE_LAMBDA_ENDPOINT,
-      region: 'local',
+      region: process.env.AWS_REGION,
     });
     // invoke lambda asynchronously to metadata update
    const command = new InvokeCommand({

--- a/packages/wallet-service/src/utils/pushnotification.utils.ts
+++ b/packages/wallet-service/src/utils/pushnotification.utils.ts
@@ -28,6 +28,7 @@ try {
     'FIREBASE_TOKEN_URI',
     'FIREBASE_AUTH_PROVIDER_X509_CERT_URL',
     'FIREBASE_CLIENT_X509_CERT_URL',
+    'AWS_REGION',
   ]);
 } catch (e) {
   logger.error(e);
@@ -49,6 +50,7 @@ export enum FunctionName {
 }
 
 const STAGE = process.env.STAGE;
+const AWS_REGION = process.env.AWS_REGION;
 const WALLET_SERVICE_LAMBDA_ENDPOINT = process.env.WALLET_SERVICE_LAMBDA_ENDPOINT;
 const SEND_NOTIFICATION_FUNCTION_NAME = buildFunctionName(FunctionName.SEND_NOTIFICATION_TO_DEVICE);
 const ON_TX_PUSH_NOTIFICATION_REQUESTED_FUNCTION_NAME = buildFunctionName(FunctionName.ON_TX_PUSH_NOTIFICATION_REQUESTED);
@@ -228,7 +230,7 @@ export class PushNotificationUtils {
 
     const client = new LambdaClient({
       endpoint: WALLET_SERVICE_LAMBDA_ENDPOINT,
-      region: 'local',
+      region: AWS_REGION,
     });
 
     const command = new InvokeCommand({
@@ -263,7 +265,7 @@ export class PushNotificationUtils {
 
     const client = new LambdaClient({
       endpoint: WALLET_SERVICE_LAMBDA_ENDPOINT,
-      region: 'local',
+      region: AWS_REGION,
     });
 
     const command = new InvokeCommand({

--- a/packages/wallet-service/tests/utils/pushnotification.utils.test.ts
+++ b/packages/wallet-service/tests/utils/pushnotification.utils.test.ts
@@ -32,6 +32,7 @@ describe('PushNotificationUtils', () => {
       FIREBASE_AUTH_PROVIDER_X509_CERT_URL: 'https://www.googleapis.com/oauth2/v1/certs',
       FIREBASE_CLIENT_X509_CERT_URL: 'https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk.iam.gserviceaccount.com',
       PUSH_ALLOWED_PROVIDERS: 'android,ios',
+      AWS_REGION: 'local',
     };
     initFirebaseAdminMock.mockReset();
     isFirebaseInitializedMock.mockReset();


### PR DESCRIPTION
### Motivation

During the migration to `aws-sdk` v3 I hard-coded the region to `local`, we should pass the correct region while interacting with aws-sdk clients

### Acceptance Criteria

- We should change the region set in the clients from `local` to the `AWS_REGION` env variable on the explorer lambdas, push notification lambdas and NFT lambda calls

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
