### PR TITLE
fix: after serverless upgrade, GONE exceptions now throw an error

### DIFF
--- a/packages/wallet-service/src/ws/utils.ts
+++ b/packages/wallet-service/src/ws/utils.ts
@@ -7,11 +7,15 @@ import {
   PostToConnectionCommandOutput,
   DeleteConnectionCommand,
   DeleteConnectionCommandOutput,
+  GoneException,
 } from '@aws-sdk/client-apigatewaymanagementapi';
 import util from 'util';
 
 import { WsConnectionInfo, Severity } from '@src/types';
 import { endWsConnection } from '@src/redis';
+import createDefaultLogger from '@src/logger';
+
+const logger = createDefaultLogger();
 
 export const connectionInfoFromEvent = (
   event: APIGatewayProxyEvent,
@@ -54,16 +58,41 @@ export const sendMessageToClient = async (
     endpoint: connInfo.url,
   });
 
+  const message = JSON.stringify(payload);
+
   const command = new PostToConnectionCommand({
     ConnectionId: connInfo.id,
-    Data: JSON.stringify(payload),
+    Data: message,
   });
 
-  const response: PostToConnectionCommandOutput = await apiGwClient.send(command);
-  // http GONE(410) means client is disconnected, but still exists on our connection store
-  if (response.$metadata.httpStatusCode === 410) {
-    // cleanup connection and subscriptions from redis if GONE
-    return endWsConnection(client, connInfo.id);
+  try {
+    const response: PostToConnectionCommandOutput = await apiGwClient.send(command);
+
+    if (response.$metadata.httpStatusCode !== 200) {
+      logger.error(response.$metadata);
+      throw new Error(`Status code from post to connection is not 200: ${response.$metadata.httpStatusCode}`);
+    }
+  } catch (e) {
+    if (e instanceof GoneException) {
+      logger.debug(`Received GONE exception, closing ${connInfo.id}`);
+      return endWsConnection(client, connInfo.id);
+    }
+
+    logger.error(e);
+
+    // Unhandled exception. We shouldn't end the connection as it might be a temporary
+    // instability with api gateway.
+    //
+    // Alert and move on, no need to throw here
+    addAlert(
+      'Unhandled error while sending websocket message to client',
+      'The wallet-service was unable to handle an error while attempting to send a message to a websocket client. Please check the logs.',
+      Severity.MINOR,
+      {
+        ConnectionId: connInfo.id,
+        Message: message,
+      },
+    )
   }
 };
 


### PR DESCRIPTION
### Motivation

Fixes https://github.com/HathorNetwork/internal-issues/issues/275

In serverless v3, `ApiGatewayManagementApiClient` throws an error on failures, our code was not ready to handle them, so we were never handling GONE exceptions and old connections were stacking up in redis because of what is described in the issue above.

### Acceptance Criteria

- We should be able to detect when a connection is already closed (GONE) and remove its handler from redis
- We should alert on unhandled errors
- We should include debug logs so we can keep track of how often this is happening (by filtering the log in cloudwatch)
- We should not throw in `sendMessageToClient` so that the SQS event is removed from the queue (and not retried)

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
