### PR TITLE
fix: Consider POA Blocks version in MySQL queries

### DIFF
--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -64,6 +64,7 @@ const logger: Logger = createDefaultLogger();
 const BLOCK_VERSION = [
   constants.BLOCK_VERSION,
   constants.MERGED_MINED_BLOCK_VERSION,
+  constants.POA_BLOCK_VERSION
 ];
 const BURN_ADDRESS = 'HDeadDeadDeadDeadDeadDeadDeagTPgmn';
 


### PR DESCRIPTION
### Motivation

The healthcheck is broken in Ekvilibro environments

### Acceptance Criteria

- We should consider the version of PoA blocks when searching for blocks in MySQL queries

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
