### PR TITLE
chore: using fixed yarn version

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -174,7 +174,7 @@ phases:
     commands:
       - npm install -g yarn
       - corepack enable
-      - yarn set version stable
+      - yarn set version 4.1.0
       - yarn install
   pre_build:
     commands:


### PR DESCRIPTION
### Motivation

We were using the `stable` version of yarn, which causes yarn to yield a different lockfile from the developer if he's using a different version. We should use the same version that is used in the nix flake

### Acceptance Criteria

- We should fix the yarn version to 4.1.0

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
