### PR TITLE
fix: daemon was always using ssl regardless of config

### DIFF
--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -84,7 +84,7 @@ export const HEALTHCHECK_SERVER_API_KEY = process.env.HEALTHCHECK_SERVER_API_KEY
 export const HEALTHCHECK_PING_INTERVAL = parseInt(process.env.HEALTHCHECK_PING_INTERVAL ?? '10000', 10);  // 10 seconds
 
 // Other
-export const USE_SSL = process.env.USE_SSL;
+export const USE_SSL = process.env.USE_SSL === 'true';
 
 // Reorg size thresholds for different alert levels
 export const REORG_SIZE_INFO = parseInt(process.env.REORG_SIZE_INFO ?? '1', 10);


### PR DESCRIPTION
### Motivation

The fullnode was always using SSL when connecting to fullnodes

### Acceptance Criteria

- The daemon should be able to connect to fullnodes without using SSL

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
