### PR TITLE
fix: io decoded handling

### DIFF
--- a/packages/common/__tests__/utils/nft.utils.test.ts
+++ b/packages/common/__tests__/utils/nft.utils.test.ts
@@ -15,7 +15,7 @@ jest.mock('winston', () => {
     error = jest.fn();
     info = jest.fn();
     debug = jest.fn();
-  };
+  }
 
   return {
     Logger: FakeLogger,

--- a/packages/common/__tests__/utils/wallet.utils.test.ts
+++ b/packages/common/__tests__/utils/wallet.utils.test.ts
@@ -1,0 +1,29 @@
+import { isDecodedValid } from '@src/utils/wallet.utils';
+
+describe('walletUtils', () => {
+  it('should validate common invalid inputs', () => {
+    expect.hasAssertions();
+
+    expect(isDecodedValid({})).toBeFalsy();
+    expect(isDecodedValid(false)).toBeFalsy();
+    expect(isDecodedValid(null)).toBeFalsy();
+    expect(isDecodedValid(undefined)).toBeFalsy();
+    expect(isDecodedValid({
+      address: 'addr1',
+      type: 'PPK',
+    })).toBeTruthy();
+  });
+
+  it('should validate requiredKeys', () => {
+    expect.hasAssertions();
+
+    expect(isDecodedValid({
+      address: 'addr1',
+      type: 'PPK',
+    }, ['address', 'type'])).toBeTruthy();
+
+    expect(isDecodedValid({
+      address: 'addr1',
+    }, ['address', 'type'])).toBeFalsy();
+  });
+});

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -11,7 +11,7 @@
  */
 
 import { constants } from '@hathor/wallet-lib';
-import { isAuthority } from './utils/wallet.utils';
+import { isAuthority, isDecodedValid } from './utils/wallet.utils';
 
 export interface StringMap<T> {
   [x: string]: T;
@@ -376,7 +376,7 @@ export class TokenBalanceMap {
    * @returns The TokenBalanceMap object
    */
   static fromTxOutput(output: TxOutput): TokenBalanceMap {
-    if (!output.decoded) {
+    if (!isDecodedValid(output.decoded)) {
       throw new Error('Output has no decoded script');
     }
     const token = output.token;

--- a/packages/common/src/utils/alerting.utils.ts
+++ b/packages/common/src/utils/alerting.utils.ts
@@ -61,7 +61,7 @@ export const addAlert = async (
 
   try {
     await client.send(command);
-  } catch(err) {
+  } catch (err) {
     logger.error('[ALERT] Erroed while sending message to the alert sqs queue', err);
   }
 };

--- a/packages/common/src/utils/wallet.utils.ts
+++ b/packages/common/src/utils/wallet.utils.ts
@@ -17,3 +17,18 @@ import { constants } from '@hathor/wallet-lib';
 export const isAuthority = (tokenData: number): boolean => (
   (tokenData & constants.TOKEN_AUTHORITY_MASK) > 0
 );
+
+/**
+ * Checks if a decoded output object is valid (not null, undefined or empty object).
+ *
+ * @param decoded - The decoded output object to check
+ * @returns true if the decoded object is valid, false otherwise
+ */
+export const isDecodedValid = (decoded: any, requiredKeys: string[] = []): boolean => {
+  return (decoded != null
+    && typeof decoded === 'object'
+    && Object.keys(decoded).length > 0)
+    && requiredKeys.reduce((state, key: string) => (
+      state && decoded[key] != null
+    ), true);
+};

--- a/packages/common/src/utils/wallet.utils.ts
+++ b/packages/common/src/utils/wallet.utils.ts
@@ -22,6 +22,7 @@ export const isAuthority = (tokenData: number): boolean => (
  * Checks if a decoded output object is valid (not null, undefined or empty object).
  *
  * @param decoded - The decoded output object to check
+ * @param requiredKeys - A list of keys to check
  * @returns true if the decoded object is valid, false otherwise
  */
 export const isDecodedValid = (decoded: any, requiredKeys: string[] = []): boolean => {

--- a/packages/daemon/__tests__/integration/balances.test.ts
+++ b/packages/daemon/__tests__/integration/balances.test.ts
@@ -71,7 +71,7 @@ let mysql: Connection;
 beforeAll(async () => {
   try {
     mysql = await getDbConnection();
-  } catch(e) {
+  } catch (e) {
     console.error('Failed to establish db connection', e);
     throw e;
   }
@@ -290,6 +290,7 @@ describe('empty script scenario', () => {
     // @ts-ignore
     await transitionUntilEvent(mysql, machine, EMPTY_SCRIPT_LAST_EVENT);
     const addressBalances = await fetchAddressBalances(mysql);
+
     // @ts-ignore
     expect(validateBalances(addressBalances, emptyScriptBalances));
   });

--- a/packages/daemon/__tests__/utils/wallet.test.ts
+++ b/packages/daemon/__tests__/utils/wallet.test.ts
@@ -25,9 +25,9 @@ describe('prepareOutputs', () => {
       token_data: 0,
       script: 'dqkUCU1EY3YLi8WURhDOEsspok4Y0XiIrA==',
       decoded: {
-          type: 'P2PKH',
-          address: 'H7NK2gjt5oaHzBEPoiH7y3d1NcPQi3Tr2F',
-          timelock: null,
+        type: 'P2PKH',
+        address: 'H7NK2gjt5oaHzBEPoiH7y3d1NcPQi3Tr2F',
+        timelock: null,
       }
     }, {
       value: 1,

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -29,6 +29,7 @@ import {
   Transaction,
   TokenBalanceMap,
   TxOutputWithIndex,
+  isDecodedValid,
 } from '@wallet-service/common';
 import {
   prepareOutputs,
@@ -133,8 +134,8 @@ export const metadataDiff = async (_context: Context, event: Event) => {
     }
 
     if (first_block
-       && first_block.length
-       && first_block.length > 0) {
+      && first_block.length
+      && first_block.length > 0) {
       if (!dbTx.height) {
         return {
           type: METADATA_DIFF_EVENT_TYPES.TX_FIRST_BLOCK,
@@ -161,7 +162,7 @@ export const metadataDiff = async (_context: Context, event: Event) => {
 };
 
 export const isBlock = (version: number): boolean => version === hathorLib.constants.BLOCK_VERSION
-      || version === hathorLib.constants.MERGED_MINED_BLOCK_VERSION;
+  || version === hathorLib.constants.MERGED_MINED_BLOCK_VERSION;
 
 export const handleVertexAccepted = async (context: Context, _event: Event) => {
   const mysql = await getDbConnection();
@@ -217,7 +218,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
     const txOutputs: TxOutputWithIndex[] = prepareOutputs(outputs, tokens);
     const txInputs: TxInput[] = prepareInputs(inputs, tokens);
 
-    let heightlock: number|null = null;
+    let heightlock: number | null = null;
     if (isBlock(version)) {
       if (typeof height !== 'number' && !height) {
         throw new Error('Block with no height set in metadata.');
@@ -238,7 +239,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       const blockRewardOutput = outputs[0];
 
       // add miner to the miners table
-      if (blockRewardOutput.decoded) {
+      if (isDecodedValid(blockRewardOutput.decoded)) {
         await addMiner(mysql, blockRewardOutput.decoded.address, hash);
       }
 
@@ -303,21 +304,21 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
 
       const addressesPerWallet = Object.entries(addressWalletMap).reduce(
         (result: StringMap<{ addresses: string[], walletDetails: Wallet }>, [address, wallet]: [string, Wallet]) => {
-        const { walletId } = wallet;
+          const { walletId } = wallet;
 
-        // Initialize the array if the walletId is not yet a key in result
-        if (!result[walletId]) {
-          result[walletId] = {
-            addresses: [],
-            walletDetails: wallet,
+          // Initialize the array if the walletId is not yet a key in result
+          if (!result[walletId]) {
+            result[walletId] = {
+              addresses: [],
+              walletDetails: wallet,
+            }
           }
-        }
 
-        // Add the current key to the array
-        result[walletId].addresses.push(address);
+          // Add the current key to the array
+          result[walletId].addresses.push(address);
 
-        return result;
-      }, {});
+          return result;
+        }, {});
 
       const seenWallets = Object.keys(addressesPerWallet);
 
@@ -420,7 +421,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
     await mysql.commit();
   } catch (e) {
     await mysql.rollback();
-    logger.error('Error handling vertex accepted', {
+    console.error('Error handling vertex accepted', {
       error: (e as Error).message,
       stack: (e as Error).stack,
     });
@@ -615,13 +616,13 @@ export const updateLastSyncedEvent = async (context: Context) => {
   const lastEventId = context.event.event.id;
 
   if (lastDbSyncedEvent
-     && lastDbSyncedEvent.last_event_id > lastEventId) {
-     logger.error('Tried to store an event lower than the one on the database', {
-       lastEventId,
-       lastDbSyncedEvent: JSON.stringify(lastDbSyncedEvent),
-     });
-      mysql.destroy();
-     throw new Error('Event lower than stored one.');
+    && lastDbSyncedEvent.last_event_id > lastEventId) {
+    logger.error('Tried to store an event lower than the one on the database', {
+      lastEventId,
+      lastDbSyncedEvent: JSON.stringify(lastDbSyncedEvent),
+    });
+    mysql.destroy();
+    throw new Error('Event lower than stored one.');
   }
   await dbUpdateLastSyncedEvent(mysql, lastEventId);
 

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -239,7 +239,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       const blockRewardOutput = outputs[0];
 
       // add miner to the miners table
-      if (isDecodedValid(blockRewardOutput.decoded)) {
+      if (isDecodedValid(blockRewardOutput.decoded, ['address'])) {
         await addMiner(mysql, blockRewardOutput.decoded.address, hash);
       }
 


### PR DESCRIPTION
### Motivation

After https://github.com/HathorNetwork/hathor-core/pull/1250, the `decoded` key of `output` and `spent_output` (inputs) is now returning an empty object when the script is unable to be parsed, causing our code to fail because we were expecting it to be null.

### Acceptance Criteria

- We should properly handle empty objects in `decoded`
- We should have a mechanism for checking if all required keys are available in the `decoded` object.

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
