### PR TITLE
chore: remove error handler middleware from authorization lambda

### DIFF
--- a/packages/wallet-service/src/api/auth.ts
+++ b/packages/wallet-service/src/api/auth.ts
@@ -235,5 +235,4 @@ export const bearerAuthorizer: APIGatewayTokenAuthorizerHandler = middy(async (e
   }
 
   return _generatePolicy(walletId, 'Deny', event.methodArn, logger);
-}).use(cors())
-  .use(errorHandler());
+}).use(cors());


### PR DESCRIPTION
### Motivation

Authorization lambda does not require a middleware for error handling.
The authorization event type is also different from the http event so the error handler may crash.

### Acceptance Criteria

- remove http error handler from authorization lambda

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
