### PR TITLE
chore: run with nodejs instead of yarn in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,14 @@ RUN yarn workspace sync-daemon run build
 # This will remove all dev dependencies and install production deps only
 RUN yarn workspaces focus -A --production
 
-CMD ["yarn", "workspace", "sync-daemon", "run", "start"]
+# Run phase
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+# Copy only the necessary files from the build phase
+COPY --from=builder /app .
+
+WORKDIR /app/packages/daemon/
+
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
### Motivation

The docker image was failing to run in kubernetes because our containers there are read-only

Upon investigation, I found out that `corepack` and `yarn` needs to write to fs

This PR changes the Dockerfile to include another stage that only have `node` installed, copies the installed dependencies and runs the service with the pre-installed `nodejs` instead of using `yarn` to run it.

### Acceptance Criteria

- We should change the Dockerfile to be multi-stage
- The second stage should only have nodejs installed and run the daemon using it

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
