### PR TITLE
chore: avoid critical alerts for reorgs

### DIFF
--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -131,14 +131,14 @@ jest.mock('../../src/config', () => {
     default: jest.fn(() => ({
       REORG_SIZE_INFO: 1,
       REORG_SIZE_MINOR: 3,
-      REORG_SIZE_MAJOR: 5,
-      REORG_SIZE_CRITICAL: 10,
+      REORG_SIZE_MEDIUM: 5,
+      REORG_SIZE_MAJOR: 10,
     })),
     getConfig: jest.fn(() => ({
       REORG_SIZE_INFO: 1,
       REORG_SIZE_MINOR: 3,
-      REORG_SIZE_MAJOR: 5,
-      REORG_SIZE_CRITICAL: 10,
+      REORG_SIZE_MEDIUM: 5,
+      REORG_SIZE_MAJOR: 10,
     })),
   };
 });
@@ -878,8 +878,8 @@ describe('handleReorgStarted', () => {
     (getConfig as jest.Mock).mockReturnValue({
       REORG_SIZE_INFO: 1,
       REORG_SIZE_MINOR: 3,
-      REORG_SIZE_MAJOR: 5,
-      REORG_SIZE_CRITICAL: 10,
+      REORG_SIZE_MEDIUM: 5,
+      REORG_SIZE_MAJOR: 10,
     });
   });
 
@@ -943,7 +943,7 @@ describe('handleReorgStarted', () => {
     );
   });
 
-  it('should add MAJOR alert when reorg size is between REORG_SIZE_MAJOR and REORG_SIZE_CRITICAL', async () => {
+  it('should add MEDIUM alert when reorg size is between REORG_SIZE_MEDIUM and REORG_SIZE_MAJOR', async () => {
     const event = generateFullNodeEvent({
       type: FullNodeEventTypes.REORG_STARTED,
       data: {
@@ -960,7 +960,7 @@ describe('handleReorgStarted', () => {
     expect(addAlert).toHaveBeenCalledWith(
       'Major Reorg Detected',
       'A major reorg of size 7 has occurred.',
-      Severity.MAJOR,
+      Severity.MEDIUM,
       {
         reorg_size: 7,
         previous_best_block: 'prev',
@@ -971,7 +971,7 @@ describe('handleReorgStarted', () => {
     );
   });
 
-  it('should add CRITICAL alert when reorg size is greater than REORG_SIZE_CRITICAL', async () => {
+  it('should add MAJOR alert when reorg size is greater than REORG_SIZE_MAJOR', async () => {
     const event = generateFullNodeEvent({
       type: FullNodeEventTypes.REORG_STARTED,
       data: {
@@ -988,7 +988,7 @@ describe('handleReorgStarted', () => {
     expect(addAlert).toHaveBeenCalledWith(
       'Critical Reorg Detected',
       'A critical reorg of size 11 has occurred.',
-      Severity.CRITICAL,
+      Severity.MAJOR,
       {
         reorg_size: 11,
         previous_best_block: 'prev',

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -89,8 +89,8 @@ export const USE_SSL = process.env.USE_SSL === 'true';
 // Reorg size thresholds for different alert levels
 export const REORG_SIZE_INFO = parseInt(process.env.REORG_SIZE_INFO ?? '1', 10);
 export const REORG_SIZE_MINOR = parseInt(process.env.REORG_SIZE_MINOR ?? '3', 10);
-export const REORG_SIZE_MAJOR = parseInt(process.env.REORG_SIZE_MAJOR ?? '5', 10);
-export const REORG_SIZE_CRITICAL = parseInt(process.env.REORG_SIZE_CRITICAL ?? '10', 10);
+export const REORG_SIZE_MEDIUM = parseInt(process.env.REORG_SIZE_MEDIUM ?? '5', 10);
+export const REORG_SIZE_MAJOR = parseInt(process.env.REORG_SIZE_MAJOR ?? '10', 10);
 
 export default () => ({
   SERVICE_NAME,
@@ -123,6 +123,6 @@ export default () => ({
   HEALTHCHECK_PING_INTERVAL,
   REORG_SIZE_INFO,
   REORG_SIZE_MINOR,
+  REORG_SIZE_MEDIUM,
   REORG_SIZE_MAJOR,
-  REORG_SIZE_CRITICAL,
 });

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -706,7 +706,7 @@ export const handleReorgStarted = async (context: Context): Promise<void> => {
   }
 
   const { reorg_size, previous_best_block, new_best_block, common_block } = fullNodeEvent.event.data;
-  const { REORG_SIZE_INFO, REORG_SIZE_MINOR, REORG_SIZE_MAJOR, REORG_SIZE_CRITICAL } = getConfig();
+  const { REORG_SIZE_INFO, REORG_SIZE_MINOR, REORG_SIZE_MEDIUM, REORG_SIZE_MAJOR } = getConfig();
 
   const metadata = {
     reorg_size,
@@ -715,19 +715,19 @@ export const handleReorgStarted = async (context: Context): Promise<void> => {
     common_block,
   };
 
-  if (reorg_size >= REORG_SIZE_CRITICAL) {
-    await addAlert(
-      'Critical Reorg Detected',
-      `A critical reorg of size ${reorg_size} has occurred.`,
-      Severity.CRITICAL,
-      metadata,
-      logger,
-    );
-  } else if (reorg_size >= REORG_SIZE_MAJOR) {
+  if (reorg_size >= REORG_SIZE_MAJOR) {
     await addAlert(
       'Major Reorg Detected',
       `A major reorg of size ${reorg_size} has occurred.`,
       Severity.MAJOR,
+      metadata,
+      logger,
+    );
+  } else if (reorg_size >= REORG_SIZE_MEDIUM) {
+    await addAlert(
+      'Medium Reorg Detected',
+      `A medium reorg of size ${reorg_size} has occurred.`,
+      Severity.MEDIUM,
       metadata,
       logger,
     );


### PR DESCRIPTION
### Motivation

Critical alerts should be extremely rare. The general idea when to fire one is described in https://github.com/HathorNetwork/ops-tools/blob/master/docs/on-call/guide.md#alert-severitypriority

Reorgs, even big ones, seemed like not a fit for critical alerts.

### Acceptance Criteria

- Do not use critical alerts for reorgs.

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
