### PR TITLE
fix: Mainnet release script

### DIFF
--- a/.codebuild/build.sh
+++ b/.codebuild/build.sh
@@ -84,6 +84,8 @@ deploy_hathor_network_account() {
             unset ${var#testnet_}
         done
 
+        send_slack_message "New version deployed to testnet-production: ${GIT_REF_TO_DEPLOY}"
+
         # --- Mainnet ---
         # Gets all env vars with `mainnet_` prefix and re-exports them without the prefix
         for var in "${!mainnet_@}"; do
@@ -100,7 +102,7 @@ deploy_hathor_network_account() {
             unset ${var#mainnet_}
         done
 
-        send_slack_message "New version deployed to testnet-production and mainnet-production: ${GIT_REF_TO_DEPLOY}"
+        send_slack_message "New version deployed to mainnet-production: ${GIT_REF_TO_DEPLOY}"
     else
         # Gets all env vars with `dev_` prefix and re-exports them without the prefix
         for var in "${!dev_@}"; do

--- a/scripts/push-daemon.sh
+++ b/scripts/push-daemon.sh
@@ -1,6 +1,11 @@
 set -e
 set -o pipefail
 
+if [ -z "$ACCOUNT_ID" ]; then
+    echo "Please export a ACCOUNT_ID env var before running this";
+    exit 1;
+fi
+
 DOCKER_IMAGE_TAG=$(cat /tmp/docker_image_tag)
 
 if [ -z "$DOCKER_IMAGE_TAG" ]; then


### PR DESCRIPTION
### Motivation

We were getting an error during the CI/CD flow:

```
bash scripts/build-daemon.sh
Please export a ACCOUNT_ID env var before running this
make: *** [Makefile:7: build-daemon] Error 1
```

### Acceptance Criteria

- The env vars should be exported when running `make build-daemon` in the deploy script.

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
