### PR TITLE
chore: added htr token seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,15 @@ AWS_SECRET_ACCESS_KEY="..."
 ```
 
 These are used for communicating with the alert SQS
+
+## Reseeding the HTR Token After Database Reset
+
+If you need to reset the database (for example, to re-sync it from scratch), you must re-insert the HTR token into the `token` table. This is handled by a seed script that will automatically calculate the correct transaction count for HTR based on the current state of the database.
+
+To run the seed and add the HTR token again, use the following command:
+
+```
+yarn dlx sequelize-cli db:seed:all
+```
+
+This will ensure the HTR token is present and its transaction count is accurate, even if the database already contains transactions for HTR.

--- a/README.md
+++ b/README.md
@@ -65,3 +65,38 @@ yarn dlx sequelize-cli db:seed:all
 ```
 
 This will ensure the HTR token is present and its transaction count is accurate, even if the database already contains transactions for HTR.
+
+## Database Cleanup
+
+If you need to re-sync the database from scratch, you must stop the daemon and clean all database tables before starting the sync process again. This ensures there is no leftover data that could cause inconsistencies.
+
+Below is a SQL script you can use to clean up (truncate) all tables in the database. This script disables foreign key checks, truncates all tables, and then re-enables foreign key checks. **Be careful: this will delete all data in the database.**
+
+```
+SET FOREIGN_KEY_CHECKS = 0;
+
+TRUNCATE TABLE address_balance;
+TRUNCATE TABLE address_tx_history;
+TRUNCATE TABLE address;
+TRUNCATE TABLE miner;
+TRUNCATE TABLE push_devices;
+TRUNCATE TABLE sync_metadata;
+TRUNCATE TABLE token;
+TRUNCATE TABLE transaction;
+TRUNCATE TABLE tx_output;
+TRUNCATE TABLE tx_proposal;
+TRUNCATE TABLE wallet;
+TRUNCATE TABLE wallet_balance;
+TRUNCATE TABLE wallet_tx_history;
+TRUNCATE TABLE version_data;
+
+SET FOREIGN_KEY_CHECKS = 1;
+```
+
+To use this script, save it as `cleanup.sql` and run:
+
+```
+mysql -u <user> -p <database> < cleanup.sql
+```
+
+After cleaning the database, you can reseed the HTR token as described in the previous section.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ These are used for communicating with the alert SQS
 
 If you need to reset the database (for example, to re-sync it from scratch), you must re-insert the HTR token into the `token` table. This is handled by a seed script that will automatically calculate the correct transaction count for HTR based on the current state of the database.
 
+To run the seed and add the HTR token again, you must have a `.env` file in your project root with all required environment variables set. At a minimum, you should include:
+
+```
+NODE_ENV=production
+DB_ENDPOINT=
+DB_NAME=
+DB_USER=
+DB_PORT=
+DB_PASS=
+```
+
+Adjust the values as needed for your environment. For production, ensure `NODE_ENV=production` is set.
+
 To run the seed and add the HTR token again, use the following command:
 
 ```

--- a/db/seeders/20250416132150-add-htr-token.js
+++ b/db/seeders/20250416132150-add-htr-token.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    // Count unique transactions for HTR
+    const [results] = await queryInterface.sequelize.query(
+      "SELECT COUNT(DISTINCT tx_id) AS count FROM tx_output WHERE token_id = '00'"
+    );
+    const htrTxCount = results[0]?.count || 0;
+
+    // Insert HTR token with the correct transaction count
+    await queryInterface.bulkInsert('token', [{
+      id: '00',
+      name: 'Hathor',
+      symbol: 'HTR',
+      transactions: htrTxCount,
+    }]);
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.bulkDelete('token', { id: '00' });
+  }
+};


### PR DESCRIPTION
### Motivation

Previously, the HTR token was inserted via a migration, which could lead to issues if the database was reset or cleaned, as the migration would not re-insert the token. Additionally, there was no clear, documented process for cleaning up the database and reseeding essential data.

This PR introduces a proper seed script for the HTR token that dynamically calculates its transaction count, and updates the documentation to provide clear instructions for database cleanup and reseeding.

### Acceptance Criteria

- [x] A seed script exists to insert the HTR token with the correct transaction count based on current database state.
- [x] The README includes clear instructions for reseeding the HTR token after a database reset.
- [x] The README includes a section and SQL script for safely cleaning up (truncating) all tables in the database, handling foreign key constraints.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.