### PR TITLE
refactor: increase network size to 32 characters in the database

### DIFF
--- a/db/migrations/20250110194443-increase-network-size.js
+++ b/db/migrations/20250110194443-increase-network-size.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('version_data', 'network', {
+      type: Sequelize.STRING(32),
+      allowNull: false,
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('version_data', 'network', {
+      type: Sequelize.STRING(8),
+      allowNull: false,
+    });
+  }
+};


### PR DESCRIPTION
### Motivation

We store in the wallet-service the data from the fullnode's `/v1a/version` API in a `version_data` table.

This is done lazily when wallets request the `/version` API, it detects that the data it has in the database expired and requests again.

We noticed that the `network` field was being stored truncated, e.g.:

`testnet-`
`nano-tes`

Upon investigation, we found out that the `version_data` table had too few characters in its definition for the `network` column:

```
...
      version: {
        type: Sequelize.STRING(11),
        allowNull: false,
      },
      network: {
        type: Sequelize.STRING(8),
        allowNull: false,
      },
      min_weight: {
        type: Sequelize.FLOAT.UNSIGNED,
        allowNull: false,
      },
...
```

Which was causing it to truncate text when inserting.

### Acceptance Criteria

- We should increase the size of the `network` column.

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
