### PR TITLE
fix: broken lambda deploy

### DIFF
--- a/packages/wallet-service/package.json
+++ b/packages/wallet-service/package.json
@@ -60,7 +60,7 @@
     "jest": "29.7.0",
     "npm-run-all": "4.1.5",
     "serverless": "3.35.2",
-    "serverless-api-gateway-throttling": "1.1.1",
+    "serverless-api-gateway-throttling": "2.0.3",
     "serverless-better-credentials": "2.0.0",
     "serverless-iam-roles-per-function": "3.2.0",
     "serverless-offline": "13.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14331,13 +14331,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serverless-api-gateway-throttling@npm:1.1.1":
-  version: 1.1.1
-  resolution: "serverless-api-gateway-throttling@npm:1.1.1"
+"serverless-api-gateway-throttling@npm:2.0.3":
+  version: 2.0.3
+  resolution: "serverless-api-gateway-throttling@npm:2.0.3"
   dependencies:
     lodash.get: "npm:^4.4.2"
     lodash.isempty: "npm:^4.4.0"
-  checksum: 10/dd122874cfbb27db9de60d60c4fa5c6e6d4c6f41be1fb83ee91a372860e92128cffcfb137df6c0a31b980e8a4d0c12fd3a2df734e60a1a464690e3bf11619546
+  checksum: 10/f8b275ab3312f9504a72bc57d67068b949e7e95dfbafae661fb91355237047cd17aa07078086e2771c494b056f4c81c630431de24f0864738cb87e0299fa8ddb
   languageName: node
   linkType: hard
 
@@ -16404,7 +16404,7 @@ __metadata:
     prom-client: "npm:13.2.0"
     redis: "npm:3.1.2"
     serverless: "npm:3.35.2"
-    serverless-api-gateway-throttling: "npm:1.1.1"
+    serverless-api-gateway-throttling: "npm:2.0.3"
     serverless-better-credentials: "npm:2.0.0"
     serverless-iam-roles-per-function: "npm:3.2.0"
     serverless-mysql: "npm:1.5.4"


### PR DESCRIPTION
### Motivation

`serverless-api-gateway-throttling` was causing the deploy to fail after we fixed the project dependencies with this error:

`At least one of the plugins defines a validation schema that is invalid. Try disabling plugins one by one to identify the problematic plugin and report it to the plugin maintainers.`

It was fixed in a later version, so I decided to update this package to the latest version

### Acceptance Criteria

- The deploy should work properly without warnings or errors
- We should update the `serverless-api-gateway-throttling` package version to the latest available.

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
