### PR TITLE
fix: handle tx with no inputs and outputs

### DIFF
--- a/packages/daemon/__tests__/types.ts
+++ b/packages/daemon/__tests__/types.ts
@@ -5,6 +5,14 @@ export interface AddressTableEntry {
   transactions: number;
 }
 
+export interface TransactionTableEntry {
+  txId: string;
+  timestamp: number;
+  version: number;
+  voided: boolean;
+  height: number;
+}
+
 export interface WalletBalanceEntry {
   walletId: string;
   tokenId: string;

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -22,7 +22,7 @@
     "test_images_wait_for_ws": "yarn dlx ts-node ./__tests__/integration/scripts/wait-for-ws-up.ts",
     "test_images_setup_database": "yarn dlx ts-node ./__tests__/integration/scripts/setup-database.ts",
     "test": "jest --coverage",
-    "test_integration": "yarn run test_images_up && yarn run test_images_wait_for_db && yarn run test_images_wait_for_ws && yarn run test_images_setup_database && yarn run test_images_migrate && yarn run test_images_integration && yarn run test_images_down"
+    "test_integration": "yarn run test_images_up && yarn run test_images_wait_for_db && yarn run test_images_wait_for_ws && yarn run test_images_setup_database && yarn run test_images_migrate && yarn run test_images_integration"
   },
   "name": "sync-daemon",
   "author": "André Abadesso",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -22,7 +22,7 @@
     "test_images_wait_for_ws": "yarn dlx ts-node ./__tests__/integration/scripts/wait-for-ws-up.ts",
     "test_images_setup_database": "yarn dlx ts-node ./__tests__/integration/scripts/setup-database.ts",
     "test": "jest --coverage",
-    "test_integration": "yarn run test_images_up && yarn run test_images_wait_for_db && yarn run test_images_wait_for_ws && yarn run test_images_setup_database && yarn run test_images_migrate && yarn run test_images_integration"
+    "test_integration": "yarn run test_images_up && yarn run test_images_wait_for_db && yarn run test_images_wait_for_ws && yarn run test_images_setup_database && yarn run test_images_migrate && yarn run test_images_integration && yarn run test_images_down"
   },
   "name": "sync-daemon",
   "author": "André Abadesso",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -17,7 +17,7 @@
     "test_images_up": "docker-compose -f ./__tests__/integration/scripts/docker-compose.yml up -d",
     "test_images_down": "docker-compose -f ./__tests__/integration/scripts/docker-compose.yml down",
     "test_images_integration": "jest --config ./jest_integration.config.js --runInBand --forceExit",
-    "test_images_migrate": "DB_NAME=hathor DB_PORT=3380 DB_PASS=hathor DB_USER=hathor yarn run sequelize-cli --migrations-path ../../db/migrations --config ./__tests__/integration/scripts/sequelize-db-config.js db:migrate",
+    "test_images_migrate": "NODE_ENV=test DB_NAME=hathor DB_PORT=3380 DB_PASS=hathor DB_USER=hathor yarn run sequelize-cli --migrations-path ../../db/migrations --config ./__tests__/integration/scripts/sequelize-db-config.js db:migrate",
     "test_images_wait_for_db": "yarn dlx ts-node ./__tests__/integration/scripts/wait-for-db-up.ts",
     "test_images_wait_for_ws": "yarn dlx ts-node ./__tests__/integration/scripts/wait-for-ws-up.ts",
     "test_images_setup_database": "yarn dlx ts-node ./__tests__/integration/scripts/setup-database.ts",

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import mysql, { Connection as MysqlConnection, Pool } from 'mysql2/promise';
+import mysql, { Connection as MysqlConnection, OkPacket, Pool, ResultSetHeader } from 'mysql2/promise';
 import {
   DbTxOutput,
   StringMap,
@@ -362,11 +362,40 @@ export const getTxOutputsAtHeight = async (
   return utxos;
 };
 
+/**
+ * Void a transaction by updating the related address and balance information in the database.
+ *
+ * @param mysql - The MySQL connection object
+ * @param txId - The ID of the transaction to be voided.
+ * @param addressBalanceMap - A map where the key is an address and the value is a map of token balances.
+ *   The TokenBalanceMap contains information about the total amount sent, unlocked and locked amounts, and authorities.
+ *
+ * @returns {Promise<void>} - A promise that resolves when the transaction has been voided and the database updated
+ *
+ * This function performs the following steps:
+ * 1. Inserts addresses with a transaction count of 0 into the `address` table or subtracts 1 from the transaction count if they already exist
+ * 2. Iterates over the addressBalanceMap to update the `address_balance` table with the received token balances.
+ * 3. Deletes the transaction entry from the `address_tx_history` table.
+ * 4. Updates the transaction entry in the `transaction` table to mark it as voided.
+ *
+ * The function ensures that the authorities are correctly updated and the smallest timelock expiration value is preserved.
+ */
 export const voidTransaction = async (
   mysql: any,
   txId: string,
   addressBalanceMap: StringMap<TokenBalanceMap>,
 ): Promise<void> => {
+  const [result]: [ResultSetHeader] = await mysql.query(
+    `UPDATE \`transaction\`
+        SET \`voided\` = TRUE
+      WHERE \`tx_id\` = ?`,
+    [txId],
+  );
+
+  if (result.affectedRows !== 1) {
+    throw new Error('Tried to void a transaction that is not in the database.');
+  }
+
   const addressEntries = Object.keys(addressBalanceMap).map((address) => [address, 0]);
 
   if (addressEntries.length > 0) {
@@ -445,13 +474,6 @@ export const voidTransaction = async (
 
   await mysql.query(
     `DELETE FROM \`address_tx_history\`
-      WHERE \`tx_id\` = ?`,
-    [txId],
-  );
-
-  await mysql.query(
-    `UPDATE \`transaction\`
-        SET \`voided\` = TRUE
       WHERE \`tx_id\` = ?`,
     [txId],
   );

--- a/packages/daemon/src/types/db.ts
+++ b/packages/daemon/src/types/db.ts
@@ -53,6 +53,14 @@ export interface AddressTableRow extends RowDataPacket {
   transactions: number;
 }
 
+export interface TransactionTableRow extends RowDataPacket {
+  tx_id: string;
+  timestamp: number;
+  version: number;
+  voided: boolean;
+  height: number;
+}
+
 export interface AddressBalanceRow extends RowDataPacket {
   address: string;
   token_id: string;


### PR DESCRIPTION
### Motivation

This should fix https://github.com/HathorNetwork/on-call-incidents/issues/179

### Acceptance Criteria

- We should add `NODE_ENV` to the `test_integration` script so that it runs locally without having to manually export it
- We should fix an issue when a transaction has no inputs and outputs, like PoA blocks from PoA side-dags

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
