### PR TITLE
fix: fetchMinRewardBlocks fails when reward_min_blocks is 0

### DIFF
--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -99,7 +99,7 @@ afterEach(() => {
 });
 
 describe('fetchInitialState', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     const mockUrl = 'http://mock-host:8080/v1a/';
     (getFullnodeHttpUrl as jest.Mock).mockReturnValue(mockUrl);
 
@@ -161,6 +161,46 @@ describe('fetchInitialState', () => {
     expect(result).toEqual({
       lastEventId: expect.any(Number),
       rewardMinBlocks: 300,
+    });
+
+    expect(mockDb.destroy).toHaveBeenCalled();
+  });
+
+  it('should not fail if reward spend min blocks is 0', async () => {
+    // Mock the return values of the dependencies
+    const mockDb = { destroy: jest.fn() };
+
+    // @ts-ignore
+    axios.get.mockResolvedValue({
+      status: 200,
+      data: {
+        version: '0.58.0-rc.1',
+        network: 'mainnet',
+        min_weight: 14,
+        min_tx_weight: 14,
+        min_tx_weight_coefficient: 1.6,
+        min_tx_weight_k: 100,
+        token_deposit_percentage: 0.01,
+        reward_spend_min_blocks: 0,
+        max_number_inputs: 255,
+        max_number_outputs: 255
+      }
+    });
+
+    // @ts-ignore
+    getDbConnection.mockReturnValue(mockDb);
+    // @ts-ignore
+    getLastSyncedEvent.mockResolvedValue({
+      id: 0,
+      last_event_id: 123,
+      updated_at: Date.now(),
+    });
+
+    const result = await fetchInitialState();
+
+    expect(result).toEqual({
+      lastEventId: expect.any(Number),
+      rewardMinBlocks: 0,
     });
 
     expect(mockDb.destroy).toHaveBeenCalled();

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -528,7 +528,7 @@ export const fetchMinRewardBlocks = async () => {
 
   const rewardSpendMinBlocks = get(response, 'data.reward_spend_min_blocks');
 
-  if (!rewardSpendMinBlocks) {
+  if (rewardSpendMinBlocks == null) {
     throw new Error('Failed to fetch reward spend min blocks');
   }
 


### PR DESCRIPTION
### Motivation

`fetchMinRewardBlocks` is throwing an error when `reward_min_blocks` is 0 on the fullnode

### Acceptance Criteria

- `fetchMinRewardBlocks` should not throw when the `reward_min_blocks` returned by the fullnode is 0

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
