### PR TITLE
fix: NFTs were not being properly processed

### DIFF
--- a/packages/common/__tests__/utils/nft.utils.test.ts
+++ b/packages/common/__tests__/utils/nft.utils.test.ts
@@ -764,25 +764,17 @@ describe('processNftEvent', () => {
     // Disable NFT auto review
     process.env.NFT_AUTO_REVIEW_ENABLED = 'false';
 
-    // Real event data from production (simplified)
-    const eventData = {
-      hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
-      version: 2,
-      inputs: [{ tx_id: "tx1", index: 0, spent_output: { value: 1, token_data: 0, script: "s" } }],
-      outputs: [{ value: 1, token_data: 0, script: "s" }],
-      tokens: ["token1"],
-      token_name: "Test",
-      token_symbol: "TST",
-    };
+    // Use the real event data constant
+    const eventData = { ...REAL_NFT_EVENT_DATA };
 
     // Mock network
     const mockNetwork = { name: 'testnet' };
-
+    
     // Call the method
     const result = await NftUtils.processNftEvent(
-      eventData,
-      'test-stage',
-      mockNetwork as any,
+      eventData, 
+      'test-stage', 
+      mockNetwork as any, 
       logger
     );
 
@@ -791,7 +783,7 @@ describe('processNftEvent', () => {
 
     // Verify shouldInvokeNftHandlerForTx was NOT called
     expect(shouldInvokeSpy).not.toHaveBeenCalled();
-
+    
     // Verify the lambda was NOT invoked
     expect(invokeNftLambdaSpy).not.toHaveBeenCalled();
   });
@@ -802,25 +794,17 @@ describe('processNftEvent', () => {
     // Make shouldInvokeNftHandlerForTx return false
     shouldInvokeSpy.mockReturnValue(false);
 
-    // Simplified event data
-    const eventData = {
-      hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
-      version: 2,
-      inputs: [{ tx_id: "tx1", index: 0, spent_output: { value: 1, token_data: 0, script: "s" } }],
-      outputs: [{ value: 1, token_data: 0, script: "s" }],
-      tokens: ["token1"],
-      token_name: "Test",
-      token_symbol: "TST",
-    };
+    // Use the real event data constant
+    const eventData = { ...REAL_NFT_EVENT_DATA };
 
     // Mock network
     const mockNetwork = { name: 'testnet' };
-
+    
     // Call the method
     const result = await NftUtils.processNftEvent(
-      eventData,
-      'test-stage',
-      mockNetwork as any,
+      eventData, 
+      'test-stage', 
+      mockNetwork as any, 
       logger
     );
 
@@ -829,7 +813,7 @@ describe('processNftEvent', () => {
 
     // Verify shouldInvokeNftHandlerForTx was called
     expect(shouldInvokeSpy).toHaveBeenCalledTimes(1);
-
+    
     // Verify the lambda was NOT invoked
     expect(invokeNftLambdaSpy).not.toHaveBeenCalled();
   });
@@ -840,25 +824,17 @@ describe('processNftEvent', () => {
     // Make invokeNftHandlerLambda throw an error
     invokeNftLambdaSpy.mockRejectedValue(new Error('Lambda invocation failed'));
 
-    // Simplified event data
-    const eventData = {
-      hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
-      version: 2,
-      inputs: [{ tx_id: "tx1", index: 0, spent_output: { value: 1, token_data: 0, script: "s" } }],
-      outputs: [{ value: 1, token_data: 0, script: "s" }],
-      tokens: ["token1"],
-      token_name: "Test",
-      token_symbol: "TST",
-    };
+    // Use the real event data constant
+    const eventData = { ...REAL_NFT_EVENT_DATA };
 
     // Mock network
     const mockNetwork = { name: 'testnet' };
-
+    
     // Call the method - it should not throw
     const result = await NftUtils.processNftEvent(
-      eventData,
-      'test-stage',
-      mockNetwork as any,
+      eventData, 
+      'test-stage', 
+      mockNetwork as any, 
       logger
     );
 
@@ -867,10 +843,10 @@ describe('processNftEvent', () => {
 
     // Verify shouldInvokeNftHandlerForTx was called
     expect(shouldInvokeSpy).toHaveBeenCalledTimes(1);
-
+    
     // Verify the lambda was invoked
     expect(invokeNftLambdaSpy).toHaveBeenCalledTimes(1);
-
+    
     // Verify error was logged
     expect(logger.error).toHaveBeenCalled();
   });

--- a/packages/common/__tests__/utils/nft.utils.test.ts
+++ b/packages/common/__tests__/utils/nft.utils.test.ts
@@ -558,7 +558,7 @@ describe('transaction transformation compatibility', () => {
 
       // Test that the transformed transaction is valid for NFT handling
       const network = { name: 'testnet' };
-      const result = NftUtils.shouldInvokeNftHandlerForTx(txFromEvent, network as any, logger);
+      const result = NftUtils.shouldInvokeNftHandlerForTx(txFromEvent, network as unknown as hathorLib.Network, logger);
       expect(result).toBe(true);
       expect(isNftTransactionSpy).toHaveBeenCalledTimes(1);
     } finally {
@@ -607,7 +607,7 @@ describe('transaction transformation compatibility', () => {
 
       // Test that this transaction is detected as an NFT
       expect(isNftTransactionSpy).toHaveBeenCalledTimes(0);
-      const shouldInvoke = NftUtils.shouldInvokeNftHandlerForTx(txFromEvent, mockNetwork as any, logger);
+      const shouldInvoke = NftUtils.shouldInvokeNftHandlerForTx(txFromEvent, mockNetwork as unknown as hathorLib.Network, logger);
       expect(shouldInvoke).toBe(true);
       expect(isNftTransactionSpy).toHaveBeenCalledTimes(1);
     } finally {
@@ -723,7 +723,7 @@ describe('processNftEvent', () => {
     const result = await NftUtils.processNftEvent(
       eventData,
       'test-stage',
-      mockNetwork as any,
+      mockNetwork as unknown as hathorLib.Network,
       logger
     );
 
@@ -767,7 +767,7 @@ describe('processNftEvent', () => {
     const result = await NftUtils.processNftEvent(
       eventData,
       'test-stage',
-      mockNetwork as any,
+      mockNetwork as unknown as hathorLib.Network,
       logger
     );
 
@@ -786,7 +786,7 @@ describe('processNftEvent', () => {
     const result = await NftUtils.processNftEvent(
       eventData,
       'test-stage',
-      mockNetwork as any,
+      mockNetwork as unknown as hathorLib.Network,
       logger
     );
 
@@ -811,7 +811,7 @@ describe('processNftEvent', () => {
     const result = await NftUtils.processNftEvent(
       eventData,
       'test-stage',
-      mockNetwork as any,
+      mockNetwork as unknown as hathorLib.Network,
       logger
     );
 
@@ -851,7 +851,7 @@ describe('processNftEvent', () => {
       const result = await NftUtils.processNftEvent(
         eventData,
         'test-stage',
-        mockNetwork as any,
+        mockNetwork as unknown as hathorLib.Network,
         logger
       );
 
@@ -937,7 +937,7 @@ it('should perform full NFT processing with real event data and no mocks', async
       const result = await NftUtils.processNftEvent(
         eventData,
         'test-stage',
-        mockNetwork as any,
+        mockNetwork as unknown as hathorLib.Network,
         logger
       );
 

--- a/packages/common/__tests__/utils/nft.utils.test.ts
+++ b/packages/common/__tests__/utils/nft.utils.test.ts
@@ -7,8 +7,12 @@ import { getHandlerContext, getTransaction } from '../events/nftCreationTx';
 import {
   LambdaClient as LambdaClientMock,
   InvokeCommandOutput,
+  InvokeCommand,
 } from '@aws-sdk/client-lambda';
 import { Logger } from 'winston';
+import { helpersUtils } from '@hathor/wallet-lib';
+import { CreateTokenTransaction } from '@hathor/wallet-lib';
+import { constants } from '@hathor/wallet-lib';
 
 jest.mock('winston', () => {
   class FakeLogger {
@@ -271,10 +275,31 @@ describe('_updateMetadata', () => {
 });
 
 describe('invokeNftHandlerLambda', () => {
-  it('should return the lambda response on success', async () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    const mLambdaClient = new LambdaClientMock({});
+    (mLambdaClient.send as jest.Mocked<any>).mockReset();
+    
+    // Set up required environment variables
+    process.env = {
+      ...originalEnv,
+      NFT_AUTO_REVIEW_ENABLED: 'true',
+      WALLET_SERVICE_LAMBDA_ENDPOINT: 'http://localhost:3000',
+      AWS_REGION: 'us-east-1'
+    };
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = originalEnv;
+  });
+
+  it('should successfully invoke the lambda handler', async () => {
     expect.hasAssertions();
 
-    // Building the mock lambda
+    // Mock successful lambda response
     const expectedLambdaResponse: InvokeCommandOutput = {
       StatusCode: 202,
       $metadata: {}
@@ -282,30 +307,78 @@ describe('invokeNftHandlerLambda', () => {
     const mLambdaClient = new LambdaClientMock({});
     (mLambdaClient.send as jest.Mocked<any>).mockImplementationOnce(async () => expectedLambdaResponse);
 
-    await expect(NftUtils.invokeNftHandlerLambda('sampleUid', 'local', logger)).resolves.toBeUndefined();
+    const result = await NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', logger);
+
+    // Method should return void
+    expect(result).toBeUndefined();
+
+    // Verify Lambda client was constructed correctly
+    expect(LambdaClientMock).toHaveBeenCalledWith({
+      endpoint: process.env.WALLET_SERVICE_LAMBDA_ENDPOINT,
+      region: process.env.AWS_REGION,
+    });
+
+    // Verify the lambda was invoked with correct parameters
+    expect(mLambdaClient.send).toHaveBeenCalledTimes(1);
+    const invokeCommand = new InvokeCommand({
+      FunctionName: 'hathor-wallet-service-local-onNewNftEvent',
+      InvocationType: 'Event',
+      Payload: JSON.stringify({ nftUid: 'test-tx-id' }),
+    });
+    expect(mLambdaClient.send).toHaveBeenCalledWith(invokeCommand);
   });
 
-  it('should throw when payload response status is invalid', async () => {
+  it('should throw error and add alert when lambda invocation fails', async () => {
     expect.hasAssertions();
 
-    // Building the mock lambda
-    const mLambdaClient = new LambdaClientMock({});
+    // Mock failed lambda response
     const expectedLambdaResponse: InvokeCommandOutput = {
       StatusCode: 500,
       $metadata: {}
     };
-    (mLambdaClient.send as jest.Mocked<any>).mockImplementation(() => expectedLambdaResponse);
+    const mLambdaClient = new LambdaClientMock({});
+    (mLambdaClient.send as jest.Mocked<any>).mockImplementationOnce(async () => expectedLambdaResponse);
 
-    await expect(NftUtils.invokeNftHandlerLambda('sampleUid', 'local', logger))
-      .rejects.toThrow(new Error('onNewNftEvent lambda invoke failed for tx: sampleUid'));
+    await expect(NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', logger))
+      .rejects.toThrow('onNewNftEvent lambda invoke failed for tx: test-tx-id');
 
+    // Verify alert was added
     expect(mockedAddAlert).toHaveBeenCalledWith(
       'Error on NFTHandler lambda',
       'Erroed on invokeNftHandlerLambda invocation',
       Severity.MINOR,
-      { TxId: 'sampleUid' },
+      { TxId: 'test-tx-id' },
       logger,
     );
+  });
+
+  it('should handle missing environment variables', async () => {
+    expect.hasAssertions();
+
+    // Clear required environment variables
+    process.env = { ...originalEnv };
+    delete process.env.WALLET_SERVICE_LAMBDA_ENDPOINT;
+    delete process.env.AWS_REGION;
+    delete process.env.NFT_AUTO_REVIEW_ENABLED;
+
+    await expect(NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', logger))
+      .rejects.toThrow('Environment variables WALLET_SERVICE_LAMBDA_ENDPOINT and AWS_REGION are not set.');
+  });
+
+  it('should not invoke lambda when NFT_AUTO_REVIEW_ENABLED is not true', async () => {
+    expect.hasAssertions();
+
+    // Disable NFT auto review
+    process.env.NFT_AUTO_REVIEW_ENABLED = 'false';
+
+    const mLambdaClient = new LambdaClientMock({});
+    const result = await NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', logger);
+
+    // Method should return void
+    expect(result).toBeUndefined();
+
+    // Verify lambda was not called
+    expect(mLambdaClient.send).not.toHaveBeenCalled();
   });
 });
 
@@ -319,4 +392,576 @@ describe('minor helpers', () => {
     expect(c.getRemainingTimeInMillis()).toStrictEqual(0);
     expect(c.succeed('pass')).toBeUndefined();
   });
+});
+
+describe('transaction transformation compatibility', () => {
+   it('should correctly process a real event from production', () => {
+    expect.hasAssertions();
+
+    // Real event data from production
+    const fullNodeData = {
+      "hash": "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
+      "nonce": 257857,
+      "timestamp": 1741649846,
+      "signal_bits": 0,
+      "version": 2,
+      "weight": 17.30946054227969,
+      "inputs": [
+        {
+          "tx_id": "00000000ba6f3fc01a3e8561f2905c50c98422e7112604a8971bdaba1535e797",
+          "index": 1,
+          "spent_output": {
+            "value": 4,
+            "token_data": 0,
+            "script": "dqkUWDMJLPqtb9X+jPcBSP6WLg6NIC6IrA==",
+            "decoded": {
+              "type": "P2PKH",
+              "address": "WWiPUqkLJbb6YMQRgHWPMBS6voJjpeWqas",
+              "timelock": null
+            }
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "value": 1,
+          "token_data": 0,
+          "script": "C2lwZnM6Ly8xMTExrA==",
+          "decoded": null
+        },
+        {
+          "value": 2,
+          "token_data": 0,
+          "script": "dqkUFUs/hBsLnxy5Jd94WWV24BCmIhmIrA==",
+          "decoded": {
+            "type": "P2PKH",
+            "address": "WQcdDHZriSQwE4neuzf9UW2xJkdhEqrt7F",
+            "timelock": null
+          }
+        },
+        {
+          "value": 1,
+          "token_data": 1,
+          "script": "dqkUhM3YhAjNc5p/oqX+yqEYcX+miNmIrA==",
+          "decoded": {
+            "type": "P2PKH",
+            "address": "WanEffTDdFo8giEj2CuNqGWsEeWjU7crnF",
+            "timelock": null
+          }
+        }
+      ],
+      "parents": [
+        "000048d3728061842625bbad6b3f463f488a0e7ba567fc7e4b3f7b28ab690075",
+        "000000000576741d4d3aa82db265776b6896b58b825fac5e816c79d5e5e2c861"
+      ],
+      "tokens": [
+        "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866"
+      ],
+      "token_name": "Test",
+      "token_symbol": "TST",
+      "metadata": {
+        "hash": "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
+        "spent_outputs": [
+          {
+            "index": 0,
+            "tx_ids": []
+          },
+          {
+            "index": 1,
+            "tx_ids": []
+          },
+          {
+            "index": 2,
+            "tx_ids": []
+          }
+        ],
+        "conflict_with": [],
+        "voided_by": [],
+        "received_by": [],
+        "children": [
+          "000000000007e794cd3e660e34af838c063370c5127f19ccab444052c2b5dadf"
+        ],
+        "twins": [],
+        "accumulated_weight": 17.30946054227969,
+        "score": 0,
+        "first_block": "000000000007e794cd3e660e34af838c063370c5127f19ccab444052c2b5dadf",
+        "height": 0,
+        "validation": "full"
+      },
+      "aux_pow": null
+    };
+
+    // Transform the data as it happens in the services/index.ts file
+    const txFromEvent = {
+      ...fullNodeData,
+      tx_id: fullNodeData.hash,
+      inputs: fullNodeData.inputs.map((input) => {
+        const tokenIndex = (input.spent_output.token_data & hathorLib.constants.TOKEN_INDEX_MASK) - 1;
+
+        return {
+          token: tokenIndex < 0 ? hathorLib.constants.HATHOR_TOKEN_CONFIG.uid : fullNodeData.tokens[tokenIndex],
+          value: input.spent_output.value,
+          token_data: input.spent_output.token_data,
+          script: input.spent_output.script,
+          decoded: {
+            ...input.spent_output.decoded,
+          },
+          tx_id: input.tx_id,
+          index: input.index
+        };
+      }),
+      outputs: fullNodeData.outputs.map((output) => {
+        const tokenIndex = (output.token_data & hathorLib.constants.TOKEN_INDEX_MASK) - 1;
+        return {
+          ...output,
+          decoded: output.decoded ? output.decoded : {},
+          spent_by: null,
+          token: tokenIndex < 0 ? hathorLib.constants.HATHOR_TOKEN_CONFIG.uid : fullNodeData.tokens[tokenIndex],
+        };
+      }),
+    };
+
+    // Save original value to restore later
+    const originalCreateTokenTxVersion = constants.CREATE_TOKEN_TX_VERSION;
+    // Since we're using real data, we need to make sure the version matches
+    const mockConstants = { ...constants, CREATE_TOKEN_TX_VERSION: 2 };
+    jest.spyOn(constants, 'CREATE_TOKEN_TX_VERSION', 'get').mockReturnValue(2);
+
+    try {
+      // Enable NFT auto review to test the full flow
+      process.env.NFT_AUTO_REVIEW_ENABLED = 'true';
+
+      // Verify token handling is correct
+      // First input should be HTR token
+      expect(txFromEvent.inputs[0].token).toBe(hathorLib.constants.HATHOR_TOKEN_CONFIG.uid);
+      
+      // First and second outputs should be HTR tokens
+      expect(txFromEvent.outputs[0].token).toBe(hathorLib.constants.HATHOR_TOKEN_CONFIG.uid);
+      expect(txFromEvent.outputs[1].token).toBe(hathorLib.constants.HATHOR_TOKEN_CONFIG.uid);
+      
+      // Third output should be the NFT token
+      expect(txFromEvent.outputs[2].token).toBe(fullNodeData.tokens[0]);
+
+      // Check null decoded field is properly handled
+      expect(txFromEvent.outputs[0].decoded).toStrictEqual({});
+
+      // Mock network for validation
+      const mockNetwork = {
+        name: 'testnet',
+      };
+      
+      // Test that this transaction is detected as an NFT
+      const isNft = NftUtils.isTransactionNFTCreation(txFromEvent, mockNetwork as any, logger);
+      expect(isNft).toBe(true);
+
+      // Test the full flow
+      const shouldInvoke = NftUtils.shouldInvokeNftHandlerForTx(txFromEvent, mockNetwork as any, logger);
+      expect(shouldInvoke).toBe(true);
+      
+      // Ensure we can create a transaction from this data
+      const libTx = helpersUtils.createTxFromHistoryObject(txFromEvent);
+      expect(libTx).toBeDefined();
+      expect(libTx.version).toBe(2);
+      expect(libTx.tokens).toContain(fullNodeData.tokens[0]);
+    } finally {
+      // Clean up mocks
+      jest.spyOn(constants, 'CREATE_TOKEN_TX_VERSION', 'get').mockRestore();
+    }
+  });
+});
+
+describe('processNftEvent', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  let invokeNftLambdaSpy: jest.SpyInstance;
+  let shouldInvokeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Save original env
+    originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      NFT_AUTO_REVIEW_ENABLED: 'true',
+      WALLET_SERVICE_LAMBDA_ENDPOINT: 'http://localhost:3000',
+      AWS_REGION: 'us-east-1'
+    };
+
+    invokeNftLambdaSpy = jest.spyOn(NftUtils, 'invokeNftHandlerLambda').mockResolvedValue();
+    shouldInvokeSpy = jest.spyOn(NftUtils, 'shouldInvokeNftHandlerForTx').mockReturnValue(true);
+
+    const mLambdaClient = new LambdaClientMock({});
+    (mLambdaClient.send as jest.Mocked<any>).mockReset();
+  });
+
+  afterEach(() => {
+    // Clean up
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('should invoke the NFT handler for a valid NFT event', async () => {
+    expect.hasAssertions();
+
+    // Real event data from production
+    const eventData = {
+      hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
+      nonce: 257857,
+      timestamp: 1741649846,
+      signal_bits: 0,
+      version: 2,
+      weight: 17.30946054227969,
+      inputs: [
+        {
+          tx_id: "00000000ba6f3fc01a3e8561f2905c50c98422e7112604a8971bdaba1535e797",
+          index: 1,
+          spent_output: {
+            value: 4,
+            token_data: 0,
+            script: "dqkUWDMJLPqtb9X+jPcBSP6WLg6NIC6IrA==",
+            decoded: {
+              type: "P2PKH",
+              address: "WWiPUqkLJbb6YMQRgHWPMBS6voJjpeWqas",
+              timelock: null
+            }
+          }
+        }
+      ],
+      outputs: [
+        {
+          value: 1,
+          token_data: 0,
+          script: "C2lwZnM6Ly8xMTExrA==",
+          decoded: null
+        },
+        {
+          value: 2,
+          token_data: 0,
+          script: "dqkUFUs/hBsLnxy5Jd94WWV24BCmIhmIrA==",
+          decoded: {
+            type: "P2PKH",
+            address: "WQcdDHZriSQwE4neuzf9UW2xJkdhEqrt7F",
+            timelock: null
+          }
+        },
+        {
+          value: 1,
+          token_data: 1,
+          script: "dqkUhM3YhAjNc5p/oqX+yqEYcX+miNmIrA==",
+          decoded: {
+            type: "P2PKH",
+            address: "WanEffTDdFo8giEj2CuNqGWsEeWjU7crnF",
+            timelock: null
+          }
+        }
+      ],
+      tokens: [
+        "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866"
+      ],
+      token_name: "Test",
+      token_symbol: "TST",
+    };
+
+    // Mock network
+    const mockNetwork = { name: 'testnet' };
+    
+    // Call the method
+    const result = await NftUtils.processNftEvent(
+      eventData, 
+      'test-stage', 
+      mockNetwork as any, 
+      logger
+    );
+
+    // Verify result is true (successful invocation)
+    expect(result).toBe(true);
+
+    // Verify shouldInvokeNftHandlerForTx was called with properly transformed tx
+    expect(shouldInvokeSpy).toHaveBeenCalledTimes(1);
+    const callArg = shouldInvokeSpy.mock.calls[0][0];
+    
+    // Verify the transaction was transformed correctly
+    expect(callArg).toMatchObject({
+      tx_id: eventData.hash,
+      version: eventData.version,
+      token_name: eventData.token_name,
+      token_symbol: eventData.token_symbol,
+    });
+    
+    // Verify outputs were transformed correctly
+    expect(callArg.outputs.length).toBe(eventData.outputs.length);
+    expect(callArg.outputs[0].spent_by).toBeNull();
+    expect(callArg.outputs[0].decoded).toEqual({});
+    expect(callArg.outputs[0].token).toBe(hathorLib.constants.HATHOR_TOKEN_CONFIG.uid);
+    
+    // Verify the lambda was invoked with the correct parameters
+    expect(invokeNftLambdaSpy).toHaveBeenCalledTimes(1);
+    expect(invokeNftLambdaSpy).toHaveBeenCalledWith(
+      eventData.hash,
+      'test-stage',
+      logger
+    );
+  });
+
+  it('should not invoke the NFT handler when NFT_AUTO_REVIEW_ENABLED is false', async () => {
+    expect.hasAssertions();
+
+    // Disable NFT auto review
+    process.env.NFT_AUTO_REVIEW_ENABLED = 'false';
+
+    // Real event data from production (simplified)
+    const eventData = {
+      hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
+      version: 2,
+      inputs: [{ tx_id: "tx1", index: 0, spent_output: { value: 1, token_data: 0, script: "s" } }],
+      outputs: [{ value: 1, token_data: 0, script: "s" }],
+      tokens: ["token1"],
+      token_name: "Test",
+      token_symbol: "TST",
+    };
+
+    // Mock network
+    const mockNetwork = { name: 'testnet' };
+    
+    // Call the method
+    const result = await NftUtils.processNftEvent(
+      eventData, 
+      'test-stage', 
+      mockNetwork as any, 
+      logger
+    );
+
+    // Verify result is false (no invocation)
+    expect(result).toBe(false);
+
+    // Verify shouldInvokeNftHandlerForTx was NOT called
+    expect(shouldInvokeSpy).not.toHaveBeenCalled();
+    
+    // Verify the lambda was NOT invoked
+    expect(invokeNftLambdaSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return false when shouldInvokeNftHandlerForTx returns false', async () => {
+    expect.hasAssertions();
+
+    // Make shouldInvokeNftHandlerForTx return false
+    shouldInvokeSpy.mockReturnValue(false);
+
+    // Simplified event data
+    const eventData = {
+      hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
+      version: 2,
+      inputs: [{ tx_id: "tx1", index: 0, spent_output: { value: 1, token_data: 0, script: "s" } }],
+      outputs: [{ value: 1, token_data: 0, script: "s" }],
+      tokens: ["token1"],
+      token_name: "Test",
+      token_symbol: "TST",
+    };
+
+    // Mock network
+    const mockNetwork = { name: 'testnet' };
+    
+    // Call the method
+    const result = await NftUtils.processNftEvent(
+      eventData, 
+      'test-stage', 
+      mockNetwork as any, 
+      logger
+    );
+
+    // Verify result is false (no invocation)
+    expect(result).toBe(false);
+
+    // Verify shouldInvokeNftHandlerForTx was called
+    expect(shouldInvokeSpy).toHaveBeenCalledTimes(1);
+    
+    // Verify the lambda was NOT invoked
+    expect(invokeNftLambdaSpy).not.toHaveBeenCalled();
+  });
+
+  it('should handle errors from invokeNftHandlerLambda', async () => {
+    expect.hasAssertions();
+
+    // Make invokeNftHandlerLambda throw an error
+    invokeNftLambdaSpy.mockRejectedValue(new Error('Lambda invocation failed'));
+
+    // Simplified event data
+    const eventData = {
+      hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
+      version: 2,
+      inputs: [{ tx_id: "tx1", index: 0, spent_output: { value: 1, token_data: 0, script: "s" } }],
+      outputs: [{ value: 1, token_data: 0, script: "s" }],
+      tokens: ["token1"],
+      token_name: "Test",
+      token_symbol: "TST",
+    };
+
+    // Mock network
+    const mockNetwork = { name: 'testnet' };
+    
+    // Call the method - it should not throw
+    const result = await NftUtils.processNftEvent(
+      eventData, 
+      'test-stage', 
+      mockNetwork as any, 
+      logger
+    );
+
+    // Verify result is false (failed invocation)
+    expect(result).toBe(false);
+
+    // Verify shouldInvokeNftHandlerForTx was called
+    expect(shouldInvokeSpy).toHaveBeenCalledTimes(1);
+    
+    // Verify the lambda was invoked
+    expect(invokeNftLambdaSpy).toHaveBeenCalledTimes(1);
+    
+    // Verify error was logged
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+it('should perform full NFT processing with real event data and no mocks', async () => {
+  expect.hasAssertions();
+
+  // Clear all mocks to test the real implementation
+  jest.restoreAllMocks();
+
+  // Set up required environment variables
+  const originalEnv = process.env;
+  process.env = {
+    ...originalEnv,
+    NFT_AUTO_REVIEW_ENABLED: 'true',
+    WALLET_SERVICE_LAMBDA_ENDPOINT: 'http://localhost:3000',
+    AWS_REGION: 'us-east-1'
+  };
+
+  // Mock the Lambda client to prevent actual AWS calls
+  const mockSend = jest.fn().mockResolvedValue({ StatusCode: 202 });
+  const mockLambdaClient = {
+    send: mockSend
+  };
+  (LambdaClientMock as jest.Mock).mockImplementation(() => mockLambdaClient);
+
+  try {
+    // Real event data from production
+    const eventData = {
+      hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
+      nonce: 257857,
+      timestamp: 1741649846,
+      signal_bits: 0,
+      version: 2,
+      weight: 17.30946054227969,
+      inputs: [
+        {
+          tx_id: "00000000ba6f3fc01a3e8561f2905c50c98422e7112604a8971bdaba1535e797",
+          index: 1,
+          spent_output: {
+            value: 4,
+            token_data: 0,
+            script: "dqkUWDMJLPqtb9X+jPcBSP6WLg6NIC6IrA==",
+            decoded: {
+              type: "P2PKH",
+              address: "WWiPUqkLJbb6YMQRgHWPMBS6voJjpeWqas",
+              timelock: null
+            }
+          }
+        }
+      ],
+      outputs: [
+        {
+          value: 1,
+          token_data: 0,
+          script: "C2lwZnM6Ly8xMTExrA==",
+          decoded: null
+        },
+        {
+          value: 2,
+          token_data: 0,
+          script: "dqkUFUs/hBsLnxy5Jd94WWV24BCmIhmIrA==",
+          decoded: {
+            type: "P2PKH",
+            address: "WQcdDHZriSQwE4neuzf9UW2xJkdhEqrt7F",
+            timelock: null
+          }
+        },
+        {
+          value: 1,
+          token_data: 1,
+          script: "dqkUhM3YhAjNc5p/oqX+yqEYcX+miNmIrA==",
+          decoded: {
+            type: "P2PKH",
+            address: "WanEffTDdFo8giEj2CuNqGWsEeWjU7crnF",
+            timelock: null
+          }
+        }
+      ],
+      tokens: [
+        "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866"
+      ],
+      token_name: "Test",
+      token_symbol: "TST",
+      metadata: {
+        hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
+        spent_outputs: [
+          { index: 0, tx_ids: [] },
+          { index: 1, tx_ids: [] },
+          { index: 2, tx_ids: [] }
+        ],
+        conflict_with: [],
+        voided_by: [],
+        received_by: [],
+        children: ["000000000007e794cd3e660e34af838c063370c5127f19ccab444052c2b5dadf"],
+        twins: [],
+        accumulated_weight: 17.30946054227969,
+        score: 0,
+        first_block: "000000000007e794cd3e660e34af838c063370c5127f19ccab444052c2b5dadf",
+        height: 0,
+        validation: "full"
+      }
+    };
+
+    // Mock network for validation
+    const mockNetwork = {
+      name: 'testnet',
+    };
+
+    // Since we're using real data, we need to make sure the version matches
+    const originalCreateTokenTxVersion = constants.CREATE_TOKEN_TX_VERSION;
+    jest.spyOn(constants, 'CREATE_TOKEN_TX_VERSION', 'get').mockReturnValue(2);
+
+    try {
+      // Process the NFT event
+      const result = await NftUtils.processNftEvent(
+        eventData,
+        'test-stage',
+        mockNetwork as any,
+        logger
+      );
+
+      // Verify the result is true (successful processing)
+      expect(result).toBe(true);
+
+      // Verify Lambda client was constructed correctly
+      expect(LambdaClientMock).toHaveBeenCalledWith({
+        endpoint: process.env.WALLET_SERVICE_LAMBDA_ENDPOINT,
+        region: process.env.AWS_REGION,
+      });
+
+      // Verify Lambda was invoked with correct parameters
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockSend.mock.calls[0][0].input).toMatchObject({
+        FunctionName: 'hathor-wallet-service-test-stage-onNewNftEvent',
+        InvocationType: 'Event',
+      });
+
+      // Verify the payload contains the correct NFT UID
+      const payload = JSON.parse(mockSend.mock.calls[0][0].input.Payload);
+      expect(payload).toEqual({ nftUid: eventData.hash });
+    } finally {
+      // Clean up mocks
+      jest.spyOn(constants, 'CREATE_TOKEN_TX_VERSION', 'get').mockRestore();
+    }
+  } finally {
+    // Restore environment
+    process.env = originalEnv;
+  }
 });

--- a/packages/common/__tests__/utils/nft.utils.test.ts
+++ b/packages/common/__tests__/utils/nft.utils.test.ts
@@ -7,7 +7,6 @@ import { getHandlerContext, getTransaction } from '../events/nftCreationTx';
 import {
   LambdaClient as LambdaClientMock,
   InvokeCommandOutput,
-  InvokeCommand,
 } from '@aws-sdk/client-lambda';
 import { Logger } from 'winston';
 
@@ -47,61 +46,61 @@ const logger = new Logger();
 
 // Real event data from production
 const REAL_NFT_EVENT_DATA = {
-  "hash": "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
-  "nonce": 257857,
-  "timestamp": 1741649846,
-  "signal_bits": 0,
-  "version": 2,
-  "weight": 17.30946054227969,
-  "inputs": [
+  'hash': '000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866',
+  'nonce': 257857,
+  'timestamp': 1741649846,
+  'signal_bits': 0,
+  'version': 2,
+  'weight': 17.30946054227969,
+  'inputs': [
     {
-      "tx_id": "00000000ba6f3fc01a3e8561f2905c50c98422e7112604a8971bdaba1535e797",
-      "index": 1,
-      "spent_output": {
-        "value": 4,
-        "token_data": 0,
-        "script": "dqkUWDMJLPqtb9X+jPcBSP6WLg6NIC6IrA==",
-        "decoded": {
-          "type": "P2PKH",
-          "address": "WWiPUqkLJbb6YMQRgHWPMBS6voJjpeWqas",
-          "timelock": null
+      'tx_id': '00000000ba6f3fc01a3e8561f2905c50c98422e7112604a8971bdaba1535e797',
+      'index': 1,
+      'spent_output': {
+        'value': 4,
+        'token_data': 0,
+        'script': 'dqkUWDMJLPqtb9X+jPcBSP6WLg6NIC6IrA==',
+        'decoded': {
+          'type': 'P2PKH',
+          'address': 'WWiPUqkLJbb6YMQRgHWPMBS6voJjpeWqas',
+          'timelock': null
         }
       }
     }
   ],
-  "outputs": [
+  'outputs': [
     {
-      "value": 1,
-      "token_data": 0,
-      "script": "C2lwZnM6Ly8xMTExrA==",
-      "decoded": null
+      'value': 1,
+      'token_data': 0,
+      'script': 'C2lwZnM6Ly8xMTExrA==',
+      'decoded': null
     },
     {
-      "value": 2,
-      "token_data": 0,
-      "script": "dqkUFUs/hBsLnxy5Jd94WWV24BCmIhmIrA==",
-      "decoded": {
-        "type": "P2PKH",
-        "address": "WQcdDHZriSQwE4neuzf9UW2xJkdhEqrt7F",
-        "timelock": null
+      'value': 2,
+      'token_data': 0,
+      'script': 'dqkUFUs/hBsLnxy5Jd94WWV24BCmIhmIrA==',
+      'decoded': {
+        'type': 'P2PKH',
+        'address': 'WQcdDHZriSQwE4neuzf9UW2xJkdhEqrt7F',
+        'timelock': null
       }
     },
     {
-      "value": 1,
-      "token_data": 1,
-      "script": "dqkUhM3YhAjNc5p/oqX+yqEYcX+miNmIrA==",
-      "decoded": {
-        "type": "P2PKH",
-        "address": "WanEffTDdFo8giEj2CuNqGWsEeWjU7crnF",
-        "timelock": null
+      'value': 1,
+      'token_data': 1,
+      'script': 'dqkUhM3YhAjNc5p/oqX+yqEYcX+miNmIrA==',
+      'decoded': {
+        'type': 'P2PKH',
+        'address': 'WanEffTDdFo8giEj2CuNqGWsEeWjU7crnF',
+        'timelock': null
       }
     }
   ],
-  "tokens": [
-    "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866"
+  'tokens': [
+    '000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866'
   ],
-  "token_name": "Test",
-  "token_symbol": "TST"
+  'token_name': 'Test',
+  'token_symbol': 'TST'
 };
 
 // Create the transformed version of the event as it would be processed
@@ -660,7 +659,7 @@ describe('processNftEvent', () => {
 
     // Real event data from production
     const eventData = {
-      hash: "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866",
+      hash: '000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866',
       nonce: 257857,
       timestamp: 1741649846,
       signal_bits: 0,
@@ -668,15 +667,15 @@ describe('processNftEvent', () => {
       weight: 17.30946054227969,
       inputs: [
         {
-          tx_id: "00000000ba6f3fc01a3e8561f2905c50c98422e7112604a8971bdaba1535e797",
+          tx_id: '00000000ba6f3fc01a3e8561f2905c50c98422e7112604a8971bdaba1535e797',
           index: 1,
           spent_output: {
             value: 4,
             token_data: 0,
-            script: "dqkUWDMJLPqtb9X+jPcBSP6WLg6NIC6IrA==",
+            script: 'dqkUWDMJLPqtb9X+jPcBSP6WLg6NIC6IrA==',
             decoded: {
-              type: "P2PKH",
-              address: "WWiPUqkLJbb6YMQRgHWPMBS6voJjpeWqas",
+              type: 'P2PKH',
+              address: 'WWiPUqkLJbb6YMQRgHWPMBS6voJjpeWqas',
               timelock: null
             }
           }
@@ -686,35 +685,35 @@ describe('processNftEvent', () => {
         {
           value: 1,
           token_data: 0,
-          script: "C2lwZnM6Ly8xMTExrA==",
+          script: 'C2lwZnM6Ly8xMTExrA==',
           decoded: null
         },
         {
           value: 2,
           token_data: 0,
-          script: "dqkUFUs/hBsLnxy5Jd94WWV24BCmIhmIrA==",
+          script: 'dqkUFUs/hBsLnxy5Jd94WWV24BCmIhmIrA==',
           decoded: {
-            type: "P2PKH",
-            address: "WQcdDHZriSQwE4neuzf9UW2xJkdhEqrt7F",
+            type: 'P2PKH',
+            address: 'WQcdDHZriSQwE4neuzf9UW2xJkdhEqrt7F',
             timelock: null
           }
         },
         {
           value: 1,
           token_data: 1,
-          script: "dqkUhM3YhAjNc5p/oqX+yqEYcX+miNmIrA==",
+          script: 'dqkUhM3YhAjNc5p/oqX+yqEYcX+miNmIrA==',
           decoded: {
-            type: "P2PKH",
-            address: "WanEffTDdFo8giEj2CuNqGWsEeWjU7crnF",
+            type: 'P2PKH',
+            address: 'WanEffTDdFo8giEj2CuNqGWsEeWjU7crnF',
             timelock: null
           }
         }
       ],
       tokens: [
-        "000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866"
+        '000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866'
       ],
-      token_name: "Test",
-      token_symbol: "TST",
+      token_name: 'Test',
+      token_symbol: 'TST',
     };
 
     // Mock network
@@ -769,12 +768,12 @@ describe('processNftEvent', () => {
 
     // Mock network
     const mockNetwork = { name: 'testnet' };
-    
+
     // Call the method
     const result = await NftUtils.processNftEvent(
-      eventData, 
-      'test-stage', 
-      mockNetwork as any, 
+      eventData,
+      'test-stage',
+      mockNetwork as any,
       logger
     );
 
@@ -783,7 +782,7 @@ describe('processNftEvent', () => {
 
     // Verify shouldInvokeNftHandlerForTx was NOT called
     expect(shouldInvokeSpy).not.toHaveBeenCalled();
-    
+
     // Verify the lambda was NOT invoked
     expect(invokeNftLambdaSpy).not.toHaveBeenCalled();
   });
@@ -799,12 +798,12 @@ describe('processNftEvent', () => {
 
     // Mock network
     const mockNetwork = { name: 'testnet' };
-    
+
     // Call the method
     const result = await NftUtils.processNftEvent(
-      eventData, 
-      'test-stage', 
-      mockNetwork as any, 
+      eventData,
+      'test-stage',
+      mockNetwork as any,
       logger
     );
 
@@ -813,7 +812,7 @@ describe('processNftEvent', () => {
 
     // Verify shouldInvokeNftHandlerForTx was called
     expect(shouldInvokeSpy).toHaveBeenCalledTimes(1);
-    
+
     // Verify the lambda was NOT invoked
     expect(invokeNftLambdaSpy).not.toHaveBeenCalled();
   });
@@ -829,12 +828,12 @@ describe('processNftEvent', () => {
 
     // Mock network
     const mockNetwork = { name: 'testnet' };
-    
+
     // Call the method - it should not throw
     const result = await NftUtils.processNftEvent(
-      eventData, 
-      'test-stage', 
-      mockNetwork as any, 
+      eventData,
+      'test-stage',
+      mockNetwork as any,
       logger
     );
 
@@ -843,10 +842,10 @@ describe('processNftEvent', () => {
 
     // Verify shouldInvokeNftHandlerForTx was called
     expect(shouldInvokeSpy).toHaveBeenCalledTimes(1);
-    
+
     // Verify the lambda was invoked
     expect(invokeNftLambdaSpy).toHaveBeenCalledTimes(1);
-    
+
     // Verify error was logged
     expect(logger.error).toHaveBeenCalled();
   });
@@ -895,13 +894,13 @@ it('should perform full NFT processing with real event data and no mocks', async
           conflict_with: [],
           voided_by: [],
           received_by: [],
-          children: ["000000000007e794cd3e660e34af838c063370c5127f19ccab444052c2b5dadf"],
+          children: ['000000000007e794cd3e660e34af838c063370c5127f19ccab444052c2b5dadf'],
           twins: [],
           accumulated_weight: 17.30946054227969,
           score: 0,
-          first_block: "000000000007e794cd3e660e34af838c063370c5127f19ccab444052c2b5dadf",
+          first_block: '000000000007e794cd3e660e34af838c063370c5127f19ccab444052c2b5dadf',
           height: 0,
-          validation: "full"
+          validation: 'full'
         }
       } as any; // Type assertion to avoid TypeScript errors
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -436,3 +436,34 @@ export class TokenBalanceMap {
     return obj;
   }
 }
+
+// The output structure in full node events is similar to TxOutput but with some differences
+export interface FullNodeOutput extends Omit<TxOutput, 'decoded' | 'token' | 'spent_by'> {
+  // In full node data, decoded can be null
+  decoded: DecodedOutput | null;
+}
+
+// The input structure in full node events is different - it contains a reference to the spent output
+export interface FullNodeInput extends Omit<TxInput, 'value' | 'token_data' | 'script' | 'token' | 'decoded'> {
+  // Instead of having these fields directly, it has a spent_output property
+  spent_output: FullNodeOutput;
+}
+
+// The FullNodeTransaction interface represents a transaction as it comes from the full node
+// which has a slightly different structure than our internal Transaction type
+export interface FullNodeTransaction extends Omit<Transaction, 'tx_id' | 'inputs' | 'outputs' | 'parents'> {
+  // From full node events we get 'hash' instead of 'tx_id'
+  hash: string;
+  // The input and output structures are different from our internal Transaction type
+  inputs: FullNodeInput[];
+  outputs: FullNodeOutput[];
+  // Additional fields specific to full node events
+  tokens: string[];
+  parents?: string[];
+  metadata?: {
+    hash: string;
+    voided_by: string[];
+    first_block: null | string;
+    height: number;
+  };
+}

--- a/packages/common/src/utils/nft.utils.ts
+++ b/packages/common/src/utils/nft.utils.ts
@@ -40,7 +40,6 @@ export class NftUtils {
    * @param {Transaction} tx
    * @returns {boolean}
    *
-   * TODO: change tx type to HistoryTransaction
    * TODO: Remove the logger param after we unify the logger from both projects
    */
   static isTransactionNFTCreation(tx: HistoryTransaction, network: Network, logger: Logger): boolean {

--- a/packages/common/src/utils/nft.utils.ts
+++ b/packages/common/src/utils/nft.utils.ts
@@ -243,6 +243,10 @@ export class NftUtils {
       token_name: fullNodeData.token_name,
       token_symbol: fullNodeData.token_symbol,
       inputs: fullNodeData.inputs.map((input: FullNodeInput) => {
+        // Extract the token index from token_data using hathor's TOKEN_INDEX_MASK
+        // The token_data field contains both the token index and other flags
+        // TOKEN_INDEX_MASK is used to isolate just the token index bits
+        // We subtract 1 because token indexes are 1-based in token_data but 0-based in the tokens array
         const tokenIndex = (input.spent_output.token_data & constants.TOKEN_INDEX_MASK) - 1;
 
         return {
@@ -256,6 +260,9 @@ export class NftUtils {
         };
       }),
       outputs: fullNodeData.outputs.map((output: FullNodeOutput) => {
+        // Extract the token index from token_data using the same bit masking technique
+        // A negative result means it's the HTR token (index < 0)
+        // A positive result is an index into the tokens array (custom tokens)
         const tokenIndex = (output.token_data & constants.TOKEN_INDEX_MASK) - 1;
 
         return {


### PR DESCRIPTION
### Motivation

There was a bug in the NFT handler invocation logic. The `shouldInvokeNftHandlerForTx` method was failing for valid NFT transactions because the event data from the full node contained null values in the decoded field for some outputs. When the output data wasn't properly transformed to handle these null values (replacing them with empty objects {}), the NFT detection would fail silently, causing NFTs to not be properly processed.


### Acceptance Criteria
- Fix the bug where NFT transactions with null decoded fields aren't properly detected
- Ensure proper transformation of transaction data from full node events
- Extract the transformation and invocation logic into a reusable method
- Add comprehensive tests with real production data that includes a valid NFT transaction
- Verify that NFT detection works correctly with the transformed data


### Checklist
[X] If you are requesting a merge into master, confirm this code is production-ready and can be included in future releases as soon as it gets merged
[X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
[X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.