### PR TITLE
ci: fix yarn version

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -214,8 +214,8 @@ phases:
       # name: version
     commands:
       - npm install -g yarn
+      # corepack will use the version of yarn specified in package.json
       - corepack enable
-      - yarn set version 4.1.0
       - yarn install
   pre_build:
     commands:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,8 @@ RUN apk update && apk add python3 g++ make py3-setuptools
 
 COPY . .
 
+# corepack will use the version of yarn specified in package.json
 RUN corepack enable
-
-# Use the same version as flake's
-RUN yarn set version 4.1.0
 
 # This will install dependencies for all packages, except for the lambdas since
 # they are ignored in .dockerignore

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "sequelize-cli": "^6.6.2",
     "typescript": "^5.8.2"
   },
-  "packageManager": "yarn@4.1.0",
+  "packageManager": "yarn@4.7.0",
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "3.540.0",
     "@aws-sdk/client-lambda": "3.540.0",


### PR DESCRIPTION
### Motivation

We were getting errors in CI/CD when trying to run `yarn install` with version 4.1.0:

```
 The lockfile would have been modified by this install, which is explicitly forbidden.
 ```

### Acceptance Criteria

- We should centralize the yarn version to use in package.json and use 4.7.0

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
