### PR TITLE
fix: address invalid parameter

### DIFF
--- a/packages/wallet-service/package.json
+++ b/packages/wallet-service/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint src/ tests/ --ext .js,.jsx,.ts,.tsx src tests",
     "lint-fix": "eslint src/ tests/ --fix --ext .js,.jsx,.ts,.tsx src tests",
     "check-types": "tsc --noemit --skipLibCheck",
-    "test": "jest -u"
+    "test": "jest"
   },
   "author": "Hathor Labs",
   "license": "MIT",

--- a/packages/wallet-service/package.json
+++ b/packages/wallet-service/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint src/ tests/ --ext .js,.jsx,.ts,.tsx src tests",
     "lint-fix": "eslint src/ tests/ --fix --ext .js,.jsx,.ts,.tsx src tests",
     "check-types": "tsc --noemit --skipLibCheck",
-    "test": "jest"
+    "test": "jest -u"
   },
   "author": "Hathor Labs",
   "license": "MIT",

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -324,12 +324,6 @@ functions:
           method: get
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
-          request:
-            parameters:
-              querystrings:
-                index:
-                  required: false
-                  default: "0"
     warmup:
       walletWarmer:
         enabled: true

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -326,8 +326,10 @@ functions:
           authorizer: ${self:custom.authorizer.walletBearer}
           request:
             parameters:
-              paths:
-                index: false
+              querystrings:
+                index:
+                  required: false
+                  default: "0"
     warmup:
       walletWarmer:
         enabled: true

--- a/packages/wallet-service/src/api/addresses.ts
+++ b/packages/wallet-service/src/api/addresses.ts
@@ -39,7 +39,7 @@ class AddressAtIndexValidator {
     index: Joi.number().min(0).optional(),
   });
 
-  static validate(payload: unknown): { value: AddressAtIndexRequest, error: ValidationError} {
+  static validate(payload: unknown): { value: AddressAtIndexRequest, error: ValidationError } {
     return AddressAtIndexValidator.bodySchema.validate(payload, {
       abortEarly: false, // We want it to return all the errors not only the first
       convert: true, // We need to convert as parameters are sent on the QueryString
@@ -92,7 +92,7 @@ export const checkMine: APIGatewayProxyHandler = middy(walletIdProxyHandler(asyn
 
   await closeDbConnection(mysql);
 
-  const addressBelongMap = sentAddresses.reduce((acc: {string: boolean}, address: string) => {
+  const addressBelongMap = sentAddresses.reduce((acc: { string: boolean }, address: string) => {
     acc[address] = walletAddresses.has(address);
 
     return acc;

--- a/packages/wallet-service/src/api/addresses.ts
+++ b/packages/wallet-service/src/api/addresses.ts
@@ -108,7 +108,7 @@ export const checkMine: APIGatewayProxyHandler = middy(walletIdProxyHandler(asyn
 })).use(cors())
   .use(errorHandler());
 
-/*
+/**
  * Get the addresses of a wallet, allowing an index filter
  * Notice: If the index filter is passed, it will only find addresses
  * that are already in our database, this will not derive new addresses
@@ -127,7 +127,7 @@ export const get: APIGatewayProxyHandler = middy(
       return closeDbAndGetError(mysql, ApiError.WALLET_NOT_READY);
     }
 
-    const { value: body, error } = AddressAtIndexValidator.validate(event.pathParameters || {});
+    const { value: body, error } = AddressAtIndexValidator.validate(event.queryStringParameters || {});
 
     if (error) {
       const details = error.details.map((err) => ({

--- a/packages/wallet-service/src/api/healthcheck.ts
+++ b/packages/wallet-service/src/api/healthcheck.ts
@@ -1,11 +1,11 @@
 import middy from '@middy/core';
 import {
-    Healthcheck,
-    HealthcheckInternalComponent,
-    HealthcheckDatastoreComponent,
-    HealthcheckHTTPComponent,
-    HealthcheckCallbackResponse,
-    HealthcheckStatus,
+  Healthcheck,
+  HealthcheckInternalComponent,
+  HealthcheckDatastoreComponent,
+  HealthcheckHTTPComponent,
+  HealthcheckCallbackResponse,
+  HealthcheckStatus,
 } from '@hathor/healthcheck-lib';
 import { getLatestHeight } from '@src/db';
 import fullnode from '@src/fullnode';
@@ -140,6 +140,6 @@ export const getHealthcheck: APIGatewayProxyHandler = middy(async (event) => {
 
   return {
     statusCode: response.getHttpStatusCode(),
-    body: JSON.stringify(JSON.parse(response.toJson())),
+    body: response.toJson(),
   };
 }).use(errorHandler());

--- a/packages/wallet-service/src/api/healthcheck.ts
+++ b/packages/wallet-service/src/api/healthcheck.ts
@@ -140,6 +140,6 @@ export const getHealthcheck: APIGatewayProxyHandler = middy(async (event) => {
 
   return {
     statusCode: response.getHttpStatusCode(),
-    body: response.toJson(),
+    body: JSON.stringify(JSON.parse(response.toJson())),
   };
 }).use(errorHandler());

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -426,7 +426,7 @@ export const getWalletAddressDetail = async (mysql: ServerlessMysql, walletId: s
       FROM \`address\`
      WHERE \`wallet_id\` = ?
          AND \`address\` = ?`,
-  [walletId, address]);
+    [walletId, address]);
 
   if (results.length > 0) {
     const data = results[0];
@@ -1160,12 +1160,12 @@ export const updateAddressLockedBalance = async (
                 \`unlocked_authorities\` = (unlocked_authorities | ?)
           WHERE \`address\` = ?
             AND \`token_id\` = ?`, [
-          tokenBalance.unlockedAmount,
-          tokenBalance.unlockedAmount,
-          tokenBalance.unlockedAuthorities.toInteger(),
-          address,
-          token,
-        ],
+        tokenBalance.unlockedAmount,
+        tokenBalance.unlockedAmount,
+        tokenBalance.unlockedAuthorities.toInteger(),
+        address,
+        token,
+      ],
       );
 
       // if any authority has been unlocked, we have to refresh the locked authorities
@@ -1201,7 +1201,7 @@ export const updateAddressLockedBalance = async (
              )
            WHERE \`address\` = ?
              AND \`token_id\` = ?`,
-        [address, token, address, token]);
+          [address, token, address, token]);
       }
     }
   }
@@ -1233,7 +1233,7 @@ export const updateWalletLockedBalance = async (
           WHERE \`wallet_id\` = ?
             AND \`token_id\` = ?`,
         [tokenBalance.unlockedAmount, tokenBalance.unlockedAmount,
-          tokenBalance.unlockedAuthorities.toInteger(), walletId, token],
+        tokenBalance.unlockedAuthorities.toInteger(), walletId, token],
       );
 
       // if any authority has been unlocked, we have to refresh the locked authorities
@@ -1418,7 +1418,7 @@ export const getWalletTokens = async (
   );
 
   for (const result of results) {
-    tokenList.push(<string> result.token_id);
+    tokenList.push(<string>result.token_id);
   }
 
   return tokenList;
@@ -1464,7 +1464,7 @@ LEFT OUTER JOIN transaction ON transaction.tx_id = wallet_tx_history.tx_id
   ORDER BY wallet_tx_history.timestamp
       DESC
      LIMIT ?, ?`,
-  [walletId, tokenId, skip, count]);
+    [walletId, tokenId, skip, count]);
 
   for (const result of results) {
     const tx: TxTokenBalance = {
@@ -2074,7 +2074,7 @@ export const markUtxosAsVoided = async (
     UPDATE \`tx_output\`
        SET \`voided\` = TRUE
      WHERE \`tx_id\` IN (?)`,
-  [txIds]);
+    [txIds]);
 };
 
 /**
@@ -2812,7 +2812,7 @@ export const existsPushDevice = async (
   mysql: ServerlessMysql,
   deviceId: string,
   walletId: string,
-) : Promise<boolean> => {
+): Promise<boolean> => {
   const [{ count }] = await mysql.query(
     `
     SELECT COUNT(1) as \`count\`
@@ -2820,7 +2820,7 @@ export const existsPushDevice = async (
      WHERE device_id = ?
        AND wallet_id = ?`,
     [deviceId, walletId],
-  ) as unknown as Array<{count}>;
+  ) as unknown as Array<{ count }>;
 
   return count > 0;
 };
@@ -2840,7 +2840,7 @@ export const registerPushDevice = async (
     enablePush: boolean,
     enableShowAmounts: boolean,
   },
-) : Promise<void> => {
+): Promise<void> => {
   await mysql.query(
     `
     INSERT
@@ -2889,7 +2889,7 @@ export const updatePushDevice = async (
     enablePush: boolean,
     enableShowAmounts: boolean,
   },
-) : Promise<void> => {
+): Promise<void> => {
   await mysql.query(
     `
     UPDATE \`push_devices\`
@@ -2912,7 +2912,7 @@ export const unregisterPushDevice = async (
   mysql: ServerlessMysql,
   deviceId: string,
   walletId?: string,
-) : Promise<void> => {
+): Promise<void> => {
   if (walletId) {
     await mysql.query(
       `
@@ -2964,8 +2964,8 @@ export const getTransactionById = async (
         WHERE transaction.tx_id = ?
           AND transaction.voided = FALSE
           AND wallet_tx_history.wallet_id = ?`,
-  // eslint-disable-next-line camelcase
-  [txId, walletId]) as Array<{tx_id, timestamp, version, voided, weight, balance, token_id, name, symbol }>;
+    // eslint-disable-next-line camelcase
+    [txId, walletId]) as Array<{ tx_id, timestamp, version, voided, weight, balance, token_id, name, symbol }>;
 
   const txTokens = [];
   result.forEach((eachTxToken) => {
@@ -2995,7 +2995,7 @@ export const getTransactionById = async (
 export const existsWallet = async (
   mysql: ServerlessMysql,
   walletId: string,
-) : Promise<boolean> => {
+): Promise<boolean> => {
   const [{ count }] = (await mysql.query(
     `
     SELECT COUNT(1) as \`count\`
@@ -3016,15 +3016,15 @@ export const existsWallet = async (
 export const getPushDevice = async (
   mysql: ServerlessMysql,
   deviceId: string,
-) : Promise<PushDevice|null> => {
+): Promise<PushDevice | null> => {
   const [pushDevice] = await mysql.query(
     `
     SELECT *
       FROM \`push_devices\`
      WHERE device_id = ?`,
     [deviceId],
-  // eslint-disable-next-line camelcase
-  ) as Array<{wallet_id, device_id, push_provider, enable_push, enable_show_amounts}>;
+    // eslint-disable-next-line camelcase
+  ) as Array<{ wallet_id, device_id, push_provider, enable_push, enable_show_amounts }>;
 
   if (!pushDevice) {
     return null;
@@ -3049,7 +3049,7 @@ export const getPushDevice = async (
 export const getPushDeviceSettingsList = async (
   mysql: ServerlessMysql,
   walletIdList: string[],
-) : Promise<PushDeviceSettings[]> => {
+): Promise<PushDeviceSettings[]> => {
   const pushDeviceSettingsResult = await mysql.query(
     `
     SELECT wallet_id
@@ -3059,8 +3059,8 @@ export const getPushDeviceSettingsList = async (
       FROM \`push_devices\`
      WHERE wallet_id in (?)`,
     [walletIdList],
-  // eslint-disable-next-line camelcase
-  ) as Array<{wallet_id, device_id, enable_push, enable_show_amounts}>;
+    // eslint-disable-next-line camelcase
+  ) as Array<{ wallet_id, device_id, enable_push, enable_show_amounts }>;
 
   const pushDeviceSettignsList = pushDeviceSettingsResult.map((each) => ({
     walletId: each.wallet_id,
@@ -3121,7 +3121,7 @@ export const getTokenSymbols = async (
   );
 
   if (results.length === 0) return null;
-  return results.reduce((prev: Record<string, string>, token: { id: string, symbol: string}) => {
+  return results.reduce((prev: Record<string, string>, token: { id: string, symbol: string }) => {
     // eslint-disable-next-line no-param-reassign
     prev[token.id] = token.symbol;
     return prev;
@@ -3176,7 +3176,7 @@ export const getAddressAtIndex = async (
      WHERE \`index\` = ?
        AND \`wallet_id\` = ?
      LIMIT 1`,
-    [walletId, index],
+    [index, walletId],
   );
 
   if (addresses.length <= 0) {

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -188,7 +188,7 @@ test('GET /addresses', async () => {
   expect(result.statusCode).toBe(STATUS_CODE_TABLE[ApiError.INVALID_PAYLOAD]);
   expect(returnBody.details).toHaveLength(1);
   expect(returnBody.details[0].message)
-    .toMatchInlineSnapshot('"\"index\" must be greater than or equal to 0"');
+    .toMatchInlineSnapshot('"index" must be greater than or equal to 0');
 
   // we should be able to filter for a specific index
   event = makeGatewayEventWithAuthorizer('my-wallet', {
@@ -2257,4 +2257,77 @@ describe('GET /health', () => {
       }
     });
   });
+});
+
+test('GET /addresses (query string index parameter)', async () => {
+  expect.hasAssertions();
+
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
+
+  const addresses = [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0 },
+  ];
+
+  await addToAddressTable(mysql, addresses);
+
+  // 1. No index parameter (should return all addresses)
+  let event = makeGatewayEventWithAuthorizer('my-wallet', null);
+  let result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  let returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.success).toBe(true);
+  expect(returnBody.addresses).toHaveLength(2);
+
+  // 2. index as a string (should return the address at that index)
+  event = makeGatewayEventWithAuthorizer('my-wallet', { index: '1' });
+  result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.success).toBe(true);
+  expect(returnBody.addresses).toHaveLength(1);
+  expect(returnBody.addresses[0].index).toBe(1);
+
+  // 3. index as a number (should return the address at that index)
+  event = makeGatewayEventWithAuthorizer('my-wallet', { index: '0' });
+  result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.success).toBe(true);
+  expect(returnBody.addresses).toHaveLength(1);
+  expect(returnBody.addresses[0].index).toBe(0);
+
+  // 4. index is invalid (non-numeric)
+  event = makeGatewayEventWithAuthorizer('my-wallet', { index: 'not-a-number' });
+  result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(400);
+  expect(returnBody.success).toBe(false);
+  expect(returnBody.error).toBe(ApiError.INVALID_PAYLOAD);
+  expect(returnBody.details[0].message).toMatch(/must be a number/);
+
+  // 5. index is negative (should error)
+  event = makeGatewayEventWithAuthorizer('my-wallet', { index: '-1' });
+  result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(400);
+  expect(returnBody.success).toBe(false);
+  expect(returnBody.error).toBe(ApiError.INVALID_PAYLOAD);
+  expect(returnBody.details[0].message).toMatch(/greater than or equal to 0/);
+
+  // 6. index not found (should return ADDRESS_NOT_FOUND)
+  event = makeGatewayEventWithAuthorizer('my-wallet', { index: '999' });
+  result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(404);
+  expect(returnBody.success).toBe(false);
+  expect(returnBody.error).toBe(ApiError.ADDRESS_NOT_FOUND);
 });

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -189,7 +189,7 @@ test('GET /addresses', async () => {
   expect(result.statusCode).toBe(STATUS_CODE_TABLE[ApiError.INVALID_PAYLOAD]);
   expect(returnBody.details).toHaveLength(1);
   expect(returnBody.details[0].message.trim())
-    .toMatchInlineSnapshot(`"index" must be greater than or equal to 0`);
+    .toMatchInlineSnapshot(`""index" must be greater than or equal to 0"`);
 
   // we should be able to filter for a specific index
   event = makeGatewayEventWithAuthorizer('my-wallet', {

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -188,8 +188,8 @@ test('GET /addresses', async () => {
 
   expect(result.statusCode).toBe(STATUS_CODE_TABLE[ApiError.INVALID_PAYLOAD]);
   expect(returnBody.details).toHaveLength(1);
-  expect(returnBody.details[0].message)
-    .toMatchInlineSnapshot('"index" must be greater than or equal to 0');
+  expect(returnBody.details[0].message.trim())
+    .toMatchInlineSnapshot(`"index" must be greater than or equal to 0`);
 
   // we should be able to filter for a specific index
   event = makeGatewayEventWithAuthorizer('my-wallet', {
@@ -1681,7 +1681,7 @@ test('GET /version', async () => {
     genesis_block_hash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     genesis_tx1_hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
     genesis_tx2_hash: 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
-    native_token: { name: 'Hathor', symbol: 'HTR'},
+    native_token: { name: 'Hathor', symbol: 'HTR' },
   };
   const returnData = convertApiVersionData(mockData);
 

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -2292,6 +2292,16 @@ test('GET /addresses (query string index parameter)', async () => {
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody.addresses).toHaveLength(2);
+  expect(returnBody.addresses).toContainEqual({
+    address: addresses[0].address,
+    index: addresses[0].index,
+    transactions: addresses[0].transactions,
+  });
+  expect(returnBody.addresses).toContainEqual({
+    address: addresses[1].address,
+    index: addresses[1].index,
+    transactions: addresses[1].transactions,
+  });
 
   // 2. index as a string (should return the address at that index)
   event = makeGatewayEventWithAuthorizer('my-wallet', { index: '1' });


### PR DESCRIPTION
### Motivation

The motivation for these changes was to correct the handling of the `index` parameter in the `/addresses` API endpoint.

Previously, the `index` was incorrectly fetched from path parameters, causing all requests with `index` to be ignored and a list of addresses instead of the queried one

---

### Acceptance Criteria

- The `/addresses` endpoint should accept the `index` parameter as a query string parameter, not as a path parameter.
- If `index` is omitted, all addresses for the wallet should be returned.
- If a valid `index` is provided, only the address at that index should be returned.
- The serverless configuration should reflect the new query string parameter for `index`

---

### Checklist

- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.