### PR TITLE
fix: invalid parameter being sent to sendMessageSQS

### DIFF
--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -388,7 +388,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
 
           await sendMessageSQS(JSON.stringify({
             wallets: Array.from(seenWallets),
-            txData,
+            tx: txData,
           }), queueUrl);
         }
       } catch (e) {

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -170,7 +170,6 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
     NETWORK,
     STAGE,
     PUSH_NOTIFICATION_ENABLED,
-    NEW_TX_SQS,
   } = getConfig();
 
   try {

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -45,6 +45,7 @@ import {
   getFullnodeHttpUrl,
   sendMessageSQS,
   generateAddresses,
+  sendRealtimeTx,
 } from '../utils';
 import {
   getDbConnection,
@@ -381,15 +382,10 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
 
       try {
         if (seenWallets.length > 0) {
-          const queueUrl = NEW_TX_SQS;
-          if (!queueUrl) {
-            throw new Error('Queue URL is invalid');
-          }
-
-          await sendMessageSQS(JSON.stringify({
-            wallets: Array.from(seenWallets),
-            tx: txData,
-          }), queueUrl);
+          await sendRealtimeTx(
+            Array.from(seenWallets),
+            txData,
+          );
         }
       } catch (e) {
         logger.error('Failed to send transaction to SQS queue');

--- a/packages/daemon/src/utils/aws.ts
+++ b/packages/daemon/src/utils/aws.ts
@@ -56,6 +56,12 @@ export const invokeOnTxPushNotificationRequestedLambda = async (walletBalanceVal
   }
 }
 
+/**
+ * Sends a message to the real-time wallet-service SQS queue.
+ *
+ * @param wallets - A list of wallets to notify
+ * @param tx - The transaction details to send to the clients
+ */
 export const sendRealtimeTx = async (wallets: string[], tx: Transaction): Promise<void> => {
   const { NEW_TX_SQS } = getConfig();
 

--- a/packages/daemon/src/utils/aws.ts
+++ b/packages/daemon/src/utils/aws.ts
@@ -4,7 +4,7 @@ import { SendMessageCommand, SendMessageCommandOutput, SQSClient, MessageAttribu
 import { StringMap } from '../types';
 import getConfig from '../config';
 import logger from '../logger';
-import { addAlert } from '@wallet-service/common';
+import { addAlert, Transaction } from '@wallet-service/common';
 
 export function buildFunctionName(functionName: string): string {
   const { STAGE } = getConfig();
@@ -54,6 +54,19 @@ export const invokeOnTxPushNotificationRequestedLambda = async (walletBalanceVal
     );
     throw new Error(`${ON_TX_PUSH_NOTIFICATION_REQUESTED_FUNCTION_NAME} lambda invoke failed for wallets: ${walletIdList}`);
   }
+}
+
+export const sendRealtimeTx = async (wallets: string[], tx: Transaction): Promise<void> => {
+  const { NEW_TX_SQS } = getConfig();
+
+  if (!NEW_TX_SQS) {
+    throw new Error('Queue URL is invalid');
+  }
+
+  await sendMessageSQS(JSON.stringify({
+    wallets,
+    tx,
+  }), NEW_TX_SQS);
 }
 
 /**


### PR DESCRIPTION
### Motivation

We changed the format of the object being sent to the real-time transaction SQS queue by mistake in https://github.com/HathorNetwork/hathor-wallet-service/pull/199, causing validation to fail on every new transaction sent to the queue.

### Acceptance Criteria

- We should fix the message format
- We should include a helper method to send realtime transactions so we have types for the parameters

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
