### PR TITLE
feat: increase memory for auth lambdas

### DIFF
--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -340,6 +340,7 @@ functions:
         enabled: true
   getNewAddresses:
     handler: src/api/newAddresses.get
+    memorySize: 1024
     events:
       - http:
           path: wallet/addresses/new
@@ -581,6 +582,7 @@ functions:
   authTokenApi:
     handler: src/api/auth.tokenHandler
     timeout: 6
+    memorySize: 1024
     events:
       - http:
           path: auth/token
@@ -591,6 +593,7 @@ functions:
         enabled: true
   bearerAuthorizer:
     handler: src/api/auth.bearerAuthorizer
+    memorySize: 1024
     warmup:
       walletWarmer:
         enabled: true


### PR DESCRIPTION
### Motivation

To make wallet startup faster we can increase the memory size on the lambdas used for wallet startup, this will also increase the available CPU which makes the apis faster.

### Acceptance Criteria

- Increase the memory limit to 1024mb on all lambdas that are used during wallet startup

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
