### PR TITLE
fix: consider Serverless prefix when invoking functions

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -59,6 +59,7 @@ env:
     testnetindia_PUSH_NOTIFICATION_ENABLED: "true"
     testnetindia_PUSH_ALLOWED_PROVIDERS: "android,ios"
     testnetindia_APPLICATION_NAME: "wallet-service-testnet-india"
+    testnetindia_SERVERLESS_DEPLOY_PREFIX: "wallet-service"
     mainnet_staging_DEFAULT_SERVER: "https://wallet-service.private-nodes.hathor.network/v1a/"
     mainnet_staging_WS_DOMAIN: "ws.staging.wallet-service.hathor.network"
     mainnet_staging_NETWORK: "mainnet"

--- a/packages/common/__tests__/utils/nft.utils.test.ts
+++ b/packages/common/__tests__/utils/nft.utils.test.ts
@@ -379,7 +379,7 @@ describe('invokeNftHandlerLambda', () => {
     const mLambdaClient = new LambdaClientMock({});
     (mLambdaClient.send as jest.Mocked<any>).mockImplementationOnce(async () => expectedLambdaResponse);
 
-    const result = await NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', logger);
+    const result = await NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', 'hathor-wallet-service', logger);
 
     // Method should return void
     expect(result).toBeUndefined();
@@ -405,7 +405,7 @@ describe('invokeNftHandlerLambda', () => {
     const mLambdaClient = new LambdaClientMock({});
     (mLambdaClient.send as jest.Mocked<any>).mockResolvedValueOnce(expectedLambdaResponse);
 
-    await expect(NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', logger))
+    await expect(NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', 'hathor-wallet-service', logger))
       .rejects.toThrow('onNewNftEvent lambda invoke failed for tx: test-tx-id');
 
     // Verify alert was added
@@ -424,7 +424,7 @@ describe('invokeNftHandlerLambda', () => {
     // Disable NFT auto review
     process.env.NFT_AUTO_REVIEW_ENABLED = 'false';
 
-    const result = await NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', logger);
+    const result = await NftUtils.invokeNftHandlerLambda('test-tx-id', 'local', 'hathor-wallet-service', logger);
 
     // Method should return void
     expect(result).toBeUndefined();
@@ -688,6 +688,7 @@ describe('processNftEvent', () => {
     const result = await NftUtils.processNftEvent(
       eventData,
       'test-stage',
+      'hathor-wallet-service',
       mockNetwork as unknown as hathorLib.Network,
       logger
     );
@@ -718,6 +719,7 @@ describe('processNftEvent', () => {
     expect(invokeNftLambdaSpy).toHaveBeenCalledWith(
       eventData.hash,
       'test-stage',
+      'hathor-wallet-service',
       logger
     );
   });
@@ -732,6 +734,7 @@ describe('processNftEvent', () => {
     const result = await NftUtils.processNftEvent(
       eventData,
       'test-stage',
+      'hathor-wallet-service',
       mockNetwork as unknown as hathorLib.Network,
       logger
     );
@@ -751,6 +754,7 @@ describe('processNftEvent', () => {
     const result = await NftUtils.processNftEvent(
       eventData,
       'test-stage',
+      'hathor-wallet-service',
       mockNetwork as unknown as hathorLib.Network,
       logger
     );
@@ -776,6 +780,7 @@ describe('processNftEvent', () => {
     const result = await NftUtils.processNftEvent(
       eventData,
       'test-stage',
+      'hathor-wallet-service',
       mockNetwork as unknown as hathorLib.Network,
       logger
     );
@@ -809,6 +814,7 @@ describe('processNftEvent', () => {
     const result = await NftUtils.processNftEvent(
       eventData,
       'test-stage',
+      'hathor-wallet-service',
       mockNetwork as unknown as hathorLib.Network,
       logger
     );
@@ -887,6 +893,7 @@ it('should perform full NFT processing with real event data and no mocks', async
       const result = await NftUtils.processNftEvent(
         eventData,
         'test-stage',
+        'hathor-wallet-service',
         mockNetwork as unknown as hathorLib.Network,
         logger
       );

--- a/packages/common/src/utils/nft.utils.ts
+++ b/packages/common/src/utils/nft.utils.ts
@@ -145,7 +145,7 @@ export class NftUtils {
    * Invokes this application's own intermediary lambda `onNewNftEvent`.
    * This is to improve the failure tolerance on this non-critical step of the sync loop.
    */
-  static async invokeNftHandlerLambda(txId: string, stage: string, logger: Logger): Promise<void> {
+  static async invokeNftHandlerLambda(txId: string, stage: string, deployPrefix: string, logger: Logger): Promise<void> {
     // Check for required environment variables
     if (!process.env.WALLET_SERVICE_LAMBDA_ENDPOINT || !process.env.AWS_REGION) {
       throw new Error('Environment variables WALLET_SERVICE_LAMBDA_ENDPOINT and AWS_REGION are not set.');
@@ -163,7 +163,7 @@ export class NftUtils {
     });
     // invoke lambda asynchronously to metadata update
     const command = new InvokeCommand({
-      FunctionName: `hathor-wallet-service-${stage}-onNewNftEvent`,
+      FunctionName: `${deployPrefix}-${stage}-onNewNftEvent`,
       InvocationType: 'Event',
       Payload: JSON.stringify({ nftUid: txId }),
     });
@@ -190,6 +190,7 @@ export class NftUtils {
   static async processNftEvent(
     eventData: FullNodeTransaction,
     stage: string,
+    deployPrefix: string,
     network: Network,
     logger: Logger
   ): Promise<boolean> {
@@ -215,7 +216,7 @@ export class NftUtils {
         const txId = eventData.hash;
 
         // Invoke the lambda function
-        await NftUtils.invokeNftHandlerLambda(txId, stage, logger);
+        await NftUtils.invokeNftHandlerLambda(txId, stage, deployPrefix, logger);
         return true;
       }
 

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -44,6 +44,7 @@ export const TX_CACHE_SIZE = parseInt(process.env.TX_CACHE_SIZE ?? '10000', 10);
 // Number of blocks before unlocking a block utxo
 export const BLOCK_REWARD_LOCK = parseInt(process.env.BLOCK_REWARD_LOCK ?? '10', 10);
 export const STAGE = process.env.STAGE ?? 'local';
+export const SERVERLESS_DEPLOY_PREFIX = process.env.SERVERLESS_DEPLOY_PREFIX ?? 'hathor-wallet-service';
 
 // Fullnode information, used to make sure we're connected to the same fullnode
 export const FULLNODE_PEER_ID = process.env.FULLNODE_PEER_ID;
@@ -114,6 +115,7 @@ export default () => ({
   PUSH_NOTIFICATION_ENABLED,
   WALLET_SERVICE_LAMBDA_ENDPOINT,
   STAGE,
+  SERVERLESS_DEPLOY_PREFIX,
   ACCOUNT_ID,
   AWS_REGION,
   ALERT_MANAGER_REGION,

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -191,6 +191,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
   const {
     NETWORK,
     STAGE,
+    SERVERLESS_DEPLOY_PREFIX,
     PUSH_NOTIFICATION_ENABLED,
   } = getConfig();
 
@@ -444,7 +445,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
 
       // Call to process the data for NFT handling (if applicable)
       // This process is not critical, so we run it in a fire-and-forget manner, not waiting for the promise.
-      NftUtils.processNftEvent(fullNodeData, STAGE, network, logger)
+      NftUtils.processNftEvent(fullNodeData, STAGE, SERVERLESS_DEPLOY_PREFIX, network, logger)
         .catch((err: unknown) => logger.error('[ALERT] Error processing NFT event', err));
     }
 

--- a/packages/daemon/src/utils/aws.ts
+++ b/packages/daemon/src/utils/aws.ts
@@ -8,8 +8,8 @@ import { addAlert, Transaction } from '@wallet-service/common';
 import { bigIntUtils } from '@hathor/wallet-lib';
 
 export function buildFunctionName(functionName: string): string {
-  const { STAGE } = getConfig();
-  return `hathor-wallet-service-${STAGE}-${functionName}`;
+  const { STAGE, SERVERLESS_DEPLOY_PREFIX } = getConfig();
+  return `${SERVERLESS_DEPLOY_PREFIX}-${STAGE}-${functionName}`;
 }
 
 /**

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -187,6 +187,7 @@ provider:
     REDIS_PASSWORD: ${env:REDIS_PASSWORD}
     SERVICE_NAME: ${self:service}
     STAGE: ${self:custom.stage}
+    SERVERLESS_DEPLOY_PREFIX: ${env:SERVERLESS_DEPLOY_PREFIX}
     EXPLORER_SERVICE_STAGE: ${self:custom.explorerServiceStage}
     NFT_AUTO_REVIEW_ENABLED: ${env:NFT_AUTO_REVIEW_ENABLED}
     VOIDED_TX_OFFSET: ${env:VOIDED_TX_OFFSET}

--- a/packages/wallet-service/src/config.ts
+++ b/packages/wallet-service/src/config.ts
@@ -13,6 +13,7 @@ export function loadEnvConfig(): EnvironmentConfig {
   const config: EnvironmentConfig = {
     defaultServer: process.env.DEFAULT_SERVER ?? 'https://node1.mainnet.hathor.network/v1a/',
     stage: process.env.STAGE,
+    serverlessDeployPrefix: process.env.SERVERLESS_DEPLOY_PREFIX ?? 'hathor-wallet-service',
     network: process.env.NETWORK,
     serviceName: process.env.SERVICE_NAME,
     maxAddressGap: Number.parseInt(process.env.MAX_ADDRESS_GAP, 10),

--- a/packages/wallet-service/src/schemas.ts
+++ b/packages/wallet-service/src/schemas.ts
@@ -41,6 +41,7 @@ export const FullnodeVersionSchema = Joi.object<FullNodeApiVersionResponse>({
 export const EnvironmentConfigSchema = Joi.object<EnvironmentConfig>({
   defaultServer: Joi.string().required(),
   stage: Joi.string().required(),
+  serverlessDeployPrefix: Joi.string().required(),
   network: Joi.string().required(),
   serviceName: Joi.string().required(),
   maxAddressGap: Joi.number().required(),

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -45,6 +45,7 @@ export enum TxProposalStatus {
 export interface EnvironmentConfig {
   defaultServer: string;
   stage: string;
+  serverlessDeployPrefix: string;
   network: string;
   serviceName: string;
   maxAddressGap: number;

--- a/packages/wallet-service/src/utils/pushnotification.utils.ts
+++ b/packages/wallet-service/src/utils/pushnotification.utils.ts
@@ -32,7 +32,7 @@ const FirebaseConfigSchema = EnvironmentConfigSchema.fork([
 ], (schema) => schema.required());
 
 export function buildFunctionName(functionName: string): string {
-  return `hathor-wallet-service-${config.stage}-${functionName}`;
+  return `${config.serverlessDeployPrefix}-${config.stage}-${functionName}`;
 }
 
 export enum FunctionName {


### PR DESCRIPTION
### Motivation

Some parts of the code have hardcoded function prefixes, and we recently started allowing customizable prefixes

### Acceptance Criteria

- The wallet-service and daemon packages should read the env var used to configure the prefix, with a default of `hathor-wallet-service`

### TODO

- [ ] We should redeploy testnet-india after this PR is merged (lambdas and daemon, also check https://github.com/HathorNetwork/ops-tools/pull/1102)

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
