### PR TITLE
fix: serverless missing env and no default set

### DIFF
--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -187,7 +187,7 @@ provider:
     REDIS_PASSWORD: ${env:REDIS_PASSWORD}
     SERVICE_NAME: ${self:service}
     STAGE: ${self:custom.stage}
-    SERVERLESS_DEPLOY_PREFIX: ${env:SERVERLESS_DEPLOY_PREFIX}
+    SERVERLESS_DEPLOY_PREFIX: ${env:SERVERLESS_DEPLOY_PREFIX, "hathor-wallet-service"}
     EXPLORER_SERVICE_STAGE: ${self:custom.explorerServiceStage}
     NFT_AUTO_REVIEW_ENABLED: ${env:NFT_AUTO_REVIEW_ENABLED}
     VOIDED_TX_OFFSET: ${env:VOIDED_TX_OFFSET}


### PR DESCRIPTION
### Motivation

```
Error:
Cannot resolve serverless.yml: Variables resolution errored with:
  - Cannot resolve variable at "provider.environment.SERVERLESS_DEPLOY_PREFIX": Value not found at "env" source
```

### Acceptance Criteria

- We should set a default for SERVERLESS_DEPLOY_PREFIX, to stop the error in serverless

### TODO

- [ ] Make sure the build runs for the daemon and update the testnet-india with the new image

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
