### PR TITLE
feat: stop lib background tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@aws-sdk/client-apigatewaymanagementapi": "3.540.0",
     "@aws-sdk/client-lambda": "3.540.0",
     "@aws-sdk/client-sqs": "3.540.0",
-    "@hathor/wallet-lib": "2.5.1",
+    "@hathor/wallet-lib": "2.8.3",
     "@wallet-service/common": "1.5.0",
     "bip32": "^4.0.0",
     "bitcoinjs-lib": "^6.1.5",

--- a/packages/common/jest.config.js
+++ b/packages/common/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   roots: ["<rootDir>/__tests__"],
+  setupFiles: ['./jestSetup.ts'],
   testRegex: ".*\\.test\\.ts$",
   moduleNameMapper: {
     '^@src/(.*)$': '<rootDir>/src/$1',

--- a/packages/common/jestSetup.ts
+++ b/packages/common/jestSetup.ts
@@ -1,0 +1,3 @@
+import { stopGLLBackgroundTask } from '@hathor/wallet-lib';
+stopGLLBackgroundTask();
+

--- a/packages/common/jestSetup.ts
+++ b/packages/common/jestSetup.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { stopGLLBackgroundTask } from '@hathor/wallet-lib';
 stopGLLBackgroundTask();
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,7 +8,7 @@
     "test": "jest --runInBand --collectCoverage --detectOpenHandles --forceExit"
   },
   "peerDependencies": {
-    "@hathor/wallet-lib": "2.5.1"
+    "@hathor/wallet-lib": "2.8.3"
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "3.540.0",

--- a/packages/daemon/jest.config.js
+++ b/packages/daemon/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   roots: ["<rootDir>/__tests__"],
+  setupFiles: ['./jestSetup.ts'],
   testRegex: ".*\\.test\\.ts$",
   transform: {
     "^.+\\.ts$": ["ts-jest", {

--- a/packages/daemon/jestSetup.ts
+++ b/packages/daemon/jestSetup.ts
@@ -1,3 +1,6 @@
 import { stopGLLBackgroundTask } from '@hathor/wallet-lib';
+
+Object.defineProperty(global, '_bitcore', { get() { return undefined; }, set() {} });
+
 stopGLLBackgroundTask();
 

--- a/packages/daemon/jestSetup.ts
+++ b/packages/daemon/jestSetup.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { stopGLLBackgroundTask } from '@hathor/wallet-lib';
 
 Object.defineProperty(global, '_bitcore', { get() { return undefined; }, set() {} });

--- a/packages/daemon/jestSetup.ts
+++ b/packages/daemon/jestSetup.ts
@@ -1,0 +1,3 @@
+import { stopGLLBackgroundTask } from '@hathor/wallet-lib';
+stopGLLBackgroundTask();
+

--- a/packages/daemon/jest_integration.config.js
+++ b/packages/daemon/jest_integration.config.js
@@ -6,6 +6,7 @@ const mainTestMatch = process.env.SPECIFIC_INTEGRATION_TEST_FILE
 
 module.exports = {
   roots: ["<rootDir>/__tests__"],
+  setupFiles: ['./jestSetup.ts'],
   transform: {
     "^.+\\.ts$": ["ts-jest", {
       tsconfig: "./tsconfig.json",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -46,7 +46,7 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "@hathor/wallet-lib": "2.5.1",
+    "@hathor/wallet-lib": "2.8.3",
     "@wallet-service/common": "1.5.0"
   },
   "dependencies": {

--- a/packages/wallet-service/package.json
+++ b/packages/wallet-service/package.json
@@ -44,7 +44,7 @@
     "winston": "3.13.0"
   },
   "peerDependencies": {
-    "@hathor/wallet-lib": "2.5.1",
+    "@hathor/wallet-lib": "2.8.3",
     "@wallet-service/common": "1.5.0"
   },
   "devDependencies": {

--- a/packages/wallet-service/tests/integration.test.ts
+++ b/packages/wallet-service/tests/integration.test.ts
@@ -15,6 +15,7 @@ import {
   checkWalletTable,
   createOutput,
   createInput,
+  stopWalletLibOpenHandles,
 } from '@tests/utils';
 import { SNSEvent } from 'aws-lambda';
 
@@ -130,6 +131,7 @@ beforeAll(async () => {
   process.env.BLOCK_REWARD_LOCK = '1';
 
   const actualUtils = jest.requireActual('@src/utils');
+  await stopWalletLibOpenHandles();
   jest.mock('@src/utils', () => {
     return {
       ...actualUtils,

--- a/packages/wallet-service/tests/jestSetup.ts
+++ b/packages/wallet-service/tests/jestSetup.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { config } from 'dotenv';
+import { stopGLLBackgroundTask } from '@hathor/wallet-lib';
 
 Object.defineProperty(global, '_bitcore', { get() { return undefined; }, set() {} });
 
+stopGLLBackgroundTask();
 config();

--- a/packages/wallet-service/tests/pushSendNotificationToDevice.test.ts
+++ b/packages/wallet-service/tests/pushSendNotificationToDevice.test.ts
@@ -19,6 +19,7 @@ import {
   makeGatewayEventWithAuthorizer,
   cleanDatabase,
   checkPushDevicesTable,
+  stopWalletLibOpenHandles,
 } from '@tests/utils';
 import { APIGatewayProxyResult, Context } from 'aws-lambda';
 import { Severity } from '@wallet-service/common/src/types';
@@ -253,6 +254,7 @@ describe('alert', () => {
     // allow android and desktop, while test for ios provider
     process.env.PUSH_ALLOWED_PROVIDERS = 'android,desktop';
     await import('@src/api/pushSendNotificationToDevice');
+    await stopWalletLibOpenHandles();
 
     await addToWalletTable(mysql, [{
       id: 'my-wallet',

--- a/packages/wallet-service/tests/utils.ts
+++ b/packages/wallet-service/tests/utils.ts
@@ -1145,3 +1145,8 @@ export const getXPrivKeyFromSeed = (
   const code = new Mnemonic(seed);
   return code.toHDPrivateKey(passphrase, network.bitcoreNetwork);
 };
+
+export const stopWalletLibOpenHandles = async () => {
+  const { stopGLLBackgroundTask } = await import('@hathor/wallet-lib');
+  stopGLLBackgroundTask();
+};

--- a/packages/wallet-service/tests/utils/pushnotification.utils.test.ts
+++ b/packages/wallet-service/tests/utils/pushnotification.utils.test.ts
@@ -10,7 +10,7 @@ import { SendNotificationToDevice } from '@src/types';
 import { Severity } from '@wallet-service/common/src/types';
 import { sendMock, lambdaInvokeCommandMock } from '@tests/utils/aws-sdk.mock';
 import { LambdaClient } from '@aws-sdk/client-lambda';
-import { buildWalletBalanceValueMap } from '@tests/utils';
+import { buildWalletBalanceValueMap, stopWalletLibOpenHandles } from '@tests/utils';
 import { bigIntUtils } from '@hathor/wallet-lib';
 
 const isFirebaseInitializedMock = jest.spyOn(pushnotificationUtils, 'isFirebaseInitialized');
@@ -61,6 +61,7 @@ describe('PushNotificationUtils', () => {
     // reload module
     jest.resetModules();
     await import('@src/utils/pushnotification.utils');
+    await stopWalletLibOpenHandles();
 
     const resultMessageOfLastCallToLoggerError = logger.error.mock.calls[0][0];
     expect(resultMessageOfLastCallToLoggerError).toMatchInlineSnapshot('"Error initializing Firebase Admin SDK. ErrorMessage: Failed to parse private key: Error: Invalid PEM formatted message."');
@@ -77,6 +78,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -97,6 +99,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -117,6 +120,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -137,6 +141,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -157,6 +162,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -177,6 +183,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -197,6 +204,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -217,6 +225,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -237,6 +246,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -257,6 +267,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -277,6 +288,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(mockedAddAlert).toHaveBeenLastCalledWith(
         'Lambda missing env variables',
@@ -300,6 +312,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       // No alert should be raised since push notifications are disabled
       expect(mockedAddAlert).not.toHaveBeenCalled();
@@ -315,6 +328,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(logger.error).toHaveBeenLastCalledWith('[ALERT] Error while parsing the env.FIREBASE_PRIVATE_KEY.');
     });
@@ -328,6 +342,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       expect(logger.error).toHaveBeenLastCalledWith('[ALERT] env.PUSH_ALLOWED_PROVIDERS is empty.');
     });
@@ -468,6 +483,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       const { PushNotificationUtils } = await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       const notification = {
         deviceId: 'device1',
@@ -511,6 +527,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       const { PushNotificationUtils } = await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       const notification = {
         deviceId: 'device1',
@@ -542,6 +559,7 @@ describe('PushNotificationUtils', () => {
       // reload module
       jest.resetModules();
       const { PushNotificationUtils } = await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       const notification = {
         deviceId: 'device1',
@@ -570,6 +588,7 @@ describe('PushNotificationUtils', () => {
       });
       jest.resetModules();
       const { PushNotificationUtils, buildFunctionName } = await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       const walletMap = buildWalletBalanceValueMap();
       const result = await PushNotificationUtils.invokeOnTxPushNotificationRequestedLambda(walletMap);
@@ -604,6 +623,7 @@ describe('PushNotificationUtils', () => {
       process.env.PUSH_NOTIFICATION_ENABLED = 'false';
       jest.resetModules();
       const { PushNotificationUtils } = await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       const walletMap = buildWalletBalanceValueMap();
       const result = await PushNotificationUtils.invokeOnTxPushNotificationRequestedLambda(walletMap);
@@ -634,6 +654,7 @@ describe('PushNotificationUtils', () => {
       process.env.PUSH_NOTIFICATION_ENABLED = 'true';
       jest.resetModules();
       const { PushNotificationUtils } = await import('@src/utils/pushnotification.utils');
+      await stopWalletLibOpenHandles();
 
       const walletMap = buildWalletBalanceValueMap();
       await expect(PushNotificationUtils.invokeOnTxPushNotificationRequestedLambda(walletMap)).rejects.toMatchInlineSnapshot('[Error: hathor-wallet-service-stage-txPushRequested lambda invoke failed for wallets: wallet1]');

--- a/packages/wallet-service/tests/ws.utils.test.ts
+++ b/packages/wallet-service/tests/ws.utils.test.ts
@@ -42,6 +42,7 @@ jest.mock('redis', () => ({
 }));
 
 import { endWsConnection } from '@src/redis';
+import { stopWalletLibOpenHandles } from './utils';
 
 test('connectionInfoFromEvent', async () => {
   expect.hasAssertions();
@@ -60,6 +61,7 @@ test('connectionInfoFromEvent', async () => {
   try {
 
     const { connectionInfoFromEvent } = await import('@src/ws/utils');
+    await stopWalletLibOpenHandles();
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const connInfo = connectionInfoFromEvent(event);
@@ -90,6 +92,7 @@ test('missing WS_DOMAIN should throw', async () => {
 
   try {
     const { connectionInfoFromEvent } = await import('@src/ws/utils');
+    await stopWalletLibOpenHandles();
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     expect(() => connectionInfoFromEvent(event)).toThrow('Domain not on env variables');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3636,9 +3636,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hathor/wallet-lib@npm:2.5.1":
-  version: 2.5.1
-  resolution: "@hathor/wallet-lib@npm:2.5.1"
+"@hathor/wallet-lib@npm:2.8.3":
+  version: 2.8.3
+  resolution: "@hathor/wallet-lib@npm:2.8.3"
   dependencies:
     axios: "npm:1.7.7"
     bitcore-lib: "npm:8.25.10"
@@ -3650,7 +3650,7 @@ __metadata:
     queue-microtask: "npm:1.2.3"
     ws: "npm:8.17.1"
     zod: "npm:3.23.8"
-  checksum: 10/6afb2123a29de80d09cfcbe14c69709a41cd36e1f4fdcbe5dcb74690057dbff482d434a904e734a0154ded4fb8e168eb443acba4d9b5815795d92f677f274b09
+  checksum: 10/a52b8f8de761a7abdfb206ed536b0fae21c3904cb6b55730cc4dc5c293874ffd89c91babf47536d040c20dc3e2dd542016dfc6bdba282a662e86c3e638291c26
   languageName: node
   linkType: hard
 
@@ -12289,7 +12289,7 @@ __metadata:
     "@aws-sdk/client-apigatewaymanagementapi": "npm:3.540.0"
     "@aws-sdk/client-lambda": "npm:3.540.0"
     "@aws-sdk/client-sqs": "npm:3.540.0"
-    "@hathor/wallet-lib": "npm:2.5.1"
+    "@hathor/wallet-lib": "npm:2.8.3"
     "@types/jest": "npm:29.5.13"
     "@typescript-eslint/eslint-plugin": "npm:^7.4.0"
     "@typescript-eslint/parser": "npm:^7.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7465,7 +7465,7 @@ __metadata:
     typescript: "npm:5.4.3"
     winston: "npm:3.13.0"
   peerDependencies:
-    "@hathor/wallet-lib": 2.5.1
+    "@hathor/wallet-lib": 2.8.3
   languageName: unknown
   linkType: soft
 
@@ -17817,7 +17817,7 @@ __metadata:
     xstate: "npm:4.38.2"
     zod: "npm:3.23.8"
   peerDependencies:
-    "@hathor/wallet-lib": 2.5.1
+    "@hathor/wallet-lib": 2.8.3
     "@wallet-service/common": 1.5.0
   languageName: unknown
   linkType: soft
@@ -18938,7 +18938,7 @@ __metadata:
     webpack-node-externals: "npm:3.0.0"
     winston: "npm:3.13.0"
   peerDependencies:
-    "@hathor/wallet-lib": 2.5.1
+    "@hathor/wallet-lib": 2.8.3
     "@wallet-service/common": 1.5.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Motivation

The wallet-lib start a background task that prevents jest from finishing properly.
The lib (after v2.8.X) exports a method to stop this task so we should use it.

### Acceptance Criteria

- Bump the lib to 2.8.3
- Call `stopGLLBackgroundTask` before all tests

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
