### PR TITLE
fix: nft utils should be imported from common index

### DIFF
--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -120,6 +120,7 @@ jest.mock('@wallet-service/common', () => {
     NftUtils: {
       shouldInvokeNftHandlerForTx: jest.fn().mockReturnValue(false),
       invokeNftHandlerLambda: jest.fn(),
+      processNftEvent: jest.fn().mockReturnValue(Promise.resolve()),
     },
   };
 });

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -9,7 +9,7 @@ import hathorLib from '@hathor/wallet-lib';
 import { Connection as MysqlConnection } from 'mysql2/promise';
 import axios from 'axios';
 import { get } from 'lodash';
-import { NftUtils } from '@wallet-service/common/src/utils/nft.utils';
+import { NftUtils } from '@wallet-service/common';
 import {
   StringMap,
   Wallet,


### PR DESCRIPTION
### Motivation

Should fix Incident #229

`Error: Cannot find module '@wallet-service/common/src/utils/nft.utils'`

### Acceptance Criteria

- Importing directly from src works in dev and tests but fails in the compiled version, we should import from the exported index
- Added the `processNftEvent` to the mocked NftUtils in services tests

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
