### PR TITLE
fix: Use Node 22 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # This software cannot be redistributed unless explicitly agreed in writing with the authors.
 
 # Build phase
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ RUN yarn workspace sync-daemon run build
 RUN yarn workspaces focus -A --production
 
 # Run phase
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
### Motivation

We were getting this error in the daemon:

```
2025-07-28T14:58:44.897Z [wallet-service-daemon][info]: Transitioned to {"CONNECTED":"idle"}
unexpected error in bigIntReviver: TypeError: Cannot read properties of undefined (reading 'source')
/app/node_modules/@hathor/wallet-lib/lib/utils/bigint.js:58
      throw e;
      ^

TypeError: Cannot read properties of undefined (reading 'source')
    at Object.bigIntReviver (/app/node_modules/@hathor/wallet-lib/lib/utils/bigint.js:41:42)
    at JSON.parse (<anonymous>)
    at Object.parse (/app/node_modules/@hathor/wallet-lib/lib/utils/bigint.js:30:17)
    at socket.onmessage (/app/packages/daemon/dist/actors/WebSocketActor.js:62:103)
    at callListener (/app/packages/daemon/node_modules/ws/lib/event-target.js:290:14)
    at WebSocket.onMessage (/app/packages/daemon/node_modules/ws/lib/event-target.js:209:9)
    at WebSocket.emit (node:events:524:28)
    at Receiver.receiverOnMessage (/app/packages/daemon/node_modules/ws/lib/websocket.js:1184:20)
    at Receiver.emit (node:events:524:28)
    at Receiver.dataMessage (/app/packages/daemon/node_modules/ws/lib/receiver.js:541:14)

Node.js v20.19.4
```

### Acceptance Criteria

- We should use Node.js v22 in the Dockerfile, which fixes the error

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
