### PR TITLE
chore: warmup middleware for authorization lambdas

### DIFF
--- a/packages/daemon/__tests__/integration/config.ts
+++ b/packages/daemon/__tests__/integration/config.ts
@@ -11,7 +11,7 @@ export const UNVOIDED_SCENARIO_PORT = 8081;
 // Last event is actually 39, but event 39 is ignored by the machine (because
 // the transaction is already added), and when we ignore an event, we don't store
 // it in the database.
-export const UNVOIDED_SCENARIO_LAST_EVENT = 38;
+export const UNVOIDED_SCENARIO_LAST_EVENT = 39;
 
 // reorg
 export const REORG_SCENARIO_PORT = 8082;

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -104,10 +104,10 @@ export const EventTxOutputSchema = z.object({
       address: z.string(),
       timelock: z.number().nullable(),
     }).passthrough().nullable(),
-    z.object({}).strict(),
     z.object({
-      token_data: z.number().nullish(),
-    }).strict()
+      token_data: z.number(),
+    }),
+    z.object({}).strict(),
   ]),
 });
 export type EventTxOutput = z.infer<typeof EventTxOutputSchema>;

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -103,9 +103,11 @@ export const EventTxOutputSchema = z.object({
       type: z.string(),
       address: z.string(),
       timelock: z.number().nullable(),
-      token_data: z.number().nullish(),
     }).passthrough().nullable(),
-    z.object({}).strict()
+    z.object({}).strict(),
+    z.object({
+      token_data: z.number().nullish(),
+    }).strict()
   ]),
 });
 export type EventTxOutput = z.infer<typeof EventTxOutputSchema>;

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -103,7 +103,8 @@ export const EventTxOutputSchema = z.object({
       type: z.string(),
       address: z.string(),
       timelock: z.number().nullable(),
-    }).nullable(),
+      token_data: z.number().nullish(),
+    }).passthrough().nullable(),
     z.object({}).strict()
   ]),
 });

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -588,12 +588,12 @@ functions:
           cors: true
     warmup:
       walletWarmer:
-        enabled: false
+        enabled: true
   bearerAuthorizer:
     handler: src/api/auth.bearerAuthorizer
     warmup:
       walletWarmer:
-        enabled: false
+        enabled: true
   metrics:
     handler: src/metrics.getMetrics
     events:

--- a/packages/wallet-service/src/api/auth.ts
+++ b/packages/wallet-service/src/api/auth.ts
@@ -26,6 +26,7 @@ import {
   validateAuthTimestamp,
   AUTH_MAX_TIMESTAMP_SHIFT_IN_SECONDS,
 } from '@src/utils';
+import { warmupMiddleware } from '@src/api/utils';
 import middy from '@middy/core';
 import cors from '@middy/http-cors';
 import createDefaultLogger from '@src/logger';
@@ -155,6 +156,7 @@ export const tokenHandler: APIGatewayProxyHandler = middy(async (event) => {
     body: JSON.stringify({ success: true, token }),
   };
 }).use(cors())
+  .use(warmupMiddleware())
   .use(errorHandler());
 
 /**
@@ -235,4 +237,5 @@ export const bearerAuthorizer: APIGatewayTokenAuthorizerHandler = middy(async (e
   }
 
   return _generatePolicy(walletId, 'Deny', event.methodArn, logger);
-}).use(cors());
+}).use(cors())
+  .use(warmupMiddleware());

--- a/packages/wallet-service/src/api/auth.ts
+++ b/packages/wallet-service/src/api/auth.ts
@@ -84,6 +84,17 @@ export const tokenHandler: APIGatewayProxyHandler = middy(async (event) => {
   const authXpubStr = value.xpub;
   const wallet: Wallet = await getWallet(mysql, value.walletId);
 
+  if (!wallet) {
+    await closeDbConnection(mysql);
+    return {
+      statusCode: 400,
+      body: JSON.stringify({
+        success: false,
+        error: ApiError.WALLET_NOT_FOUND,
+      }),
+    };
+  }
+
   const [validTimestamp, timestampShift] = validateAuthTimestamp(timestamp, Date.now() / 1000);
 
   if (!validTimestamp) {

--- a/packages/wallet-service/src/api/newAddresses.ts
+++ b/packages/wallet-service/src/api/newAddresses.ts
@@ -30,16 +30,16 @@ const mysql = getDbConnection();
  * This lambda is called by API Gateway on GET /addresses/new
  */
 export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId) => {
-  const status = await getWallet(mysql, walletId);
+  const wallet = await getWallet(mysql, walletId);
 
-  if (!status) {
+  if (!wallet) {
     return closeDbAndGetError(mysql, ApiError.WALLET_NOT_FOUND);
   }
-  if (!status.readyAt) {
+  if (!wallet.readyAt) {
     return closeDbAndGetError(mysql, ApiError.WALLET_NOT_READY);
   }
 
-  const addresses = await getNewAddresses(mysql, walletId);
+  const addresses = await getNewAddresses(mysql, wallet);
 
   await closeDbConnection(mysql);
 

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -289,6 +289,7 @@ export const createWallet = async (
     status: WalletStatus.CREATING,
     created_at: ts,
     max_gap: maxGap,
+    last_used_address_index: -1,
   };
   await mysql.query(
     `INSERT INTO \`wallet\`
@@ -304,6 +305,7 @@ export const createWallet = async (
     status: WalletStatus.CREATING,
     createdAt: ts,
     readyAt: null,
+    lastUsedAddressIndex: -1,
   };
 };
 

--- a/packages/wallet-service/src/db/utils.ts
+++ b/packages/wallet-service/src/db/utils.ts
@@ -83,6 +83,7 @@ export const getWalletFromDbEntry = (entry: Record<string, unknown>): Wallet => 
   maxGap: entry.max_gap as number,
   createdAt: entry.created_at as number,
   readyAt: entry.ready_at as number,
+  lastUsedAddressIndex: entry.last_used_address_index as number,
 });
 
 /**

--- a/packages/wallet-service/src/db/utils.ts
+++ b/packages/wallet-service/src/db/utils.ts
@@ -75,7 +75,7 @@ export async function transactionDecorator(_mysql: ServerlessMysql, wrapped: Fun
  * @param result - The result row to map to a Wallet object
  */
 export const getWalletFromDbEntry = (entry: Record<string, unknown>): Wallet => ({
-  walletId: getWalletId(entry.xpubkey as string),
+  walletId: entry.id as string,
   xpubkey: entry.xpubkey as string,
   authXpubkey: entry.auth_xpubkey as string,
   status: entry.status as WalletStatus,

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -144,6 +144,7 @@ export interface Wallet {
   retryCount?: number;
   createdAt?: number;
   readyAt?: number;
+  lastUsedAddressIndex?: number;
 }
 
 export interface AddressInfo {

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -750,7 +750,7 @@ test('GET /wallet', async () => {
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody.status).toStrictEqual({
-    walletId: getWalletId(XPUBKEY),
+    walletId: 'my-wallet',
     xpubkey: XPUBKEY,
     authXpubkey: AUTH_XPUBKEY,
     status: 'ready',
@@ -758,6 +758,7 @@ test('GET /wallet', async () => {
     retryCount: 0,
     createdAt: 10000,
     readyAt: 10001,
+    lastUsedAddressIndex: -1,
   });
 });
 


### PR DESCRIPTION
### Motivation

Having both the auth token api and the authorizer lambda cold start at the same time increases the wallet start by more than 2 seconds.
Having them always be warmed would improve the UX.

### Acceptance Criteria

- Add the warmup middleware for both the auth token api and authorizer lambda

### Extra chores

- Added missing error treatment in auth token api
- Fixed fullnode event parser
- Prevent the get new addresses to fetch the same walet twice from the database.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
