### PR TITLE
fix: support empty object for decoded output in full node events

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -443,7 +443,7 @@ export class TokenBalanceMap {
 // The output structure in full node events is similar to TxOutput but with some differences
 export interface FullNodeOutput extends Omit<TxOutput, 'decoded' | 'token' | 'spent_by'> {
   // In full node data, decoded can be null
-  decoded: DecodedOutput | null;
+  decoded: DecodedOutput | null | {};
 }
 
 // The input structure in full node events is different - it contains a reference to the spent output

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -75,7 +75,7 @@ export interface TxOutputWithIndex extends TxOutput {
   index: number;
 }
 
-export interface DecodedOutput {
+export type DecodedOutput = {
   type: string;
   address: string;
   timelock: number | null;

--- a/packages/common/src/utils/wallet.utils.ts
+++ b/packages/common/src/utils/wallet.utils.ts
@@ -6,6 +6,7 @@
  */
 
 import { constants } from '@hathor/wallet-lib';
+import { DecodedOutput } from '../types';
 
 /**
  * Checks if a given tokenData has any authority bit set
@@ -25,9 +26,7 @@ export const isAuthority = (tokenData: number): boolean => (
  * @param requiredKeys - A list of keys to check
  * @returns true if the decoded object is valid, false otherwise
  */
-type Decoded = { type: string; address: string; timelock: number | null };
-
-export const isDecodedValid = (decoded: any, requiredKeys: string[] = []): decoded is Decoded => {
+export const isDecodedValid = (decoded: any, requiredKeys: string[] = []): decoded is DecodedOutput => {
   return (decoded != null
     && typeof decoded === 'object'
     && Object.keys(decoded).length > 0)

--- a/packages/common/src/utils/wallet.utils.ts
+++ b/packages/common/src/utils/wallet.utils.ts
@@ -25,7 +25,9 @@ export const isAuthority = (tokenData: number): boolean => (
  * @param requiredKeys - A list of keys to check
  * @returns true if the decoded object is valid, false otherwise
  */
-export const isDecodedValid = (decoded: any, requiredKeys: string[] = []): boolean => {
+type Decoded = { type: string; address: string; timelock: number | null };
+
+export const isDecodedValid = (decoded: any, requiredKeys: string[] = []): decoded is Decoded => {
   return (decoded != null
     && typeof decoded === 'object'
     && Object.keys(decoded).length > 0)

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -98,11 +98,14 @@ export const EventTxOutputSchema = z.object({
   token_data: z.number(),
   script: z.string(),
   locked: z.boolean().optional(),
-  decoded: z.object({
-    type: z.string(),
-    address: z.string(),
-    timelock: z.number().nullable(),
-  }).nullable(),
+  decoded: z.union([
+    z.object({
+      type: z.string(),
+      address: z.string(),
+      timelock: z.number().nullable(),
+    }).nullable(),
+    z.object({}).strict()
+  ]),
 });
 export type EventTxOutput = z.infer<typeof EventTxOutputSchema>;
 

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -79,7 +79,6 @@ export const prepareOutputs = (outputs: EventTxOutput[], tokens: string[]): TxOu
       output.token = token;
 
       if (!isDecodedValid(_output.decoded)
-        || _output.decoded === null
         || _output.decoded.type === null
         || _output.decoded.type === undefined) {
         console.log('Decode failed, skipping..');


### PR DESCRIPTION
### Motivation

There's a case when the full node sends an event where the `decoded` value of the output is an empty object (`{}`) and we were supporting only `null` or the full object.

### Acceptance Criteria

- Support typing of empty object for the decoded output.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
