### PR TITLE
fix: serverless failing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ packages/wallet-service/node_modules
 packages/wallet-service/.serverless
 packages/wallet-service/.webpack
 packages/wallet-service/.env*
+packages/wallet-service/.warmup
 .yarn/
 .env.*

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,7 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+# Without this setting, the common package is hoisted in the root node_modules, causing the serverless-monorepo plugin to fail
 nmHoistingLimits: workspaces
 
 nodeLinker: node-modules

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,6 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
-nmHoistingLimits: dependencies
+nmHoistingLimits: workspaces
 
 nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/client-lambda": "3.540.0",
     "@aws-sdk/client-sqs": "3.540.0",
     "@hathor/wallet-lib": "0.39.0",
+    "@wallet-service/common": "1.5.0",
     "bip32": "^4.0.0",
     "bitcoinjs-lib": "^6.1.5",
     "bitcoinjs-message": "^2.2.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@wallet-service/common",
+  "version": "1.5.0",
   "packageManager": "yarn@4.1.0",
   "scripts": {
     "test": "jest --runInBand --collectCoverage --detectOpenHandles --forceExit"

--- a/packages/wallet-service/package.json
+++ b/packages/wallet-service/package.json
@@ -11,14 +11,21 @@
   "author": "Hathor Labs",
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "3.540.0",
+    "@aws-sdk/client-lambda": "3.540.0",
+    "@aws-sdk/client-sqs": "3.540.0",
     "@hathor/healthcheck-lib": "^0.1.0",
+    "@hathor/wallet-lib": "0.39.0",
     "@middy/core": "^2.5.7",
     "@middy/http-cors": "^2.5.7",
     "@types/redis": "^2.8.28",
-    "@wallet-service/common": "workspace:^",
+    "@wallet-service/common": "../../packages/common",
     "aws-lambda": "^1.0.7",
     "axios": "^0.21.1",
     "bip32": "^3.0.1",
+    "bitcoinjs-lib": "^6.1.5",
+    "bitcoinjs-message": "^2.2.0",
+    "bitcore-lib": "8.25.10",
     "bitcore-mnemonic": "8.25.10",
     "firebase-admin": "^11.3.0",
     "joi": "^17.4.0",
@@ -31,7 +38,8 @@
     "serverless-mysql": "^1.5.4",
     "source-map-support": "^0.5.19",
     "tiny-secp256k1": "^2.2.1",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "winston": "^3.13.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.95",
@@ -39,7 +47,6 @@
     "@types/node": "^18.0.4",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^3.3.0",
-    "bitcore-lib": "8.25.10",
     "dotenv": "^10.0.0",
     "eslint": "^8.50.0",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -66,14 +73,5 @@
     "typescript-eslint": "0.0.1-alpha.0",
     "webpack": "^5.88.2",
     "webpack-node-externals": "^3.0.0"
-  },
-  "peerDependencies": {
-    "@aws-sdk/client-apigatewaymanagementapi": "3.540.0",
-    "@aws-sdk/client-lambda": "3.540.0",
-    "@aws-sdk/client-sqs": "3.540.0",
-    "@hathor/wallet-lib": "^0.39.0",
-    "bitcoinjs-lib": "^6.1.5",
-    "bitcoinjs-message": "^2.2.0",
-    "winston": "^3.13.0"
   }
 }

--- a/packages/wallet-service/package.json
+++ b/packages/wallet-service/package.json
@@ -11,20 +11,13 @@
   "author": "Hathor Labs",
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-apigatewaymanagementapi": "3.540.0",
-    "@aws-sdk/client-lambda": "3.540.0",
-    "@aws-sdk/client-sqs": "3.540.0",
     "@hathor/healthcheck-lib": "^0.1.0",
-    "@hathor/wallet-lib": "0.39.0",
     "@middy/core": "^2.5.7",
     "@middy/http-cors": "^2.5.7",
     "@types/redis": "^2.8.28",
-    "@wallet-service/common": "1.5.0",
     "aws-lambda": "^1.0.7",
     "axios": "^0.21.1",
     "bip32": "^3.0.1",
-    "bitcoinjs-lib": "^6.1.5",
-    "bitcoinjs-message": "^2.2.0",
     "bitcore-lib": "8.25.10",
     "bitcore-mnemonic": "8.25.10",
     "firebase-admin": "^11.3.0",
@@ -38,7 +31,16 @@
     "serverless-mysql": "^1.5.4",
     "source-map-support": "^0.5.19",
     "tiny-secp256k1": "^2.2.1",
-    "uuid": "^8.3.0",
+    "uuid": "^8.3.0"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "3.540.0",
+    "@aws-sdk/client-lambda": "3.540.0",
+    "@aws-sdk/client-sqs": "3.540.0",
+    "@hathor/wallet-lib": "^0.39.0",
+    "@wallet-service/common": "1.5.0",
+    "bitcoinjs-lib": "^6.1.5",
+    "bitcoinjs-message": "^2.2.0",
     "winston": "^3.13.0"
   },
   "devDependencies": {

--- a/packages/wallet-service/package.json
+++ b/packages/wallet-service/package.json
@@ -11,6 +11,9 @@
   "author": "Hathor Labs",
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "3.540.0",
+    "@aws-sdk/client-lambda": "3.540.0",
+    "@aws-sdk/client-sqs": "3.540.0",
     "@hathor/healthcheck-lib": "^0.1.0",
     "@middy/core": "^2.5.7",
     "@middy/http-cors": "^2.5.7",
@@ -18,6 +21,8 @@
     "aws-lambda": "^1.0.7",
     "axios": "^0.21.1",
     "bip32": "^3.0.1",
+    "bitcoinjs-lib": "^6.1.5",
+    "bitcoinjs-message": "^2.2.0",
     "bitcore-lib": "8.25.10",
     "bitcore-mnemonic": "8.25.10",
     "firebase-admin": "^11.3.0",
@@ -31,17 +36,12 @@
     "serverless-mysql": "^1.5.4",
     "source-map-support": "^0.5.19",
     "tiny-secp256k1": "^2.2.1",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "winston": "^3.13.0"
   },
   "peerDependencies": {
-    "@aws-sdk/client-apigatewaymanagementapi": "3.540.0",
-    "@aws-sdk/client-lambda": "3.540.0",
-    "@aws-sdk/client-sqs": "3.540.0",
     "@hathor/wallet-lib": "^0.39.0",
-    "@wallet-service/common": "1.5.0",
-    "bitcoinjs-lib": "^6.1.5",
-    "bitcoinjs-message": "^2.2.0",
-    "winston": "^3.13.0"
+    "@wallet-service/common": "1.5.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.95",

--- a/packages/wallet-service/package.json
+++ b/packages/wallet-service/package.json
@@ -19,7 +19,7 @@
     "@middy/core": "^2.5.7",
     "@middy/http-cors": "^2.5.7",
     "@types/redis": "^2.8.28",
-    "@wallet-service/common": "../../packages/common",
+    "@wallet-service/common": "1.5.0",
     "aws-lambda": "^1.0.7",
     "axios": "^0.21.1",
     "bip32": "^3.0.1",

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -11,6 +11,7 @@ custom:
         - schedule: rate(5 minutes)
   webpack:
     webpackConfig: ./webpack.config.js
+    packager: "yarn"
     includeModules: true
   prune:
     automatic: true

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -11,7 +11,7 @@ custom:
         - schedule: rate(5 minutes)
   webpack:
     webpackConfig: ./webpack.config.js
-    packager: "yarn"
+    packager: "npm"
     includeModules: true
   prune:
     automatic: true

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -351,8 +351,7 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
      */
     await invokeLoadWalletAsync(xpubkeyStr, maxGap);
   } catch (e) {
-    logger.error('Error on lambda wallet invoke', e);
-
+    logger.error(e);
     const newRetryCount = wallet.retryCount ? wallet.retryCount + 1 : 1;
     // update wallet status to 'error'
     await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, newRetryCount);

--- a/packages/wallet-service/src/txProcessor.ts
+++ b/packages/wallet-service/src/txProcessor.ts
@@ -12,7 +12,6 @@ import { NftUtils } from '@wallet-service/common/src/utils/nft.utils';
 
 export const CREATE_NFT_MAX_RETRIES: number = parseInt(process.env.CREATE_NFT_MAX_RETRIES || '3', 10);
 
-
 /**
  * This intermediary handler is responsible for making the final validations and calling
  * the Explorer Service to update a NFT metadata, if needed.

--- a/packages/wallet-service/webpack.config.js
+++ b/packages/wallet-service/webpack.config.js
@@ -24,6 +24,11 @@ module.exports = {
     filename: '[name].js',
   },
   target: 'node',
+  // The bundle gets too big if we allow webpack to bundle all dependencies so
+  // we remove them from the bundle (they get loaded in runtime).
+  //
+  // We are adding the common project to allowlist because otherwise it would not
+  // be seen by the serverless-monorepo package.
   externals: [nodeExternals({
     allowlist: [new RegExp("@wallet-service/common*")],
   })],

--- a/packages/wallet-service/webpack.config.js
+++ b/packages/wallet-service/webpack.config.js
@@ -41,7 +41,6 @@ module.exports = {
               return /node_modules/.test(modulePath) &&
                      !/node_modules\/@wallet-service\/common/.test(modulePath);
             },
-            // path.resolve(__dirname, 'node_modules'),
             path.resolve(__dirname, '.serverless'),
             path.resolve(__dirname, '.webpack'),
           ],

--- a/packages/wallet-service/webpack.config.js
+++ b/packages/wallet-service/webpack.config.js
@@ -24,7 +24,9 @@ module.exports = {
     filename: '[name].js',
   },
   target: 'node',
-  externals: [nodeExternals()],
+  externals: [nodeExternals({
+    allowlist: [new RegExp("@wallet-service/common*")],
+  })],
   module: {
     rules: [
       // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
@@ -33,7 +35,13 @@ module.exports = {
         loader: 'ts-loader',
         exclude: [
           [
-            path.resolve(__dirname, 'node_modules'),
+            // The common module is not transpiled to javascript, so it needs
+            // to be loaded with the ts-loader
+            function(modulePath) {
+              return /node_modules/.test(modulePath) &&
+                     !/node_modules\/@wallet-service\/common/.test(modulePath);
+            },
+            // path.resolve(__dirname, 'node_modules'),
             path.resolve(__dirname, '.serverless'),
             path.resolve(__dirname, '.webpack'),
           ],

--- a/packages/wallet-service/webpack.config.js
+++ b/packages/wallet-service/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   entry: slsw.lib.entries,
   devtool: slsw.lib.webpack.isLocal ? 'eval-cheap-module-source-map' : 'source-map',
   resolve: {
-    extensions: ['.mjs', '.json', '.ts'],
+    extensions: ['.js', '.mjs', '.json', '.ts'],
     symlinks: false,
     cacheWithContext: false,
     alias: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4874,6 +4874,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wallet-service/common@file:../../packages/common::locator=wallet-service%40workspace%3Apackages%2Fwallet-service":
+  version: 1.5.0
+  resolution: "@wallet-service/common@file:../../packages/common#../../packages/common::hash=770320&locator=wallet-service%40workspace%3Apackages%2Fwallet-service"
+  peerDependencies:
+    "@aws-sdk/client-lambda": 3.540.0
+    "@hathor/wallet-lib": 0.39.0
+    winston: ^3.13.0
+  checksum: 10/8c963d4d0e0ec1664002e33fb9ac481a58b9bb17714b0551581eebef9f11856b185c0566835148ad32d945779230ed0e5b6781a34f59be7f6d440759b20eb813
+  languageName: node
+  linkType: hard
+
 "@wallet-service/common@workspace:^, @wallet-service/common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@wallet-service/common@workspace:packages/common"
@@ -15875,7 +15886,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wallet-service@workspace:packages/wallet-service"
   dependencies:
+    "@aws-sdk/client-apigatewaymanagementapi": "npm:3.540.0"
+    "@aws-sdk/client-lambda": "npm:3.540.0"
+    "@aws-sdk/client-sqs": "npm:3.540.0"
     "@hathor/healthcheck-lib": "npm:^0.1.0"
+    "@hathor/wallet-lib": "npm:0.39.0"
     "@middy/core": "npm:^2.5.7"
     "@middy/http-cors": "npm:^2.5.7"
     "@types/aws-lambda": "npm:^8.10.95"
@@ -15884,10 +15899,12 @@ __metadata:
     "@types/redis": "npm:^2.8.28"
     "@typescript-eslint/eslint-plugin": "npm:^6.7.4"
     "@typescript-eslint/parser": "npm:^3.3.0"
-    "@wallet-service/common": "workspace:^"
+    "@wallet-service/common": ../../packages/common
     aws-lambda: "npm:^1.0.7"
     axios: "npm:^0.21.1"
     bip32: "npm:^3.0.1"
+    bitcoinjs-lib: "npm:^6.1.5"
+    bitcoinjs-message: "npm:^2.2.0"
     bitcore-lib: "npm:8.25.10"
     bitcore-mnemonic: "npm:8.25.10"
     dotenv: "npm:^10.0.0"
@@ -15928,14 +15945,7 @@ __metadata:
     uuid: "npm:^8.3.0"
     webpack: "npm:^5.88.2"
     webpack-node-externals: "npm:^3.0.0"
-  peerDependencies:
-    "@aws-sdk/client-apigatewaymanagementapi": 3.540.0
-    "@aws-sdk/client-lambda": 3.540.0
-    "@aws-sdk/client-sqs": 3.540.0
-    "@hathor/wallet-lib": ^0.39.0
-    bitcoinjs-lib: ^6.1.5
-    bitcoinjs-message: ^2.2.0
-    winston: ^3.13.0
+    winston: "npm:^3.13.0"
   languageName: unknown
   linkType: soft
 
@@ -16157,7 +16167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston@npm:3.13.0":
+"winston@npm:3.13.0, winston@npm:^3.13.0":
   version: 3.13.0
   resolution: "winston@npm:3.13.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9407,6 +9407,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@typescript-eslint/eslint-plugin": "npm:^7.4.0"
     "@typescript-eslint/parser": "npm:^7.4.0"
+    "@wallet-service/common": "npm:1.5.0"
     bip32: "npm:^4.0.0"
     bitcoinjs-lib: "npm:^6.1.5"
     bitcoinjs-message: "npm:^2.2.0"
@@ -15875,11 +15876,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wallet-service@workspace:packages/wallet-service"
   dependencies:
-    "@aws-sdk/client-apigatewaymanagementapi": "npm:3.540.0"
-    "@aws-sdk/client-lambda": "npm:3.540.0"
-    "@aws-sdk/client-sqs": "npm:3.540.0"
     "@hathor/healthcheck-lib": "npm:^0.1.0"
-    "@hathor/wallet-lib": "npm:0.39.0"
     "@middy/core": "npm:^2.5.7"
     "@middy/http-cors": "npm:^2.5.7"
     "@types/aws-lambda": "npm:^8.10.95"
@@ -15888,12 +15885,9 @@ __metadata:
     "@types/redis": "npm:^2.8.28"
     "@typescript-eslint/eslint-plugin": "npm:^6.7.4"
     "@typescript-eslint/parser": "npm:^3.3.0"
-    "@wallet-service/common": "npm:1.5.0"
     aws-lambda: "npm:^1.0.7"
     axios: "npm:^0.21.1"
     bip32: "npm:^3.0.1"
-    bitcoinjs-lib: "npm:^6.1.5"
-    bitcoinjs-message: "npm:^2.2.0"
     bitcore-lib: "npm:8.25.10"
     bitcore-mnemonic: "npm:8.25.10"
     dotenv: "npm:^10.0.0"
@@ -15934,7 +15928,15 @@ __metadata:
     uuid: "npm:^8.3.0"
     webpack: "npm:^5.88.2"
     webpack-node-externals: "npm:^3.0.0"
-    winston: "npm:^3.13.0"
+  peerDependencies:
+    "@aws-sdk/client-apigatewaymanagementapi": 3.540.0
+    "@aws-sdk/client-lambda": 3.540.0
+    "@aws-sdk/client-sqs": 3.540.0
+    "@hathor/wallet-lib": ^0.39.0
+    "@wallet-service/common": 1.5.0
+    bitcoinjs-lib: ^6.1.5
+    bitcoinjs-message: ^2.2.0
+    winston: ^3.13.0
   languageName: unknown
   linkType: soft
 
@@ -16156,7 +16158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston@npm:3.13.0, winston@npm:^3.13.0":
+"winston@npm:3.13.0":
   version: 3.13.0
   resolution: "winston@npm:3.13.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -15876,6 +15876,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wallet-service@workspace:packages/wallet-service"
   dependencies:
+    "@aws-sdk/client-apigatewaymanagementapi": "npm:3.540.0"
+    "@aws-sdk/client-lambda": "npm:3.540.0"
+    "@aws-sdk/client-sqs": "npm:3.540.0"
     "@hathor/healthcheck-lib": "npm:^0.1.0"
     "@middy/core": "npm:^2.5.7"
     "@middy/http-cors": "npm:^2.5.7"
@@ -15888,6 +15891,8 @@ __metadata:
     aws-lambda: "npm:^1.0.7"
     axios: "npm:^0.21.1"
     bip32: "npm:^3.0.1"
+    bitcoinjs-lib: "npm:^6.1.5"
+    bitcoinjs-message: "npm:^2.2.0"
     bitcore-lib: "npm:8.25.10"
     bitcore-mnemonic: "npm:8.25.10"
     dotenv: "npm:^10.0.0"
@@ -15928,15 +15933,10 @@ __metadata:
     uuid: "npm:^8.3.0"
     webpack: "npm:^5.88.2"
     webpack-node-externals: "npm:^3.0.0"
+    winston: "npm:^3.13.0"
   peerDependencies:
-    "@aws-sdk/client-apigatewaymanagementapi": 3.540.0
-    "@aws-sdk/client-lambda": 3.540.0
-    "@aws-sdk/client-sqs": 3.540.0
     "@hathor/wallet-lib": ^0.39.0
     "@wallet-service/common": 1.5.0
-    bitcoinjs-lib: ^6.1.5
-    bitcoinjs-message: ^2.2.0
-    winston: ^3.13.0
   languageName: unknown
   linkType: soft
 
@@ -16158,7 +16158,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston@npm:3.13.0":
+"winston@npm:3.13.0, winston@npm:^3.13.0":
   version: 3.13.0
   resolution: "winston@npm:3.13.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4874,18 +4874,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wallet-service/common@file:../../packages/common::locator=wallet-service%40workspace%3Apackages%2Fwallet-service":
-  version: 1.5.0
-  resolution: "@wallet-service/common@file:../../packages/common#../../packages/common::hash=770320&locator=wallet-service%40workspace%3Apackages%2Fwallet-service"
-  peerDependencies:
-    "@aws-sdk/client-lambda": 3.540.0
-    "@hathor/wallet-lib": 0.39.0
-    winston: ^3.13.0
-  checksum: 10/8c963d4d0e0ec1664002e33fb9ac481a58b9bb17714b0551581eebef9f11856b185c0566835148ad32d945779230ed0e5b6781a34f59be7f6d440759b20eb813
-  languageName: node
-  linkType: hard
-
-"@wallet-service/common@workspace:^, @wallet-service/common@workspace:packages/common":
+"@wallet-service/common@npm:1.5.0, @wallet-service/common@workspace:^, @wallet-service/common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@wallet-service/common@workspace:packages/common"
   dependencies:
@@ -15899,7 +15888,7 @@ __metadata:
     "@types/redis": "npm:^2.8.28"
     "@typescript-eslint/eslint-plugin": "npm:^6.7.4"
     "@typescript-eslint/parser": "npm:^3.3.0"
-    "@wallet-service/common": ../../packages/common
+    "@wallet-service/common": "npm:1.5.0"
     aws-lambda: "npm:^1.0.7"
     axios: "npm:^0.21.1"
     bip32: "npm:^3.0.1"


### PR DESCRIPTION
### Motivation

Serverless was failing to package because of multiple issues related to the new yarn workspaces monorepo structure:

1. It wasn't able to find the common module:

```
Error: Cannot find module './@wallet-service/common/package.json'
```

Upon investigation, I found out that this was happening because it yarn workspaces symlinks internal modules to the package's `node_modules` and `serverless-monorepo` was cleaning it

The fix for this issue was adding it as a peer dependency, which actually copied the dependency to the `node_modules` folder and also adding it to be parsed by the `ts-loader`

2. Peer dependencies were not being transpiled by webpack

This is a weird one, but after we solved the issue with the common module, the package was failing in runtime because of errors on the imports

I wasn't to dive deep into why this was the case, but moving the peer dependencies to be dependencies fixed this issue.

My suggestion is to move on with this PR because it is stopping us from fixing a bug affecting our production server (NFT metadata is not being created on S3) and investigate in a KTLO in the near future.

The side effect is only that `yarn install` will take a little longer because it will not hoist the peer dependencies into the root package.



### Acceptance Criteria

- The wallet-service should be able to be packaged and deployed using the common module
- Dependencies should be properly transpiled by webpack

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
