### PR TITLE
tests: missing tests on websocket

### DIFF
--- a/packages/wallet-service/tests/ws.utils.test.ts
+++ b/packages/wallet-service/tests/ws.utils.test.ts
@@ -1,6 +1,46 @@
 import { mockedAddAlert } from '@tests/utils/alerting.utils.mock';
-import { connectionInfoFromEvent } from '@src/ws/utils';
+import { connectionInfoFromEvent, sendMessageToClient } from '@src/ws/utils';
 import { Severity } from '@src/types';
+
+import { logger } from '@tests/winston.mock';
+import { RedisClient } from 'redis';
+import {
+  GoneException,
+} from '@aws-sdk/client-apigatewaymanagementapi';
+import { RedisConfig } from '@src/types';
+
+const mockedSend = jest.fn();
+
+jest.mock('@src/redis', () => {
+  const originalModule = jest.requireActual('@src/redis');
+  return {
+    ...originalModule,
+    endWsConnection: jest.fn(),
+  };
+});
+
+jest.mock('@aws-sdk/client-apigatewaymanagementapi', () => {
+  const originalModule = jest.requireActual('@aws-sdk/client-apigatewaymanagementapi');
+  return {
+    ...originalModule,
+    ApiGatewayManagementApiClient: jest.fn().mockImplementation(() => ({
+      send: mockedSend,
+    })),
+  };
+});
+
+jest.mock('redis', () => ({
+  RedisClient: jest.fn().mockImplementation(() => ({
+    endWsConnection: jest.fn(),
+    on: jest.fn(),
+    set: jest.fn(),
+    get: jest.fn(),
+    del: jest.fn(),
+    quit: jest.fn(),
+  })),
+}));
+
+import { endWsConnection } from '@src/redis';
 
 test('connectionInfoFromEvent', async () => {
   expect.hasAssertions();
@@ -41,4 +81,66 @@ test('missing WS_DOMAIN should throw', () => {
     'Domain not on env variables',
     Severity.MINOR,
   );
+});
+
+describe('sendMessageToClient', () => {
+  let client: any;
+  const redisConfig: RedisConfig = {
+    url: 'http://doesntmatter.com',
+    password: 'password',
+  };
+  const connInfo = { url: 'http://example.com', id: '1234' };
+  const message = 'hello';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new RedisClient(redisConfig);
+  });
+
+  it('should send a message successfully', async () => {
+    mockedSend.mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+    });
+
+    await sendMessageToClient(client, connInfo, message);
+
+    expect(mockedSend).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        ConnectionId: connInfo.id,
+        Data: JSON.stringify(message),
+      })
+    }));
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('should log and throw an error if API Gateway returns non-200 status', async () => {
+    mockedSend.mockResolvedValue({
+      $metadata: { httpStatusCode: 400 },
+    });
+
+    await sendMessageToClient(client, connInfo, message);
+
+    expect(mockedAddAlert).toHaveBeenCalledWith(
+      'Unhandled error while sending websocket message to client',
+      'The wallet-service was unable to handle an error while attempting to send a message to a websocket client. Please check the logs.',
+      Severity.MINOR,
+      {
+        ConnectionId: connInfo.id,
+        Message: JSON.stringify(message),
+      }
+    );
+  });
+
+  it('should handle GoneException by closing the connection', async () => {
+    mockedSend.mockRejectedValue(new GoneException({
+      message: 'Connection is gone.',
+      $metadata: {
+        httpStatusCode: 410,
+      }
+    }));
+
+    await sendMessageToClient(client, connInfo, message);
+    expect(endWsConnection).toHaveBeenCalledWith(client, connInfo.id);
+  });
 });


### PR DESCRIPTION
### Motivation

Changes were made to the websocket utils without adding new tests, causing the coverage to drop below the minimum percentage, this PR should introduce new tests to the changed method

### Acceptance Criteria

- We should test the `sendMessageToClient` util

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
