### PR TITLE
fix: invalid assert in release tx proposal utxos

### DIFF
--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -1875,18 +1875,12 @@ export const releaseTxProposalUtxos = async (
   mysql: ServerlessMysql,
   txProposalIds: string[],
 ): Promise<void> => {
-  const result: OkPacket = await mysql.query(
+  await mysql.query(
     `UPDATE \`tx_output\`
         SET \`tx_proposal\` = NULL,
             \`tx_proposal_index\` = NULL
       WHERE \`tx_proposal\` IN (?)`,
     [txProposalIds],
-  );
-
-  assert.strictEqual(
-    result.affectedRows,
-    txProposalIds.length,
-    'Not all utxos were correctly updated',
   );
 };
 

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -1602,8 +1602,6 @@ test('createTxProposal, updateTxProposal, getTxProposal, countUnsentTxProposals,
     weight: 0,
   }]);
 
-  expect(txOutputs.map((txOutput) => txOutput.txProposalId)).toStrictEqual([txProposalId1, txProposalId2, txProposalId3]);
-
   // Check that txProposalId is null after releasing
   txOutputs.forEach((txOutput) => {
     expect(txOutput.txProposalId).toBeNull();

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -84,6 +84,7 @@ import {
   cleanupVoidedTx,
   checkTxWasVoided,
   getWalletTxHistory,
+  getTxOutputs,
 } from '@src/db';
 import * as Db from '@src/db';
 import { cleanUnsentTxProposalsUtxos } from '@src/db/cronRoutines';
@@ -1580,7 +1581,33 @@ test('createTxProposal, updateTxProposal, getTxProposal, countUnsentTxProposals,
   // Release txProposalUtxos should properly release the utxos. This method will throw an error if the
   // updated count is different from the sent tx proposals count.
   await releaseTxProposalUtxos(mysql, [txProposalId1, txProposalId2, txProposalId3]);
-  await expect(releaseTxProposalUtxos(mysql, ['invalid-tx-proposal'])).rejects.toMatchInlineSnapshot('[AssertionError: Not all utxos were correctly updated]');
+
+  const txOutputs = await getTxOutputs(mysql, [{
+    txId: 'tx1',
+    timestamp: 0,
+    version: 0,
+    voided: false,
+    weight: 0
+  }, {
+    txId: 'tx2',
+    timestamp: 0,
+    version: 0,
+    voided: false,
+    weight: 0
+  }, {
+    txId: 'tx3',
+    timestamp: 0,
+    version: 0,
+    voided: false,
+    weight: 0,
+  }]);
+
+  expect(txOutputs.map((txOutput) => txOutput.txProposalId)).toStrictEqual([txProposalId1, txProposalId2, txProposalId3]);
+
+  // Check that txProposalId is null after releasing
+  txOutputs.forEach((txOutput) => {
+    expect(txOutput.txProposalId).toBeNull();
+  });
 });
 
 test('updateVersionData', async () => {


### PR DESCRIPTION
### Acceptance Criteria

- We should remove the assert validating the number of `tx_outputs` in the wallet-service when releasing the tx proposals

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
