### PR TITLE
feat: handling REORG_STARTED event plus tests

### DIFF
--- a/packages/daemon/__tests__/guards/guards.test.ts
+++ b/packages/daemon/__tests__/guards/guards.test.ts
@@ -12,6 +12,7 @@ import {
   voided,
   unchanged,
   invalidNetwork,
+  reorgStarted,
 } from '../../src/guards';
 import { EventTypes } from '../../src/types';
 
@@ -170,6 +171,14 @@ describe('fullnode event guards', () => {
 
     // Any event other than FULLNODE_EVENT should return false
     expect(() => unchanged(mockContext, generateMetadataDecidedEvent('TX_NEW'))).toThrow('Invalid event type on unchanged guard: METADATA_DECIDED');
+  });
+
+  test('reorgStarted', () => {
+    expect(reorgStarted(mockContext, generateFullNodeEvent(FullNodeEventTypes.REORG_STARTED))).toBe(true);
+    expect(reorgStarted(mockContext, generateFullNodeEvent(FullNodeEventTypes.VERTEX_METADATA_CHANGED))).toBe(false);
+
+    // Any event other than FULLNODE_EVENT should throw
+    expect(() => reorgStarted(mockContext, generateMetadataDecidedEvent('TX_NEW'))).toThrow('Invalid event type on reorgStarted guard: METADATA_DECIDED');
   });
 });
 

--- a/packages/daemon/__tests__/machines/SyncMachine.test.ts
+++ b/packages/daemon/__tests__/machines/SyncMachine.test.ts
@@ -519,7 +519,7 @@ describe('Event handling', () => {
     expect(currentState.matches(`${SYNC_MACHINE_STATES.CONNECTED}.${CONNECTED_STATES.handlingUnhandledEvent}`)).toBeTruthy();
   });
 
-  it('should ignore REORG_STARTED event but still send ack', () => {
+  it('should handle REORG_STARTED event', () => {
     const MockedFetchMachine = SyncMachine.withConfig({
       guards: {
         invalidPeerId: () => false,
@@ -535,6 +535,6 @@ describe('Event handling', () => {
       event: REORG_STARTED as unknown as FullNodeEvent,
     });
 
-    expect(currentState.matches(`${SYNC_MACHINE_STATES.CONNECTED}.${CONNECTED_STATES.handlingUnhandledEvent}`)).toBeTruthy();
+    expect(currentState.matches(`${SYNC_MACHINE_STATES.CONNECTED}.${CONNECTED_STATES.handlingReorgStarted}`)).toBeTruthy();
   });
 });

--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -47,6 +47,7 @@ import getConfig from '../../src/config';
 import { addAlert } from '@wallet-service/common';
 import { Severity } from '@wallet-service/common';
 import { FullNodeEventTypes } from '../../src/types';
+import { EventTypes } from '../../src/types';
 
 jest.mock('../../src/config', () => {
   return {
@@ -118,6 +119,10 @@ jest.mock('@wallet-service/common', () => ({
   addAlert: jest.fn(),
   Severity: {
     MAJOR: 'MAJOR',
+  },
+  NftUtils: {
+    shouldInvokeNftHandlerForTx: jest.fn().mockReturnValue(false),
+    invokeNftHandlerLambda: jest.fn(),
   },
 }));
 
@@ -863,21 +868,22 @@ describe('handleReorgStarted', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (getConfig as jest.Mock).mockReturnValue({
+      MAX_REORG_SIZE: 3,
+    });
   });
 
   it('should handle reorg started event and add alert when reorg size exceeds max', async () => {
     const mockContext = createMockContext({
+      type: EventTypes.FULLNODE_EVENT,
       event: {
-        type: 'FULLNODE_EVENT',
-        event: {
-          type: FullNodeEventTypes.REORG_STARTED,
-          id: 123,
-          data: {
-            reorg_size: 5,
-            previous_best_block: 'prev123',
-            new_best_block: 'new456',
-            common_block: 'common789',
-          },
+        type: FullNodeEventTypes.REORG_STARTED,
+        id: 123,
+        data: {
+          reorg_size: 5,
+          previous_best_block: 'prev123',
+          new_best_block: 'new456',
+          common_block: 'common789',
         },
       },
     });
@@ -900,17 +906,15 @@ describe('handleReorgStarted', () => {
 
   it('should not add alert when reorg size is within limits', async () => {
     const mockContext = createMockContext({
+      type: EventTypes.FULLNODE_EVENT,
       event: {
-        type: 'FULLNODE_EVENT',
-        event: {
-          type: FullNodeEventTypes.REORG_STARTED,
-          id: 123,
-          data: {
-            reorg_size: 2,
-            previous_best_block: 'prev123',
-            new_best_block: 'new456',
-            common_block: 'common789',
-          },
+        type: FullNodeEventTypes.REORG_STARTED,
+        id: 123,
+        data: {
+          reorg_size: 2,
+          previous_best_block: 'prev123',
+          new_best_block: 'new456',
+          common_block: 'common789',
         },
       },
     });
@@ -928,13 +932,11 @@ describe('handleReorgStarted', () => {
 
   it('should throw error when event type is incorrect', async () => {
     const mockContext = createMockContext({
+      type: EventTypes.FULLNODE_EVENT,
       event: {
-        type: 'FULLNODE_EVENT',
-        event: {
-          type: FullNodeEventTypes.VERTEX_METADATA_CHANGED,
-          id: 123,
-          data: {},
-        },
+        type: FullNodeEventTypes.VERTEX_METADATA_CHANGED,
+        id: 123,
+        data: {},
       },
     });
 

--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -48,24 +48,6 @@ import { FullNodeEventTypes } from '../../src/types';
 import { Context } from '../../src/types';
 import { generateFullNodeEvent } from '../utils';
 
-jest.mock('../../src/config', () => {
-  return {
-    __esModule: true, // This property is needed for mocking a default export
-    default: jest.fn(() => ({
-      REORG_SIZE_INFO: 1,
-      REORG_SIZE_MINOR: 3,
-      REORG_SIZE_MAJOR: 5,
-      REORG_SIZE_CRITICAL: 10,
-    })),
-    getConfig: jest.fn(() => ({
-      REORG_SIZE_INFO: 1,
-      REORG_SIZE_MINOR: 3,
-      REORG_SIZE_MAJOR: 5,
-      REORG_SIZE_CRITICAL: 10,
-    })),
-  };
-});
-
 jest.mock('@hathor/wallet-lib');
 jest.mock('../../src/logger', () => ({
   debug: jest.fn(),
@@ -139,6 +121,24 @@ jest.mock('@wallet-service/common', () => {
       shouldInvokeNftHandlerForTx: jest.fn().mockReturnValue(false),
       invokeNftHandlerLambda: jest.fn(),
     },
+  };
+});
+
+jest.mock('../../src/config', () => {
+  return {
+    __esModule: true, // This property is needed for mocking a default export
+    default: jest.fn(() => ({
+      REORG_SIZE_INFO: 1,
+      REORG_SIZE_MINOR: 3,
+      REORG_SIZE_MAJOR: 5,
+      REORG_SIZE_CRITICAL: 10,
+    })),
+    getConfig: jest.fn(() => ({
+      REORG_SIZE_INFO: 1,
+      REORG_SIZE_MINOR: 3,
+      REORG_SIZE_MAJOR: 5,
+      REORG_SIZE_CRITICAL: 10,
+    })),
   };
 });
 
@@ -874,6 +874,15 @@ describe('metadataDiff', () => {
 
 describe('handleReorgStarted', () => {
   beforeEach(() => {
+    (getConfig as jest.Mock).mockReturnValue({
+      REORG_SIZE_INFO: 1,
+      REORG_SIZE_MINOR: 3,
+      REORG_SIZE_MAJOR: 5,
+      REORG_SIZE_CRITICAL: 10,
+    });
+  });
+
+  afterEach(() => {
     jest.clearAllMocks();
   });
 
@@ -919,11 +928,9 @@ describe('handleReorgStarted', () => {
     // @ts-ignore
     await handleReorgStarted({ event } as Context);
 
-    console.log('ADD ALERT:', addAlert);
-
     expect(addAlert).toHaveBeenCalledWith(
       'Minor Reorg Detected',
-      'A minor blockchain reorg of size 3 has occurred.',
+      'A minor reorg of size 3 has occurred.',
       Severity.MINOR,
       {
         reorg_size: 3,

--- a/packages/daemon/__tests__/utils.ts
+++ b/packages/daemon/__tests__/utils.ts
@@ -27,6 +27,7 @@ import {
   TransactionTableEntry
 } from './types';
 import { isEqual } from 'lodash';
+import { EventTypes } from '../src/types';
 
 export const XPUBKEY = 'xpub6CsZPtBWMkwxVxyBTKT8AWZcYqzwZ5K2qMkqjFpibMbBZ72JAvLMz7LquJNs4svfTiNYy6GbLo8gqECWsC6hTRt7imnphUFNEMz6VuRSjww';
 export const ADDRESSES = [
@@ -775,3 +776,16 @@ export const addToAddressTxHistoryTable = async (
     VALUES ?`,
   [payload]);
 };
+
+export const generateFullNodeEvent = (event: any) => ({
+  type: EventTypes.FULLNODE_EVENT,
+  event: {
+    peer_id: 'peer123',
+    stream_id: 'stream456',
+    network: 'mainnet',
+    id: 123,
+    timestamp: Date.now(),
+    type: event.type,
+    data: event.data,
+  },
+});

--- a/packages/daemon/src/actions/index.ts
+++ b/packages/daemon/src/actions/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { assign, AssignAction, raise, sendTo } from 'xstate';
-import { Context, Event, EventTypes } from '../types';
+import { Context, Event, EventTypes, StandardFullNodeEvent } from '../types';
 import { get } from 'lodash';
 import logger from '../logger';
 import { hashTxData } from '../utils';
@@ -164,7 +164,7 @@ export const metadataDecided = raise((_context: Context, event: Event) => ({
  * Updates the cache with the last processed event (from the context)
  */
 export const updateCache = (context: Context) => {
-  const fullNodeEvent = context.event;
+  const fullNodeEvent = context.event as StandardFullNodeEvent;
   if (!fullNodeEvent) {
     return;
   }

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -43,8 +43,6 @@ export const CONSOLE_LEVEL = process.env.CONSOLE_LEVEL ?? 'debug';
 export const TX_CACHE_SIZE = parseInt(process.env.TX_CACHE_SIZE ?? '10000', 10);
 // Number of blocks before unlocking a block utxo
 export const BLOCK_REWARD_LOCK = parseInt(process.env.BLOCK_REWARD_LOCK ?? '10', 10);
-// Maximum size of a reorg before triggering an alert
-export const MAX_REORG_SIZE = parseInt(process.env.MAX_REORG_SIZE ?? '3', 10);
 export const STAGE = process.env.STAGE ?? 'local';
 
 // Fullnode information, used to make sure we're connected to the same fullnode
@@ -123,7 +121,6 @@ export default () => ({
   HEALTHCHECK_SERVER_URL,
   HEALTHCHECK_SERVER_API_KEY,
   HEALTHCHECK_PING_INTERVAL,
-  MAX_REORG_SIZE,
   REORG_SIZE_INFO,
   REORG_SIZE_MINOR,
   REORG_SIZE_MAJOR,

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -43,6 +43,8 @@ export const CONSOLE_LEVEL = process.env.CONSOLE_LEVEL ?? 'debug';
 export const TX_CACHE_SIZE = parseInt(process.env.TX_CACHE_SIZE ?? '10000', 10);
 // Number of blocks before unlocking a block utxo
 export const BLOCK_REWARD_LOCK = parseInt(process.env.BLOCK_REWARD_LOCK ?? '10', 10);
+// Maximum size of a reorg before triggering an alert
+export const MAX_REORG_SIZE = parseInt(process.env.MAX_REORG_SIZE ?? '3', 10);
 export const STAGE = process.env.STAGE ?? 'local';
 
 // Fullnode information, used to make sure we're connected to the same fullnode
@@ -115,4 +117,5 @@ export default () => ({
   HEALTHCHECK_SERVER_URL,
   HEALTHCHECK_SERVER_API_KEY,
   HEALTHCHECK_PING_INTERVAL,
+  MAX_REORG_SIZE,
 });

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -88,6 +88,12 @@ export const HEALTHCHECK_PING_INTERVAL = parseInt(process.env.HEALTHCHECK_PING_I
 // Other
 export const USE_SSL = process.env.USE_SSL;
 
+// Reorg size thresholds for different alert levels
+export const REORG_SIZE_INFO = parseInt(process.env.REORG_SIZE_INFO ?? '1', 10);
+export const REORG_SIZE_MINOR = parseInt(process.env.REORG_SIZE_MINOR ?? '5', 10);
+export const REORG_SIZE_MAJOR = parseInt(process.env.REORG_SIZE_MAJOR ?? '10', 10);
+export const REORG_SIZE_CRITICAL = parseInt(process.env.REORG_SIZE_CRITICAL ?? '10', 10);
+
 export default () => ({
   SERVICE_NAME,
   CONSOLE_LEVEL,
@@ -118,4 +124,8 @@ export default () => ({
   HEALTHCHECK_SERVER_API_KEY,
   HEALTHCHECK_PING_INTERVAL,
   MAX_REORG_SIZE,
+  REORG_SIZE_INFO,
+  REORG_SIZE_MINOR,
+  REORG_SIZE_MAJOR,
+  REORG_SIZE_CRITICAL,
 });

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -88,8 +88,8 @@ export const USE_SSL = process.env.USE_SSL;
 
 // Reorg size thresholds for different alert levels
 export const REORG_SIZE_INFO = parseInt(process.env.REORG_SIZE_INFO ?? '1', 10);
-export const REORG_SIZE_MINOR = parseInt(process.env.REORG_SIZE_MINOR ?? '5', 10);
-export const REORG_SIZE_MAJOR = parseInt(process.env.REORG_SIZE_MAJOR ?? '10', 10);
+export const REORG_SIZE_MINOR = parseInt(process.env.REORG_SIZE_MINOR ?? '3', 10);
+export const REORG_SIZE_MAJOR = parseInt(process.env.REORG_SIZE_MAJOR ?? '5', 10);
 export const REORG_SIZE_CRITICAL = parseInt(process.env.REORG_SIZE_CRITICAL ?? '10', 10);
 
 export default () => ({

--- a/packages/daemon/src/guards/index.ts
+++ b/packages/daemon/src/guards/index.ts
@@ -237,3 +237,14 @@ export const unchanged = (context: Context, event: Event) => {
 
   return txHashFromCache === txHashFromEvent;
 };
+
+/*
+ * This guard is used to detect if the event is a REORG_STARTED event
+ */
+export const reorgStarted = (_context: Context, event: Event) => {
+  if (event.type !== EventTypes.FULLNODE_EVENT) {
+    throw new Error(`Invalid event type on reorgStarted guard: ${event.type}`);
+  }
+
+  return event.event.event.type === FullNodeEventTypes.REORG_STARTED;
+};

--- a/packages/daemon/src/machines/SyncMachine.ts
+++ b/packages/daemon/src/machines/SyncMachine.ts
@@ -41,6 +41,7 @@ import {
   voided,
   unchanged,
   vertexRemoved,
+  reorgStarted,
 } from '../guards';
 import {
   storeInitialState,
@@ -81,7 +82,7 @@ export const CONNECTED_STATES = {
 
 const { TX_CACHE_SIZE } = getConfig();
 
-const SyncMachine = Machine<Context, any, Event>({
+export const SyncMachine = Machine<Context, any, Event>({
   id: 'SyncMachine',
   initial: SYNC_MACHINE_STATES.INITIALIZING,
   context: {
@@ -300,10 +301,17 @@ const SyncMachine = Machine<Context, any, Event>({
     },
   },
 }, {
+  services: {
+    fetchInitialState,
+    handleVertexAccepted,
+    handleVertexRemoved,
+    metadataDiff,
+    handleVoidedTx,
+    handleTxFirstBlock,
+    updateLastSyncedEvent,
+    handleUnvoidedTx,
+  },
   guards: {
-    invalidStreamId,
-    invalidPeerId,
-    invalidNetwork,
     metadataIgnore,
     metadataVoided,
     metadataUnvoided,
@@ -311,10 +319,14 @@ const SyncMachine = Machine<Context, any, Event>({
     metadataFirstBlock,
     metadataChanged,
     vertexAccepted,
+    invalidPeerId,
+    invalidStreamId,
+    invalidNetwork,
     websocketDisconnected,
     voided,
     unchanged,
     vertexRemoved,
+    reorgStarted,
   },
   delays: { BACKOFF_DELAYED_RECONNECT },
   actions: {
@@ -330,16 +342,6 @@ const SyncMachine = Machine<Context, any, Event>({
     updateCache,
     startHealthcheckPing,
     stopHealthcheckPing,
-  },
-  services: {
-    handleVoidedTx,
-    handleUnvoidedTx,
-    handleVertexAccepted,
-    handleVertexRemoved,
-    handleTxFirstBlock,
-    metadataDiff,
-    updateLastSyncedEvent,
-    fetchInitialState,
   },
 });
 

--- a/packages/daemon/src/machines/SyncMachine.ts
+++ b/packages/daemon/src/machines/SyncMachine.ts
@@ -25,6 +25,7 @@ import {
   updateLastSyncedEvent,
   fetchInitialState,
   handleUnvoidedTx,
+  handleReorgStarted,
 } from '../services';
 import {
   metadataIgnore,
@@ -302,14 +303,15 @@ export const SyncMachine = Machine<Context, any, Event>({
   },
 }, {
   services: {
-    fetchInitialState,
     handleVertexAccepted,
     handleVertexRemoved,
-    metadataDiff,
     handleVoidedTx,
     handleTxFirstBlock,
-    updateLastSyncedEvent,
     handleUnvoidedTx,
+    handleReorgStarted,
+    fetchInitialState,
+    metadataDiff,
+    updateLastSyncedEvent,
   },
   guards: {
     metadataIgnore,

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -686,14 +686,7 @@ export const handleReorgStarted = async (context: Context): Promise<void> => {
     common_block,
   };
 
-  console.log(reorg_size, {
-    REORG_SIZE_CRITICAL,
-    REORG_SIZE_INFO,
-    REORG_SIZE_MAJOR,
-    REORG_SIZE_MINOR,
-  });
-
-  if (reorg_size > REORG_SIZE_CRITICAL) {
+  if (reorg_size >= REORG_SIZE_CRITICAL) {
     await addAlert(
       'Critical Reorg Detected',
       `A critical reorg of size ${reorg_size} has occurred.`,
@@ -701,7 +694,7 @@ export const handleReorgStarted = async (context: Context): Promise<void> => {
       metadata,
       logger,
     );
-  } else if (reorg_size > REORG_SIZE_MAJOR) {
+  } else if (reorg_size >= REORG_SIZE_MAJOR) {
     await addAlert(
       'Major Reorg Detected',
       `A major reorg of size ${reorg_size} has occurred.`,
@@ -709,7 +702,7 @@ export const handleReorgStarted = async (context: Context): Promise<void> => {
       metadata,
       logger,
     );
-  } else if (reorg_size > REORG_SIZE_MINOR) {
+  } else if (reorg_size >= REORG_SIZE_MINOR) {
     await addAlert(
       'Minor Reorg Detected',
       `A minor reorg of size ${reorg_size} has occurred.`,

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -60,16 +60,19 @@ export interface VertexRemovedEventData {
   vertex_id: string;
 }
 
-export type FullNodeEvent = {
+export type FullNodeEventBase = {
   stream_id: string;
   peer_id: string;
   network: string;
   type: string;
   latest_event_id: number;
+};
+
+export type StandardFullNodeEvent = FullNodeEventBase & {
   event: {
     id: number;
     timestamp: number;
-    type: FullNodeEventTypes;
+    type: Exclude<FullNodeEventTypes, "REORG_STARTED">; // All types except "REORG_STARTED"
     data: {
       hash: string;
       timestamp: number;
@@ -89,9 +92,26 @@ export type FullNodeEvent = {
         first_block: null | string;
         height: number;
       };
-    }
-  }
-}
+    };
+  };
+};
+
+export type ReorgFullNodeEvent = FullNodeEventBase & {
+  event: {
+    id: number;
+    timestamp: number;
+    type: "REORG_STARTED";
+    data: {
+      reorg_size: number;
+      previous_best_block: string;
+      new_best_block: string;
+      common_block: string;
+    };
+    group_id: number;
+  };
+};
+
+export type FullNodeEvent = StandardFullNodeEvent | ReorgFullNodeEvent;
 
 export interface EventTxInput {
   tx_id: string;


### PR DESCRIPTION
### Motivation

During the wallet-service refactor, we lost the reorg size alert, this PR should add it back

### Acceptance Criteria

- We should have different alert severities depending on the reorg size
- We should include tests for all alarm sizes

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
