### PR TITLE
feat: do not start background tasks during tests

### DIFF
--- a/packages/daemon/jest.config.js
+++ b/packages/daemon/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  setupFiles: ["<rootDir>/setupTests.js"],
   roots: ["<rootDir>/__tests__"],
   testRegex: ".*\\.test\\.ts$",
   transform: {

--- a/packages/daemon/jest_integration.config.js
+++ b/packages/daemon/jest_integration.config.js
@@ -5,6 +5,7 @@ const mainTestMatch = process.env.SPECIFIC_INTEGRATION_TEST_FILE
   : '<rootDir>/__tests__/integration/**/*.test.ts';
 
 module.exports = {
+  setupFiles: ["<rootDir>/setupTests.js"],
   roots: ["<rootDir>/__tests__"],
   transform: {
     "^.+\\.ts$": ["ts-jest", {

--- a/packages/daemon/setupTests.js
+++ b/packages/daemon/setupTests.js
@@ -1,3 +1,3 @@
-import { stopGLLBackgroundTask } from '@hathor/wallet-lib';
+const { stopGLLBackgroundTask } = require('@hathor/wallet-lib');
 
 stopGLLBackgroundTask();

--- a/packages/daemon/setupTests.js
+++ b/packages/daemon/setupTests.js
@@ -1,0 +1,3 @@
+import { stopGLLBackgroundTask } from '@hathor/wallet-lib';
+
+stopGLLBackgroundTask();

--- a/packages/wallet-service/tests/jestSetup.ts
+++ b/packages/wallet-service/tests/jestSetup.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { config } from 'dotenv';
+import { stopGLLBackgroundTask } from '@hathor/wallet-lib';
+
+stopGLLBackgroundTask();
 
 Object.defineProperty(global, '_bitcore', { get() { return undefined; }, set() {} });
 


### PR DESCRIPTION
### Motivation

Some test logs were reporting background tasks that kept hanging.
This is because there is a background task for the wallet-lib that will keep running.

### Acceptance Criteria

- Stop the background task before the tests start

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
