### PR TITLE
feat: allow sending alerts to another account

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -89,6 +89,7 @@ env:
     dev_FIREBASE_CLIENT_X509_CERT_URL: "WalletService/dev:FIREBASE_CLIENT_X509_CERT_URL"
     dev_ALERT_MANAGER_REGION: "WalletService/dev:ALERT_MANAGER_REGION"
     dev_ALERT_MANAGER_TOPIC: "WalletService/dev:ALERT_MANAGER_TOPIC"
+    dev_ALERT_MANAGER_ACCOUNT_ID: "WalletService/dev:ALERT_MANAGER_ACCOUNT_ID"
     # Testnet secrets
     testnet_ACCOUNT_ID: "WalletService/testnet:account_id"
     testnet_AUTH_SECRET: "WalletService/testnet:auth_secret"
@@ -114,6 +115,7 @@ env:
     testnet_FIREBASE_CLIENT_X509_CERT_URL: "WalletService/testnet:FIREBASE_CLIENT_X509_CERT_URL"
     testnet_ALERT_MANAGER_REGION: "WalletService/testnet:ALERT_MANAGER_REGION"
     testnet_ALERT_MANAGER_TOPIC: "WalletService/testnet:ALERT_MANAGER_TOPIC"
+    testnet_ALERT_MANAGER_ACCOUNT_ID: "WalletService/testnet:ALERT_MANAGER_ACCOUNT_ID"
     # Mainnet Staging secrets
     mainnet_staging_ACCOUNT_ID: "WalletService/mainnet_staging:account_id"
     mainnet_staging_AUTH_SECRET: "WalletService/mainnet_staging:auth_secret"
@@ -139,6 +141,7 @@ env:
     mainnet_staging_FIREBASE_CLIENT_X509_CERT_URL: "WalletService/mainnet_staging:FIREBASE_CLIENT_X509_CERT_URL"
     mainnet_staging_ALERT_MANAGER_REGION: "WalletService/mainnet_staging:ALERT_MANAGER_REGION"
     mainnet_staging_ALERT_MANAGER_TOPIC: "WalletService/mainnet_staging:ALERT_MANAGER_TOPIC"
+    mainnet_staging_ALERT_MANAGER_ACCOUNT_ID: "WalletService/mainnet_staging:ALERT_MANAGER_ACCOUNT_ID"
     # Mainnet secrets
     mainnet_ACCOUNT_ID: "WalletService/mainnet:account_id"
     mainnet_AUTH_SECRET: "WalletService/mainnet:auth_secret"
@@ -164,6 +167,7 @@ env:
     mainnet_FIREBASE_CLIENT_X509_CERT_URL: "WalletService/mainnet:FIREBASE_CLIENT_X509_CERT_URL"
     mainnet_ALERT_MANAGER_REGION: "WalletService/mainnet:ALERT_MANAGER_REGION"
     mainnet_ALERT_MANAGER_TOPIC: "WalletService/mainnet:ALERT_MANAGER_TOPIC"
+    mainnet_ALERT_MANAGER_ACCOUNT_ID: "WalletService/mainnet:ALERT_MANAGER_ACCOUNT_ID"
 phases:
   install:
     #If you use the Ubuntu standard image 2.0 or later, you must specify runtime-versions.

--- a/packages/common/src/utils/alerting.utils.ts
+++ b/packages/common/src/utils/alerting.utils.ts
@@ -36,11 +36,13 @@ export const addAlert = async (
 
   const {
     ACCOUNT_ID,
+    ALERT_MANAGER_ACCOUNT_ID,
     ALERT_MANAGER_REGION,
     ALERT_MANAGER_TOPIC,
   } = process.env;
 
-  const QUEUE_URL = `https://sqs.${ALERT_MANAGER_REGION}.amazonaws.com/${ACCOUNT_ID}/${ALERT_MANAGER_TOPIC}`;
+  const account_id = ALERT_MANAGER_ACCOUNT_ID || ACCOUNT_ID;
+  const QUEUE_URL = `https://sqs.${ALERT_MANAGER_REGION}.amazonaws.com/${account_id}/${ALERT_MANAGER_TOPIC}`;
 
   const client = new SQSClient({
     endpoint: QUEUE_URL,

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -74,6 +74,7 @@ export const PUSH_NOTIFICATION_LAMBDA_REGION = process.env.PUSH_NOTIFICATION_LAM
 export const ACCOUNT_ID = process.env.ACCOUNT_ID;
 export const ALERT_MANAGER_REGION = process.env.ALERT_MANAGER_REGION;
 export const ALERT_MANAGER_TOPIC  = process.env.ALERT_MANAGER_TOPIC;
+export const ALERT_MANAGER_ACCOUNT_ID = process.env.ALERT_MANAGER_ACCOUNT_ID;
 export const AWS_REGION = process.env.AWS_REGION;
 
 // Healthcheck configuration

--- a/packages/wallet-service/README.md
+++ b/packages/wallet-service/README.md
@@ -69,6 +69,10 @@ PUSH_ALLOWED_PROVIDERS=android
 
 Do not modify the `STAGE` variable. The other variables should be updated accordingly.
 
+The following variables are optional:
+
+- `ALERT_MANAGER_ACCOUNT_ID`: Account ID to send alerts to. If not set, `ACCOUNT_ID` will be used instead. If neither is set, alerting will not work.
+
 ### AWS cli credentials
 
 You need to have `awscli` [configured with your credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -37,10 +37,10 @@ custom:
     topics: # SNS Topics to send alerts to
       major:
         alarm:
-          topic: arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:opsgenie-cloudwatch-integration-production-major
+          topic: arn:aws:sns:${self:provider.region}:${self:provider.environment.ALERT_MANAGER_ACCOUNT_ID}:opsgenie-cloudwatch-integration-production-major
       minor:
         alarm:
-          topic: arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:opsgenie-cloudwatch-integration-production-minor
+          topic: arn:aws:sns:${self:provider.region}:${self:provider.environment.ALERT_MANAGER_ACCOUNT_ID}:opsgenie-cloudwatch-integration-production-minor
     definitions: # Definition of alarms
       majorFunctionErrors:
         description: "Too many errors in hathor-wallet-service. Runbook: https://github.com/HathorNetwork/ops-tools/blob/master/docs/runbooks/wallet-service/errors-in-logs.md"
@@ -149,7 +149,7 @@ provider:
             - sqs:*
           Resource:
             - Fn::GetAtt: [ WalletServiceNewTxQueue, Arn ]
-            - arn:aws:sqs:${self:provider.environment.ALERT_MANAGER_REGION}:${self:provider.environment.ACCOUNT_ID}:${self:provider.environment.ALERT_MANAGER_TOPIC}
+            - arn:aws:sqs:${self:provider.environment.ALERT_MANAGER_REGION}:${self:provider.environment.ALERT_MANAGER_ACCOUNT_ID}:${self:provider.environment.ALERT_MANAGER_TOPIC}
   vpc:
     securityGroupIds:
       - ${env:AWS_VPC_DEFAULT_SG_ID}
@@ -208,6 +208,7 @@ provider:
     LOG_LEVEL: ${env:LOG_LEVEL}
     ALERT_MANAGER_REGION: ${env:ALERT_MANAGER_REGION}
     ALERT_MANAGER_TOPIC: ${env:ALERT_MANAGER_TOPIC}
+    ALERT_MANAGER_ACCOUNT_ID: ${env:ALERT_MANAGER_ACCOUNT_ID}
 
 functions:
   getLatestBlock:


### PR DESCRIPTION
### Motivation

We need to send alerts from wallet-service Lambdas running in separate AWS sub-accounts

### Acceptance Criteria

- We should have a new variable to define the account id where alert-manager is located. It's possible now that this account will be different than the one where wallet-service Lambdas/daemon run.

### Deploy
- [ ] We need to manually deploy this to our test networks (like `nano-testnet`) after merging

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
