### PR TITLE
fix: slow address generation

### DIFF
--- a/db/migrations/20241203185227-add-address-wallet_id-index.js
+++ b/db/migrations/20241203185227-add-address-wallet_id-index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.addIndex(
+      'address',
+      ['wallet_id', 'index'],
+      {
+        name: 'idx_wallet_address_index',
+      }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('address', 'idx_wallet_address_index');
+  }
+};

--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -12,7 +12,6 @@ import {
   addUtxos,
   fetchAddressBalance,
   fetchAddressTxHistorySum,
-  generateAddresses,
   getAddressWalletInfo,
   getBestBlockHeight,
   getDbConnection,
@@ -74,6 +73,7 @@ import { DbTxOutput, StringMap, TokenInfo, WalletStatus } from '../../src/types'
 import { Authorities, TokenBalanceMap } from '@wallet-service/common';
 // @ts-ignore
 import { constants } from '@hathor/wallet-lib';
+import { generateAddresses } from '../../src/utils';
 
 // Use a single mysql connection for all tests
 let mysql: Connection;
@@ -792,7 +792,7 @@ describe('address and wallet related tests', () => {
     const address4 = ADDRESSES[4];
 
     // check first with no addresses on database, so it should return only maxGap addresses
-    let addresses = await generateAddresses(XPUBKEY, 0, maxGap);
+    let addresses = await generateAddresses('mainnet', XPUBKEY, 0, maxGap);
 
     expect(Object.keys(addresses).length).toBe(maxGap);
     expect(addresses[address0]).toBe(0);
@@ -805,14 +805,14 @@ describe('address and wallet related tests', () => {
       transactions: 0,
     }]);
 
-    addresses = await generateAddresses(XPUBKEY, 0, maxGap);
+    addresses = await generateAddresses('mainnet', XPUBKEY, 0, maxGap);
     expect(Object.keys(addresses).length).toBe(maxGap);
     expect(addresses[address0]).toBe(0);
 
     // now mark address0 as used
     let usedIndex = 0;
     await mysql.query('UPDATE `address` SET `transactions` = ? WHERE `address` = ?', [1, address0]);
-    addresses = await generateAddresses(XPUBKEY, 0, maxGap + usedIndex + 1);
+    addresses = await generateAddresses('mainnet', XPUBKEY, 0, maxGap + usedIndex + 1);
     expect(Object.keys(addresses).length).toBe(maxGap + usedIndex + 1);
     expect(addresses[address0]).toBe(0);
 
@@ -825,7 +825,7 @@ describe('address and wallet related tests', () => {
       transactions: 1,
     }]);
 
-    addresses = await generateAddresses(XPUBKEY, 0, maxGap + usedIndex + 1);
+    addresses = await generateAddresses('mainnet', XPUBKEY, 0, maxGap + usedIndex + 1);
     expect(Object.keys(addresses).length).toBe(maxGap + usedIndex + 1);
     expect(addresses[address0]).toBe(0);
     expect(addresses[address1]).toBe(1);
@@ -839,7 +839,7 @@ describe('address and wallet related tests', () => {
       transactions: 1,
     }]);
 
-    addresses = await generateAddresses(XPUBKEY, 0, maxGap + usedIndex + 1);
+    addresses = await generateAddresses('mainnet', XPUBKEY, 0, maxGap + usedIndex + 1);
     expect(Object.keys(addresses).length).toBe(maxGap + usedIndex + 1);
     expect(addresses[address0]).toBe(0);
     expect(addresses[address4]).toBe(4);
@@ -1266,7 +1266,7 @@ describe('address generation and index methods', () => {
 
     const startIndex = 0;
     const count = 3;
-    const addresses = await generateAddresses(XPUBKEY, startIndex, count);
+    const addresses = await generateAddresses('mainnet', XPUBKEY, startIndex, count);
 
     // Check if we got the expected number of addresses
     expect(Object.keys(addresses).length).toBe(count);

--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -21,6 +21,7 @@ import {
   getAddressWalletInfo,
   generateAddresses,
   storeTokenInformation,
+  getMaxIndicesForWallets,
 } from '../../src/db';
 import {
   fetchInitialState,
@@ -83,8 +84,9 @@ jest.mock('../../src/db', () => ({
   generateAddresses: jest.fn(),
   addNewAddresses: jest.fn(),
   updateWalletTablesWithTx: jest.fn(),
-  getMaxIndexAmongAddresses: jest.fn(),
-  getMaxWalletAddressIndex: jest.fn(),
+  getMaxIndicesForWallets: jest.fn(() => new Map([
+    ['wallet1', { maxAmongAddresses: 10, maxWalletIndex: 15 }]
+  ])),
 }));
 
 jest.mock('../../src/utils', () => ({
@@ -456,11 +458,18 @@ describe('handleVertexAccepted', () => {
     jest.clearAllMocks();
 
     (getDbConnection as jest.Mock).mockResolvedValue(mockDb);
-    (getAddressWalletInfo as jest.Mock).mockResolvedValue({});
-    (generateAddresses as jest.Mock).mockResolvedValue({
-      newAddresses: ['mockAddress1', 'mockAddress2'],
-      lastUsedAddressIndex: 1
+    (getAddressWalletInfo as jest.Mock).mockResolvedValue({
+      address1: { walletId: 'wallet1', xpubkey: 'xpubkey1', maxGap: 10 }
     });
+
+    (generateAddresses as jest.Mock).mockResolvedValue({
+      'new-address-1': 16,
+      'new-address-2': 17,
+    });
+
+    (getMaxIndicesForWallets as jest.Mock).mockResolvedValue(new Map([
+      ['wallet1', { maxAmongAddresses: 10, maxWalletIndex: 15 }]
+    ]));
   });
 
   it('should handle vertex accepted successfully', async () => {

--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -83,6 +83,8 @@ jest.mock('../../src/db', () => ({
   generateAddresses: jest.fn(),
   addNewAddresses: jest.fn(),
   updateWalletTablesWithTx: jest.fn(),
+  getMaxIndexAmongAddresses: jest.fn(),
+  getMaxWalletAddressIndex: jest.fn(),
 }));
 
 jest.mock('../../src/utils', () => ({

--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -19,7 +19,6 @@ import {
   getUtxosLockedAtHeight,
   addOrUpdateTx,
   getAddressWalletInfo,
-  generateAddresses,
   storeTokenInformation,
   getMaxIndicesForWallets,
 } from '../../src/db';
@@ -40,6 +39,7 @@ import {
   getFullnodeHttpUrl,
   invokeOnTxPushNotificationRequestedLambda,
   getWalletBalancesForTx,
+  generateAddresses,
 } from '../../src/utils';
 import getConfig from '../../src/config';
 
@@ -106,6 +106,7 @@ jest.mock('../../src/utils', () => ({
   invokeOnTxPushNotificationRequestedLambda: jest.fn(),
   sendMessageSQS: jest.fn(),
   getWalletBalancesForTx: jest.fn(),
+  generateAddresses: jest.fn(),
 }));
 
 beforeEach(() => {

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -1563,7 +1563,18 @@ export const getTokenSymbols = async (
   }, {}) as unknown as StringMap<string>;
 };
 
-// TODO: docstring
+/**
+ * Get the maximum index among a set of addresses for a specific wallet.
+ *
+ * @remarks
+ * This function is used to find the highest index used among a set of addresses that belong to a wallet.
+ * This is particularly useful when we need to determine where to start generating new addresses from.
+ *
+ * @param mysql - Database connection
+ * @param walletId - The ID of the wallet to check
+ * @param addresses - Array of addresses to check
+ * @returns The highest index found among the addresses, or null if no addresses are found
+ */
 export const getMaxIndexAmongAddresses = async (
   mysql: MysqlConnection,
   walletId: string,
@@ -1586,7 +1597,18 @@ export const getMaxIndexAmongAddresses = async (
   return results[0].max_index;
 };
 
-// TODO: docstring
+/**
+ * Get the maximum index used by any address in a wallet.
+ *
+ * @remarks
+ * This function retrieves the highest index used by any address in the given wallet.
+ * This is essential for wallet synchronization and address generation, as it helps determine
+ * the starting point for generating new addresses and maintaining the gap limit.
+ *
+ * @param mysql - Database connection
+ * @param walletId - The ID of the wallet to check
+ * @returns The highest index used in the wallet, or null if no addresses are found
+ */
 export const getMaxWalletAddressIndex = async (
   mysql: MysqlConnection,
   walletId: string,

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -1592,7 +1592,7 @@ export const getMaxWalletAddressIndex = async (
   walletId: string,
 ): Promise<number | null> => {
   const [results] = await mysql.query<MaxAddressIndexRow[]>(
-    `SELECT MAX(\`index\`)
+    `SELECT MAX(\`index\`) AS max_index
        FROM address
       WHERE wallet_id = ?
      `, [walletId]

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -1537,6 +1537,23 @@ export const getTokenSymbols = async (
 /**
  * Get maximum indices for multiple wallets in a single query.
  *
+ * This function retrieves two key metrics for each wallet:
+ *
+ * 1. `max_among_addresses`: The highest `index` value for the wallet, but only considering the specified addresses provided in `walletData`.
+ * 2. `max_wallet_index`: The highest `index` value for the wallet across all its addresses in the database.
+ *
+ * How it works:
+ * - The SQL query operates on the `address` table.
+ * - It groups the rows by `wallet_id` using `GROUP BY wallet_id`.
+ * - For each wallet group:
+ *   - The `MAX` function calculates the highest `index` value in two contexts:
+ *     a. For addresses explicitly listed in the input (`CASE WHEN address IN (?) THEN index END`).
+ *     b. For all addresses associated with the wallet (`MAX(index)`).
+ * - If no addresses for a wallet match the provided input, `max_among_addresses` will be `NULL`.
+ * - If a wallet has no addresses in the database, both `max_among_addresses` and `max_wallet_index` will be `NULL`.
+ *
+ * This allows the function to return a consolidated view of the maximum indices for each wallet
+ *
  * @param mysql - Database connection
  * @param walletData - Array of objects containing wallet IDs and their associated addresses
  * @returns Map of wallet IDs to their maximum indices (both among specific addresses and overall)

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -22,6 +22,7 @@ import {
   FullNodeEvent,
   EventTxInput,
   EventTxOutput,
+  WalletStatus,
 } from '../types';
 import {
   TxInput,
@@ -341,7 +342,10 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
         const { maxAmongAddresses, maxWalletIndex } = indices;
 
         if (!maxAmongAddresses || !maxWalletIndex) {
-          // Do nothing, this is unexpected and an error should have been logged already
+          // Do nothing, wallet is most likely not loaded yet.
+          if (walletDetails.status === WalletStatus.READY) {
+            logger.error('[ERROR] A wallet marked as READY does not have a max wallet index or address index was not found in the database');
+          }
           continue;
         }
 

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -70,7 +70,7 @@ import {
 } from '../db';
 import getConfig from '../config';
 import logger from '../logger';
-import { invokeOnTxPushNotificationRequestedLambda, sendMessageSQS } from '../utils';
+import { invokeOnTxPushNotificationRequestedLambda } from '../utils';
 
 export const METADATA_DIFF_EVENT_TYPES = {
   IGNORE: 'IGNORE',
@@ -170,7 +170,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
   try {
     const fullNodeEvent = context.event as FullNodeEvent;
     const now = getUnixTimestamp();
-    const { NEW_TX_SQS, PUSH_NOTIFICATION_ENABLED } = getConfig();
+    const { PUSH_NOTIFICATION_ENABLED } = getConfig();
     const blockRewardLock = context.rewardMinBlocks;
 
     if (!blockRewardLock) {

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -42,6 +42,7 @@ import {
   validateAddressBalances,
   getWalletBalancesForTx,
   getFullnodeHttpUrl,
+  sendMessageSQS,
 } from '../utils';
 import {
   getDbConnection,
@@ -65,10 +66,9 @@ import {
   getTxOutputsFromTx,
   markUtxosAsVoided,
   cleanupVoidedTx,
-  getMaxIndexAmongAddresses,
-  getMaxWalletAddressIndex,
+  getMaxIndicesForWallets,
 } from '../db';
-import getConfig from '../config';
+import getConfig, { NEW_TX_SQS } from '../config';
 import logger from '../logger';
 import { invokeOnTxPushNotificationRequestedLambda } from '../utils';
 
@@ -162,10 +162,8 @@ export const isBlock = (version: number): boolean => version === hathorLib.const
       || version === hathorLib.constants.MERGED_MINED_BLOCK_VERSION;
 
 export const handleVertexAccepted = async (context: Context, _event: Event) => {
-  console.time('handleVertexAccepted');
   const mysql = await getDbConnection();
   await mysql.beginTransaction();
-  logger.info('Handling vertex accepted.');
 
   try {
     const fullNodeEvent = context.event as FullNodeEvent;
@@ -192,11 +190,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       parents,
     } = fullNodeEvent.event.data;
 
-    logger.info('Will get tx by id');
-    console.time('tx by id');
     const dbTx: DbTransaction | null = await getTransactionById(mysql, hash);
-    console.timeEnd('tx by id');
-    logger.info('done.');
 
     if (dbTx) {
       logger.error(`Transaction ${hash} already in the database, this should only happen if the service has been recently restarted`);
@@ -222,17 +216,11 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       }
 
       // unlock older blocks
-      logger.info('Will get utxos locked at height');
-      console.time('getUtxosLockedAtHeight');
       const utxos = await getUtxosLockedAtHeight(mysql, now, height);
-      console.timeEnd('getUtxosLockedAtHeight');
-      logger.info('got utxos locked at height');
 
       if (utxos.length > 0) {
         logger.debug(`Block transaction, unlocking ${utxos.length} locked utxos at height ${height}`);
-        console.time('unlockUtxos');
         await unlockUtxos(mysql, utxos, false);
-        console.timeEnd('unlockUtxos');
       }
 
       // set heightlock
@@ -243,9 +231,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
 
       // add miner to the miners table
       if (blockRewardOutput.decoded) {
-        console.time('addMiner');
         await addMiner(mysql, blockRewardOutput.decoded.address, hash);
-        console.timeEnd('addMiner');
       }
 
       // here we check if we have any utxos on our database that is locked but
@@ -256,34 +242,27 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       // (that will unlock it). This delay is only perceived on the wallet as the
       // sync mechanism will unlock the timelocked utxos as soon as they are seen
       // on a received transaction.
-      console.time('unlockTimelockedUtxos');
       await unlockTimelockedUtxos(mysql, now);
-      console.timeEnd('unlockTimelockedUtxos');
     }
 
     if (version === hathorLib.constants.CREATE_TOKEN_TX_VERSION) {
       if (!token_name || !token_symbol) {
         throw new Error('Processed a token creation event but it did not come with token name and symbol');
       }
-      console.time('storeTokenInformation');
       await storeTokenInformation(mysql, hash, token_name, token_symbol);
-      console.timeEnd('storeTokenInformation');
     }
 
     // check if any of the inputs are still marked as locked and update tables accordingly.
     // See remarks on getLockedUtxoFromInputs for more explanation. It's important to perform this
     // before updating the balances
     const lockedInputs = await getLockedUtxoFromInputs(mysql, inputs);
-    console.time('unlockUtxos');
     await unlockUtxos(mysql, lockedInputs, true);
-    console.timeEnd('unlockUtxos');
 
     // add transaction outputs to the tx_outputs table
     markLockedOutputs(txOutputs, now, heightlock !== null);
 
     // Add the transaction
     logger.debug('Will add the tx with height', height);
-    console.time('addOrUpdateTx');
     await addOrUpdateTx(
       mysql,
       hash,
@@ -292,35 +271,27 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       version,
       weight,
     );
-    console.timeEnd('addOrUpdateTx');
 
     // Add utxos
-    console.time('addUtxos');
     await addUtxos(mysql, hash, txOutputs, heightlock);
-    console.timeEnd('addUtxos');
-    console.time('updateTxOutputSpentBy');
+
+    // Mark tx utxos as spent
     await updateTxOutputSpentBy(mysql, txInputs, hash);
-    console.timeEnd('updateTxOutputSpentBy');
 
     // Genesis tx has no inputs and outputs, so nothing to be updated, avoid it
     if (inputs.length > 0 || outputs.length > 0) {
       const tokenList: string[] = getTokenListFromInputsAndOutputs(txInputs, txOutputs);
 
       // Update transaction count with the new tx
-      console.time('incrementTokensTxCount');
       await incrementTokensTxCount(mysql, tokenList);
-      console.timeEnd('incrementTokensTxCount');
 
       const addressBalanceMap: StringMap<TokenBalanceMap> = getAddressBalanceMap(txInputs, txOutputs);
 
       // update address tables (address, address_balance, address_tx_history)
-      console.time('updateAddressTablesWithTx');
       await updateAddressTablesWithTx(mysql, hash, timestamp, addressBalanceMap);
-      console.timeEnd('updateAddressTablesWithTx');
 
       // for the addresses present on the tx, check if there are any wallets associated
       const addressWalletMap: StringMap<Wallet> = await getAddressWalletInfo(mysql, Object.keys(addressBalanceMap));
-      console.log('address wallet map: ', addressWalletMap);
 
       const seenWallets = new Set();
       const addressesPerWallet = Object.entries(addressWalletMap).reduce(
@@ -344,23 +315,39 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
         return result;
       }, {});
 
-      for (const [walletId, data] of Object.entries(addressesPerWallet)) {
-        const { addresses, walletDetails } = data;
-        const maxIndexAmongAddresses = await getMaxIndexAmongAddresses(mysql, walletId, addresses);
-        const maxWalletAddressIndex = await getMaxWalletAddressIndex(mysql, walletId);
+      // Convert to array format expected by getMaxIndicesForWallets
+      const walletDataArray = Object.entries(addressesPerWallet).map(([walletId, data]) => ({
+        walletId,
+        addresses: data.addresses
+      }));
 
-        if (!maxIndexAmongAddresses || !maxWalletAddressIndex) {
-          // Do nothing, this is unexpected and an error should have been logged already.
+      // Get all max indices in a single query
+      const walletIndices = await getMaxIndicesForWallets(mysql, walletDataArray);
+
+      // Process each wallet
+      for (const [walletId, data] of Object.entries(addressesPerWallet)) {
+        const { walletDetails } = data;
+        const indices = walletIndices.get(walletId);
+
+        if (!indices) {
+          // This is unexpected as we just queried for this wallet
+          logger.error('Failed to get indices for wallet', { walletId });
           continue;
         }
 
-        const diff = maxWalletAddressIndex - maxIndexAmongAddresses;
+        const { maxAmongAddresses, maxWalletIndex } = indices;
+
+        if (!maxAmongAddresses || !maxWalletIndex) {
+          // Do nothing, this is unexpected and an error should have been logged already
+          continue;
+        }
+
+        const diff = maxWalletIndex - maxAmongAddresses;
 
         if (diff < walletDetails.maxGap) {
-          // We need to generate addresses.
-          const addresses = await generateAddresses(walletDetails.xpubkey, maxWalletAddressIndex + 1, walletDetails.maxGap);
-          // might need to generate new addresses to keep maxGap
-          await addNewAddresses(mysql, walletId, addresses, maxIndexAmongAddresses);
+          // We need to generate addresses
+          const addresses = await generateAddresses(walletDetails.xpubkey, maxWalletIndex + 1, walletDetails.maxGap);
+          await addNewAddresses(mysql, walletId, addresses, maxAmongAddresses);
         }
       }
 
@@ -368,14 +355,18 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       const walletBalanceMap: StringMap<TokenBalanceMap> = getWalletBalanceMap(addressWalletMap, addressBalanceMap);
       await updateWalletTablesWithTx(mysql, hash, timestamp, walletBalanceMap);
 
-      const tx: Transaction = {
+      // validate address balances
+      await validateAddressBalances(mysql, Object.keys(addressBalanceMap));
+
+      // prepare the transaction data to be sent to the SQS queue
+      const txData: Transaction = {
         tx_id: hash,
         nonce,
         timestamp,
+        version,
         voided: metadata.voided_by.length > 0,
         weight,
         parents,
-        version,
         inputs: txInputs,
         outputs: txOutputs,
         height: metadata.height,
@@ -384,7 +375,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
         signal_bits: 0, // TODO: we should actually receive this and store in the database
       };
 
-      /* try {
+      try {
         if (seenWallets.size > 0) {
           const queueUrl = NEW_TX_SQS;
           if (!queueUrl) {
@@ -393,17 +384,17 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
 
           await sendMessageSQS(JSON.stringify({
             wallets: Array.from(seenWallets),
-            tx,
+            txData,
           }), queueUrl);
         }
       } catch (e) {
         logger.error('Failed to send transaction to SQS queue');
         logger.error(e);
-      } */
+      }
 
       try {
         if (PUSH_NOTIFICATION_ENABLED) {
-          const walletBalanceMap = await getWalletBalancesForTx(mysql, tx);
+          const walletBalanceMap = await getWalletBalancesForTx(mysql, txData);
           const { length: hasAffectWallets } = Object.keys(walletBalanceMap);
           if (hasAffectWallets) {
             invokeOnTxPushNotificationRequestedLambda(walletBalanceMap)
@@ -423,10 +414,10 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       const network = new hathorLib.Network(NETWORK);
 
       // Validating for NFTs only after the tx is successfully added
-      if (NftUtils.shouldInvokeNftHandlerForTx(tx, network, logger)) {
+      if (NftUtils.shouldInvokeNftHandlerForTx(txData, network, logger)) {
         // This process is not critical, so we run it in a fire-and-forget manner, not waiting for the promise.
         // In case of errors, just log the asynchronous exception and take no action on it.
-        NftUtils.invokeNftHandlerLambda(tx.tx_id, STAGE, logger)
+        NftUtils.invokeNftHandlerLambda(txData.tx_id, STAGE, logger)
           .catch((err: unknown) => logger.error('[ALERT] Error on nftHandlerLambda invocation', err));
       }
     }
@@ -438,9 +429,17 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
     await mysql.rollback();
     logger.error(e);
 
+    if (e instanceof Error) {
+      logger.error('Error handling vertex accepted', {
+        error: e.message,
+        stack: e.stack,
+      });
+    } else {
+      logger.error('Error handling vertex accepted', { error: e });
+    }
+
     throw e;
   } finally {
-    console.timeEnd('handleVertexAccepted');
     mysql.destroy();
   }
 };

--- a/packages/daemon/src/types/db.ts
+++ b/packages/daemon/src/types/db.ts
@@ -142,5 +142,6 @@ export interface TokenSymbolsRow extends RowDataPacket {
 }
 
 export interface MaxAddressIndexRow extends RowDataPacket {
-  max_index: number;
+  max_among_addresses: number,
+  max_wallet_index: number
 }

--- a/packages/daemon/src/types/db.ts
+++ b/packages/daemon/src/types/db.ts
@@ -140,3 +140,7 @@ export interface TokenSymbolsRow extends RowDataPacket {
   id: string;
   symbol: string;
 }
+
+export interface MaxAddressIndexRow extends RowDataPacket {
+  max_index: number;
+}

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -40,6 +40,8 @@ import {
   updateWalletLockedBalance,
 } from '../db';
 import logger from '../logger';
+// @ts-ignore
+import { walletUtils } from '@hathor/wallet-lib';
 import { stringMapIterator } from './helpers';
 
 /**
@@ -507,3 +509,29 @@ export class WalletBalanceMapConverter {
     return walletBalanceValueMap;
   }
 }
+
+/**
+ * Generate a batch of addresses from a given xpubkey.
+ *
+ * @remarks
+ * This function generates addresses starting from a specific index.
+ *
+ * @param xpubkey - The extended public key to derive addresses from
+ * @param startIndex - The index to start generating addresses from
+ * @param count - How many addresses to generate
+ * @returns A map of addresses to their corresponding indices
+ */
+export const generateAddresses = async (
+  network: string,
+  xpubkey: string,
+  startIndex: number,
+  count: number,
+): Promise<StringMap<number>> => {
+  // We currently generate only addresses in change derivation path 0
+  // (more details in https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Change)
+  // so we derive our xpub to this path and use it to get the addresses
+  const derivedXpub = walletUtils.xpubDeriveChild(xpubkey, 0);
+  const addrMap = walletUtils.getAddresses(derivedXpub, startIndex, count, network);
+
+  return addrMap;
+};


### PR DESCRIPTION
## Motivation

We currently iterate through all address indices of a wallet when a new address needs to be generated, this is taking up to 20 seconds when the wallet has many addresses


## Acceptance Criteria
- We should add a new composite index on `(wallet_id, index)`, improving query performance
- All existing functionality should be maintained (address generation, gap limit)
- Tests should be passing and should cover the new implementation

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
