### PR TITLE
fix: nonce as bigint

### DIFF
--- a/packages/common/__tests__/events/nftCreationTx.ts
+++ b/packages/common/__tests__/events/nftCreationTx.ts
@@ -120,7 +120,7 @@ export const nftCreationTx = {
 export function getTransaction(): HistoryTransaction {
   return {
     tx_id: nftCreationTx.tx_id,
-    nonce: 1n,
+    nonce: 1,
     timestamp: nftCreationTx.timestamp,
     signalBits: nftCreationTx.signal_bits,
     version: nftCreationTx.version,

--- a/packages/common/__tests__/events/nftCreationTx.ts
+++ b/packages/common/__tests__/events/nftCreationTx.ts
@@ -120,7 +120,7 @@ export const nftCreationTx = {
 export function getTransaction(): HistoryTransaction {
   return {
     tx_id: nftCreationTx.tx_id,
-    nonce: 1,
+    nonce: 1n,
     timestamp: nftCreationTx.timestamp,
     signalBits: nftCreationTx.signal_bits,
     version: nftCreationTx.version,

--- a/packages/common/__tests__/utils/nft.utils.test.ts
+++ b/packages/common/__tests__/utils/nft.utils.test.ts
@@ -46,7 +46,7 @@ const logger = new Logger();
 // Real event data from production
 const REAL_NFT_EVENT_DATA = {
   'hash': '000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866',
-  'nonce': 257857,
+  'nonce': 257857n,
   'timestamp': 1741649846,
   'signal_bits': 0,
   'version': 2,
@@ -496,7 +496,7 @@ describe('transaction transformation compatibility', () => {
           }
         }],
         headers: [],
-        nonce: 0,
+        nonce: 0n,
         signal_bits: 1,
         timestamp: 0,
         weight: 18.2,
@@ -624,7 +624,7 @@ describe('processNftEvent', () => {
     // Real event data from production
     const eventData = {
       hash: '000041f860a327969fa03685ed05cf316fc941708c53801cf81f426ac4a55866',
-      nonce: 257857,
+      nonce: 257857n,
       timestamp: 1741649846,
       signal_bits: 0,
       version: 2,

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -29,7 +29,7 @@ export enum Severity {
 export interface Transaction {
   // eslint-disable-next-line camelcase
   tx_id: string;
-  nonce: number;
+  nonce: bigint;
   timestamp: number;
   // eslint-disable-next-line camelcase
   signal_bits: number;

--- a/packages/common/src/utils/nft.utils.ts
+++ b/packages/common/src/utils/nft.utils.ts
@@ -271,7 +271,8 @@ export class NftUtils {
       weight: fullNodeData.weight,
       timestamp: fullNodeData.timestamp,
       is_voided: !!fullNodeData.voided,
-      nonce: fullNodeData.nonce,
+      // XXX: This may have conversion errors but the value is of no consequence
+      nonce: Number(fullNodeData.nonce),
       parents: fullNodeData.parents ?? [],
     };
 

--- a/packages/daemon/__tests__/guards/guards.test.ts
+++ b/packages/daemon/__tests__/guards/guards.test.ts
@@ -112,7 +112,7 @@ const generateMetadataDecidedEvent = (type: 'TX_VOIDED' | 'TX_UNVOIDED' | 'TX_NE
         timestamp: 0,
         version: 1,
         weight: 1,
-        nonce: 1,
+        nonce: 1n,
         inputs: [],
         outputs: [],
         parents: [],

--- a/packages/daemon/src/actors/WebSocketActor.ts
+++ b/packages/daemon/src/actors/WebSocketActor.ts
@@ -72,6 +72,7 @@ export default (callback: any, receive: any) => {
       bigIntUtils.JSONBigInt.parse(socketEvent.data.toString())
     );
     if (!parseResult.success) {
+      logger.error(`Could not parse event: ${socketEvent.data.toString()}`);
       throw new Error(parseResult.error.message);
     }
     const event = parseResult.data;

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -139,7 +139,7 @@ export const TxEventDataWithoutMetaSchema = z.object({
   timestamp: z.number(),
   version: z.number(),
   weight: z.number(),
-  nonce: z.number(),
+  nonce: bigIntUtils.bigIntCoercibleSchema,
   inputs: EventTxInputSchema.array(),
   outputs: EventTxOutputSchema.array(),
   headers: EventTxNanoHeaderSchema.array().optional(),

--- a/packages/wallet-service/tests/commons.test.ts
+++ b/packages/wallet-service/tests/commons.test.ts
@@ -684,7 +684,7 @@ describe('getWalletBalancesForTx', () => {
 
     const tx = {
       tx_id: tx1.id,
-      nonce: 10,
+      nonce: 10n,
       timestamp: tx1.timestamp,
       version: tx1.version,
       weight: tx1.weight,
@@ -786,7 +786,7 @@ describe('getWalletBalancesForTx', () => {
 
     const tx = {
       tx_id: tx1.id,
-      nonce: 10,
+      nonce: 10n,
       timestamp: tx1.timestamp,
       version: tx1.version,
       weight: tx1.weight,
@@ -939,7 +939,7 @@ describe('getWalletBalancesForTx', () => {
 
       const tx = {
         tx_id: tx1.id,
-        nonce: 10,
+        nonce: 10n,
         timestamp: tx1.timestamp,
         version: tx1.version,
         weight: tx1.weight,
@@ -1110,7 +1110,7 @@ describe('getWalletBalancesForTx', () => {
 
       const tx = {
         tx_id: tx1.id,
-        nonce: 10,
+        nonce: 10n,
         timestamp: tx1.timestamp,
         version: tx1.version,
         weight: tx1.weight,


### PR DESCRIPTION
### Motivation

Some nonces were too big to be `number` and the parsing would fail.
We need to parse these values using nonce as a bigint instead.

### Acceptance Criteria

- Parse nonce as bigint
- Improve logging on parse fails

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
