### PR TITLE
chore: avoid false positive alerts on duplicate tx

### DIFF
--- a/packages/daemon/src/utils/date.ts
+++ b/packages/daemon/src/utils/date.ts
@@ -13,3 +13,15 @@
 export const getUnixTimestamp = (): number => (
   Math.round((new Date()).getTime() / 1000)
 );
+
+
+const daemonStartTime = getUnixTimestamp();
+
+/**
+ * Get the daemon uptime in seconds
+ *
+ * @returns The daemon uptime in seconds
+ */
+export const getDaemonUptime = (): number => (
+  getUnixTimestamp() - daemonStartTime
+);


### PR DESCRIPTION
### Motivation

We receive a false positive alert every time a daemon is restarted in some environment

### Acceptance Criteria

- Only log an error about duplicate transaction if the daemon has not been restarted recently

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
