### PR TITLE
fix: we should await mark utxos with proposal id to prevent a race condition

### DIFF
--- a/packages/wallet-service/src/api/txProposalCreate.ts
+++ b/packages/wallet-service/src/api/txProposalCreate.ts
@@ -118,7 +118,7 @@ export const create = middy(walletIdProxyHandler(async (walletId, event) => {
 
   // mark utxos with tx-proposal id
   const txProposalId = uuidv4();
-  markUtxosWithProposalId(mysql, txProposalId, inputUtxos);
+  await markUtxosWithProposalId(mysql, txProposalId, inputUtxos);
 
   await createTxProposal(mysql, txProposalId, walletId, now);
 


### PR DESCRIPTION
### Motivation

We should wait until the utxos are marked as spent before returning a success in the tx proposal creation. This was most likely creating a race condition where we were attempting to clear the tx proposal from utxos but they weren't even marked yet and another potential issue where the lambda would kill the connection before the query even runs.

### Acceptance Criteria

- We should await the `utxo` marking in the `createTxProposal` lambda

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
