### PR TITLE
fix: wallet-service dev config

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -16,7 +16,7 @@ env:
     TX_HISTORY_MAX_COUNT: 50
     CREATE_NFT_MAX_RETRIES: 3
     dev_DEFAULT_SERVER: "https://wallet-service.private-nodes.india.testnet.hathor.network/v1a/"
-    dev_WS_DOMAIN: "ws.dev.wallet-service.india.testnet.hathor.network"
+    dev_WS_DOMAIN: "ws.wallet-service.india.testnet.hathor.network"
     dev_NETWORK: "testnet"
     dev_LOG_LEVEL: "debug"
     dev_NFT_AUTO_REVIEW_ENABLED: "true"


### PR DESCRIPTION
### Acceptance Criteria

- Fix the websocket URL for dev-testnet

### Motivation

The domain ws.dev.wallet-service.india.testnet.hathor.network does not exist.

We have a fullnode for wallet-service in Testnet-india which serves in wallet-service.india.testnet.hathor.network and ws.wallet-service.india.testnet.hathor.network.

We point the dev-testnet to it as well, we don't have a domain specifically for the dev-testnet.

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
