### PR TITLE
feat: token version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,33 @@ Refer to https://github.com/HathorNetwork/rfcs/blob/master/projects/wallet-servi
 ### Local environment
 
 #### System dependencies
+```
+Node: 20x
+yarn: v4 (yarn-berry)
+```
 
-You need nodejs installed on your enviroment, we suggest the latest Active LTS version (v18.x.x).
+#### Install nix (preferred)
+
+For a better developer experience we suggest nix usage for mananing the enviroment. Visit this [link](https://nixos.org/download/#download-nix) to download it.
+
+To enable the commands `nix develop` and `nix build` using flakes, add the following to your `/etc/nix/nix.conf` file:
+
+```
+experimental-features = nix-command flakes
+```
 
 #### Clone the project and install dependencies
-
-`git clone https://github.com/HathorNetwork/hathor-wallet-service-sync_daemon.git`
-
-`npm install`
+```sh
+$ git clone https://github.com/HathorNetwork/hathor-wallet-service-sync_daemon.git
+```
+To initialize nix dev environment:
+```sh
+$ nix develop
+```
+then, install the depencies: 
+```sh
+yarn
+```
 
 #### Add env variables or an .env file to the repository:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Refer to https://github.com/HathorNetwork/rfcs/blob/master/projects/wallet-servi
 ### Local environment
 
 #### System dependencies
+
 ```
 Node: 20x
 yarn: v4 (yarn-berry)
@@ -23,14 +24,19 @@ experimental-features = nix-command flakes
 ```
 
 #### Clone the project and install dependencies
+
 ```sh
 $ git clone https://github.com/HathorNetwork/hathor-wallet-service-sync_daemon.git
 ```
+
 To initialize nix dev environment:
+
 ```sh
 $ nix develop
 ```
-then, install the depencies: 
+
+then, install the depencies:
+
 ```sh
 yarn
 ```
@@ -72,6 +78,16 @@ AWS_SECRET_ACCESS_KEY="..."
 ```
 
 These are used for communicating with the alert SQS
+
+#### Docker images
+
+Some packages depends on some docker images. To build them you'll need to have Hathor VPN access configured, check this [link](https://github.com/HathorNetwork/ops-tools/blob/master/terraform/wireguard-vpn/SOP.md#adding-a-new-client-to-the-vpn) for it.
+
+#### Db initialize
+
+Before running the tests, make sure your database is already initialize by running the migrations.
+
+`nix develop . -c yarn sequelize db:migrate`
 
 ## Reseeding the HTR Token After Database Reset
 

--- a/db/migrations/20250529233113-add-token-version.js
+++ b/db/migrations/20250529233113-add-token-version.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    queryInterface.addColumn("token", "version", {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    queryInterface.removeColumn("token", "version");
+  },
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/wallet-service"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "nohoist": [
     "**"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc --declaration",
+    "check-types": "tsc --noemit --skipLibCheck",
     "test": "jest --runInBand --collectCoverage --detectOpenHandles --forceExit"
   },
   "peerDependencies": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -14,6 +14,7 @@
     "build": "tsc -b",
     "start": "node dist/index.js",
     "watch": "tsc -w",
+    "check-types": "tsc --noemit --skipLibCheck",
     "test_images_up": "docker compose -f ./__tests__/integration/scripts/docker-compose.yml up -d",
     "test_images_down": "docker compose -f ./__tests__/integration/scripts/docker-compose.yml down",
     "test_images_integration": "jest --config ./jest_integration.config.js --runInBand --forceExit",

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -20,6 +20,7 @@ import {
   Miner,
   TokenSymbolsRow,
   MaxAddressIndexRow,
+  TokenInfoVersion,
 } from '../types';
 import {
   TxInput,
@@ -974,14 +975,16 @@ export const mapDbResultToDbTxOutput = (result: TxOutputRow): DbTxOutput => ({
  * @param tokenId - The token's id
  * @param tokenName - The token's name
  * @param tokenSymbol - The token's symbol
+ * @param tokenVersion - The token's version
  */
 export const storeTokenInformation = async (
   mysql: MysqlConnection,
   tokenId: string,
   tokenName: string,
   tokenSymbol: string,
+  tokenVersion?: TokenInfoVersion | null
 ): Promise<void> => {
-  const entry = { id: tokenId, name: tokenName, symbol: tokenSymbol };
+  const entry = { id: tokenId, name: tokenName, symbol: tokenSymbol, version: tokenVersion };
   await mysql.query(
     'INSERT INTO `token` SET ?',
     [entry],
@@ -1462,7 +1465,12 @@ export const getTokenInformation = async (
 
   if (results.length === 0) return null;
 
-  return new TokenInfo(tokenId, results[0].name as string, results[0].symbol as string);
+  return new TokenInfo({
+    id: tokenId,
+    name: results[0].name as string,
+    symbol: results[0].symbol as string,
+    version: results[0].version as (TokenInfoVersion | null),
+  });
 };
 
 /**

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -196,6 +196,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       tokens,
       token_name,
       token_symbol,
+      token_info_version,
       parents,
     } = fullNodeData;
 
@@ -258,7 +259,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
       if (!token_name || !token_symbol) {
         throw new Error('Processed a token creation event but it did not come with token name and symbol');
       }
-      await storeTokenInformation(mysql, hash, token_name, token_symbol);
+      await storeTokenInformation(mysql, hash, token_name, token_symbol, token_info_version);
     }
 
     // check if any of the inputs are still marked as locked and update tables accordingly.

--- a/packages/daemon/src/types/db.ts
+++ b/packages/daemon/src/types/db.ts
@@ -119,6 +119,7 @@ export interface TokenInformationRow extends RowDataPacket {
   name: string;
   symbol: string;
   transactions: number;
+  version?: number | null;
   created_at: number;
   updated_at: number;
 }

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -85,6 +85,7 @@ export type StandardFullNodeEvent = FullNodeEventBase & {
       tokens: string[];
       token_name: null | string;
       token_symbol: null | string;
+      token_info_version: null | number;
       signal_bits: number;
       metadata: {
         hash: string;

--- a/packages/daemon/src/types/token.ts
+++ b/packages/daemon/src/types/token.ts
@@ -5,9 +5,26 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { constants } from '@hathor/wallet-lib';
+import { constants } from "@hathor/wallet-lib";
 
-export class TokenInfo {
+export enum TokenInfoVersion {
+  DEPOSIT = 1,
+
+  FEE = 2,
+}
+
+export interface ITokenInfo {
+  id: string;
+  name: string;
+  symbol: string;
+  version?: TokenInfoVersion | null;
+}
+
+export interface ITokenInfoOptions extends ITokenInfo {
+  transactions?: number;
+}
+
+export class TokenInfo implements ITokenInfo {
   id: string;
 
   name: string;
@@ -16,11 +33,14 @@ export class TokenInfo {
 
   transactions: number;
 
-  constructor(id: string, name: string, symbol: string, transactions?: number) {
+  version?: TokenInfoVersion | null;
+
+  constructor({ id, name, symbol, version, transactions }: ITokenInfoOptions) {
     this.id = id;
     this.name = name;
     this.symbol = symbol;
     this.transactions = transactions || 0;
+    this.version = version || TokenInfoVersion.DEPOSIT;
 
     // XXX: get config from settings?
     const hathorConfig = constants.DEFAULT_NATIVE_TOKEN_CONFIG;
@@ -28,14 +48,16 @@ export class TokenInfo {
     if (this.id === constants.NATIVE_TOKEN_UID) {
       this.name = hathorConfig.name;
       this.symbol = hathorConfig.symbol;
+      this.version = null;
     }
   }
 
-  toJSON(): Record<string, unknown> {
+  toJSON(): ITokenInfo {
     return {
       id: this.id,
       name: this.name,
       symbol: this.symbol,
+      version: this.version,
     };
   }
 }

--- a/packages/daemon/tsconfig.json
+++ b/packages/daemon/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "ES2022",
     "module": "CommonJS",
     "sourceMap": true,

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -164,7 +164,23 @@ export interface TokenBalance {
   transactions: number;
 }
 
-export class TokenInfo {
+export enum TokenInfoVersion {
+  DEPOSIT = 1,
+  FEE = 2
+}
+
+export interface ITokenInfo {
+  id: string;
+  name: string;
+  symbol: string;
+  version?: TokenInfoVersion | null;
+}
+
+export interface ITokenInfoOptions extends ITokenInfo {
+  transactions?: number
+}
+
+export class TokenInfo implements ITokenInfo {
   id: string;
 
   name: string;
@@ -173,25 +189,30 @@ export class TokenInfo {
 
   transactions: number;
 
-  constructor(id: string, name: string, symbol: string, transactions?: number) {
+  version: TokenInfoVersion | null; // HTR is undefined
+
+  constructor({ id, name, symbol, transactions, version }: ITokenInfoOptions) {
     this.id = id;
     this.name = name;
     this.symbol = symbol;
     this.transactions = transactions || 0;
+    this.version = version || TokenInfoVersion.DEPOSIT;
 
     const hathorConfig = hathorLib.constants.DEFAULT_NATIVE_TOKEN_CONFIG;
 
     if (this.id === hathorLib.constants.NATIVE_TOKEN_UID) {
       this.name = hathorConfig.name;
       this.symbol = hathorConfig.symbol;
+      this.version = null;
     }
   }
 
-  toJSON(): Record<string, unknown> {
+  toJSON(): ITokenInfo {
     return {
       id: this.id,
       name: this.name,
       symbol: this.symbol,
+      version: this.version
     };
   }
 }

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -32,7 +32,7 @@ import * as Db from '@src/db';
 import { ApiError } from '@src/api/errors';
 import { closeDbConnection, getDbConnection, getUnixTimestamp, getWalletId } from '@src/utils';
 import { STATUS_CODE_TABLE } from '@src/api/utils';
-import { WalletStatus, FullNodeApiVersionResponse } from '@src/types';
+import { WalletStatus, FullNodeApiVersionResponse, TokenInfoVersion } from '@src/types';
 import { walletUtils, addressUtils, constants, network, HathorWalletServiceWallet } from '@hathor/wallet-lib';
 import bitcore from 'bitcore-lib';
 import {
@@ -1464,12 +1464,12 @@ test('GET /wallet/tokens/token_id/details', async () => {
   expect(returnBody.details[0]).toStrictEqual({ message: '"token_id" is required', path: ['token_id'] });
 
   // add tokens
-  const token1 = { id: TX_IDS[1], name: 'MyToken1', symbol: 'MT1' };
-  const token2 = { id: TX_IDS[2], name: 'MyToken2', symbol: 'MT2' };
+  const token1 = { id: TX_IDS[1], name: 'MyToken1', symbol: 'MT1', version: TokenInfoVersion.DEPOSIT };
+  const token2 = { id: TX_IDS[2], name: 'MyToken2', symbol: 'MT2', version: TokenInfoVersion.DEPOSIT };
 
   await addToTokenTable(mysql, [
-    { id: token1.id, name: token1.name, symbol: token1.symbol, transactions: 0 },
-    { id: token2.id, name: token2.name, symbol: token2.symbol, transactions: 0 },
+    { id: token1.id, name: token1.name, symbol: token1.symbol, transactions: 0, version: token1.version },
+    { id: token2.id, name: token2.name, symbol: token2.symbol, transactions: 0, version: token2.version },
   ]);
 
   await addToUtxoTable(mysql, [{

--- a/packages/wallet-service/tests/commons.test.ts
+++ b/packages/wallet-service/tests/commons.test.ts
@@ -17,6 +17,7 @@ import {
   Block,
   FullNodeApiVersionResponse,
   TxOutputWithIndex,
+  TokenInfoVersion,
 } from '@src/types';
 import fullnode from '@src/fullnode';
 import {
@@ -649,8 +650,9 @@ describe('getWalletBalancesForTx', () => {
       id: 'token1',
       name: 'Token 1',
       symbol: 'T1',
+      version: TokenInfoVersion.DEPOSIT
     };
-    await storeTokenInformation(mysql, token1.id, token1.name, token1.symbol);
+    await storeTokenInformation(mysql, token1.id, token1.name, token1.symbol, token1.version);
 
     // transaction base
     const utxos = [
@@ -733,8 +735,9 @@ describe('getWalletBalancesForTx', () => {
       id: 'token1',
       name: 'Token 1',
       symbol: 'T1',
+      version: TokenInfoVersion.DEPOSIT
     };
-    await storeTokenInformation(mysql, token1.id, token1.name, token1.symbol);
+    await storeTokenInformation(mysql, token1.id, token1.name, token1.symbol, token1.version);
 
     // instantiate token balance
     const balanceToken1 = {
@@ -862,14 +865,16 @@ describe('getWalletBalancesForTx', () => {
         id: 'token1',
         name: 'Token 1',
         symbol: 'T1',
+        version: TokenInfoVersion.DEPOSIT
       };
-      await storeTokenInformation(mysql, token1.id, token1.name, token1.symbol);
+      await storeTokenInformation(mysql, token1.id, token1.name, token1.symbol, token1.version);
       const token2 = {
         id: 'token2',
         name: 'Token 2',
         symbol: 'T2',
+        version: TokenInfoVersion.DEPOSIT
       };
-      await storeTokenInformation(mysql, token2.id, token2.name, token2.symbol);
+      await storeTokenInformation(mysql, token2.id, token2.name, token2.symbol, token2.version);
 
       // instantiate token balance
       const balanceToken1 = {
@@ -1032,14 +1037,16 @@ describe('getWalletBalancesForTx', () => {
         id: 'token1',
         name: 'Token 1',
         symbol: 'T1',
+        version: TokenInfoVersion.DEPOSIT
       };
-      await storeTokenInformation(mysql, token1.id, token1.name, token1.symbol);
+      await storeTokenInformation(mysql, token1.id, token1.name, token1.symbol, token1.version);
       const token2 = {
         id: 'token2',
         name: 'Token 2',
         symbol: 'T2',
+        version: TokenInfoVersion.DEPOSIT
       };
-      await storeTokenInformation(mysql, token2.id, token2.name, token2.symbol);
+      await storeTokenInformation(mysql, token2.id, token2.name, token2.symbol, token2.version);
 
       // instantiate token balance
       const balanceToken1 = {

--- a/packages/wallet-service/tests/txPushNotificationRequested.test.ts
+++ b/packages/wallet-service/tests/txPushNotificationRequested.test.ts
@@ -7,7 +7,7 @@ import {
   buildWallet,
 } from '@tests/utils';
 import { handleRequest, pushNotificationMessage } from '@src/api/txPushNotificationRequested';
-import { StringMap, WalletBalanceValue, PushProvider, SendNotificationToDevice } from '@src/types';
+import { StringMap, WalletBalanceValue, PushProvider, SendNotificationToDevice, TokenInfoVersion } from '@src/types';
 import { PushNotificationUtils } from '@src/utils/pushnotification.utils';
 import { registerPushDevice, storeTokenInformation } from '@src/db';
 import { Context } from 'aws-lambda';
@@ -28,6 +28,7 @@ const buildEvent = (walletId, txId, walletBalanceForTx?): StringMap<WalletBalanc
       {
         tokenId: 'token2',
         tokenSymbol: 'T2',
+        tokenVersion: TokenInfoVersion.DEPOSIT,
         lockExpires: null,
         lockedAmount: 0,
         lockedAuthorities: {
@@ -45,6 +46,7 @@ const buildEvent = (walletId, txId, walletBalanceForTx?): StringMap<WalletBalanc
       {
         tokenId: 'token1',
         tokenSymbol: 'T1',
+        tokenVersion: TokenInfoVersion.DEPOSIT,
         lockExpires: null,
         lockedAmount: 0,
         lockedAuthorities: {
@@ -89,7 +91,7 @@ describe('success', () => {
       enableShowAmounts: false,
     };
 
-    await storeTokenInformation(mysql, 'token1', 'token1', 'T1');
+    await storeTokenInformation(mysql, 'token1', 'token1', 'T1', TokenInfoVersion.DEPOSIT);
 
     await registerPushDevice(mysql, pushDevice);
 
@@ -141,8 +143,8 @@ describe('success', () => {
       enableShowAmounts: false,
     };
 
-    await storeTokenInformation(mysql, 'token1', 'token1', 'T1');
-    await storeTokenInformation(mysql, 'token2', 'token2', 'T2');
+    await storeTokenInformation(mysql, 'token1', 'token1', 'T1', TokenInfoVersion.DEPOSIT);
+    await storeTokenInformation(mysql, 'token2', 'token2', 'T2', TokenInfoVersion.DEPOSIT);
 
     await registerPushDevice(mysql, pushDevice);
 
@@ -228,7 +230,7 @@ describe('success', () => {
     };
     await registerPushDevice(mysql, pushDevice);
 
-    await storeTokenInformation(mysql, 'token2', 'token2', 'T2');
+    await storeTokenInformation(mysql, 'token2', 'token2', 'T2', TokenInfoVersion.DEPOSIT);
 
     const sendEvent = buildEvent(walletId, txId, [
       {
@@ -274,10 +276,10 @@ describe('success', () => {
         enableShowAmounts: true,
       };
       await registerPushDevice(mysql, pushDevice);
-      await storeTokenInformation(mysql, 'token1', 'token1', 'T1');
-      await storeTokenInformation(mysql, 'token2', 'token2', 'T2');
-      await storeTokenInformation(mysql, 'token3', 'token3', 'T3');
-      await storeTokenInformation(mysql, 'token4', 'token4', 'T4');
+      await storeTokenInformation(mysql, 'token1', 'token1', 'T1', TokenInfoVersion.DEPOSIT);
+      await storeTokenInformation(mysql, 'token2', 'token2', 'T2', TokenInfoVersion.DEPOSIT);
+      await storeTokenInformation(mysql, 'token3', 'token3', 'T3', TokenInfoVersion.DEPOSIT);
+      await storeTokenInformation(mysql, 'token4', 'token4', 'T4', TokenInfoVersion.DEPOSIT);
     });
 
     it('token balance with 1 token', async () => {

--- a/packages/wallet-service/tests/types.test.ts
+++ b/packages/wallet-service/tests/types.test.ts
@@ -1,4 +1,5 @@
-import { Authorities, Balance, TokenBalanceMap } from '@src/types';
+import { NATIVE_TOKEN_UID } from '@hathor/wallet-lib/lib/constants';
+import { Authorities, Balance, TokenBalanceMap, TokenInfo, TokenInfoVersion } from '@src/types';
 import { DecodedOutput, TxInput, TxOutput } from '@wallet-service/common/src/types';
 
 test('Authorities', () => {
@@ -153,3 +154,16 @@ test('TokenBalanceMap fromTxOutput fromTxInput', () => {
   txOutput.locked = true;
   expect(TokenBalanceMap.fromTxOutput(txOutput)).toStrictEqual(TokenBalanceMap.fromStringMap({ '00': { totalSent: 200, locked: txOutput.value, unlocked: 0, lockExpires: timelock } }));
 });
+
+test('TokenInfo', () => {
+   expect.hasAssertions();
+
+   const htr = new TokenInfo({ id: NATIVE_TOKEN_UID, name: "Hathor" ,symbol: 'HTR' })
+   expect(htr.version).toBeNull();
+
+   const token1 = new TokenInfo({ id: 'Token1', name: "MyToken1" ,symbol: 'TK1' })
+   expect(token1.version).toBe(TokenInfoVersion.DEPOSIT);
+   
+   const token2 = new TokenInfo({ id: 'Token2', name: "MyToken2" ,symbol: 'TK2', version: TokenInfoVersion.FEE })
+   expect(token2.version).toBe(TokenInfoVersion.FEE);
+})

--- a/packages/wallet-service/tests/types.ts
+++ b/packages/wallet-service/tests/types.ts
@@ -39,6 +39,7 @@ export interface TokenTableEntry {
   name: string;
   symbol: string;
   transactions: number;
+  version?: number | null;
 }
 
 export interface WalletTableEntry {

--- a/packages/wallet-service/tests/utils.ts
+++ b/packages/wallet-service/tests/utils.ts
@@ -493,6 +493,7 @@ type Token = {
   tokenSymbol: string;
   tokenName: string;
   transactions: number;
+  tokenVersion: number | null;
 }
 
 export const checkTokenTable = async (
@@ -518,7 +519,8 @@ export const checkTokenTable = async (
     SELECT id AS tokenId,
            symbol AS tokenSymbol,
            name AS tokenName,
-           transactions
+           transactions,
+           version as tokenVersion
       FROM \`token\`
      WHERE \`id\` IN (?)
   `;
@@ -743,10 +745,11 @@ export const addToTokenTable = async (
     entry.name,
     entry.symbol,
     entry.transactions,
+    entry.version
   ]));
 
   await mysql.query(
-    'INSERT INTO `token`(`id`, `name`, `symbol`, `transactions`) VALUES ?',
+    'INSERT INTO `token`(`id`, `name`, `symbol`, `transactions`, `version`) VALUES ?',
     [payload],
   );
 };

--- a/packages/wallet-service/tsconfig.json
+++ b/packages/wallet-service/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "lib": ["es2017"],
     "removeComments": true,
     "moduleResolution": "node",
@@ -24,7 +25,9 @@
   "include": [
     "src/*.ts",
     "src/**/*.ts",
-    "tests"
+    "tests",
+    "events/*.json",
+    "events/**/*.json"
   ],
   "exclude": [
     "node_modules/**/*",


### PR DESCRIPTION
### Motivation
This PR is part of the Dynamic transaction model implementation.

According to the [docs](https://github.com/HathorNetwork/rfcs/pull/94), tokens can be created with two versions:
> 
> # Token info version
> Given Hathor's [Anatomy of a Transaction RFC](https://github.com/HathorNetwork/rfcs/blob/master/text/0015-anatomy-of-tx.md#token-creation), it is reasonable to suggest that the byte used by the token creation transaction token_info_version will be used to determine fee-created tokens.
>
> Since each custom token id is the hash of the token creation transaction that created it, we can assume the enum values below can be assigned to the token_info_version byte in the token creation tx and then we can retrieve it.
>
> So, by adding a TokenInfoVersion enum we have:
> 
> DEPOSIT = 1 (as is)
> FEE = 2

The `wallet-service` is used by `wallet-lib`, a project that expect the `version` field to be available on the `getTokenDetails` API.

### Acceptance Criteria

- Add the version column in the database with a migration
- Update the `TokenInfo` entity to handle the `version`
  - Add to sync-daemon workspace
  - Add to wallet-service workspace
- Update some test utils functions to handle the version field
- Update the sql statements that brings the token details
- Add the version field in the `getTokenInformation` API method.

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
