### PR TITLE
fix: exp retry checkformissingevents

### DIFF
--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -113,6 +113,7 @@ jest.mock('../../src/utils', () => ({
   sendMessageSQS: jest.fn(),
   getWalletBalancesForTx: jest.fn(),
   generateAddresses: jest.fn(),
+  retryWithBackoff: jest.fn((fn) => fn()),
 }));
 
 jest.mock('@wallet-service/common', () => {

--- a/packages/daemon/__tests__/utils/retry.test.ts
+++ b/packages/daemon/__tests__/utils/retry.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { retryWithBackoff } from '../../src/utils/retry';
+import logger from '../../src/logger';
+
+jest.mock('../../src/logger', () => ({
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+}));
+
+describe('retryWithBackoff', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should succeed on first attempt', async () => {
+    const mockFn = jest.fn().mockResolvedValue('success');
+
+    const promise = retryWithBackoff(mockFn);
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry on network error and eventually succeed', async () => {
+    const mockFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce('success');
+
+    const promise = retryWithBackoff(mockFn, {
+      maxRetries: 3,
+      initialDelayMs: 100,
+    });
+
+    // Fast-forward through all timers
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledTimes(3);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should retry on 5xx server errors', async () => {
+    const serverError = {
+      response: {
+        status: 500,
+      },
+      message: 'Internal Server Error',
+    };
+
+    const mockFn = jest
+      .fn()
+      .mockRejectedValueOnce(serverError)
+      .mockResolvedValueOnce('success');
+
+    const promise = retryWithBackoff(mockFn, {
+      maxRetries: 3,
+      initialDelayMs: 100,
+    });
+
+    await jest.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not retry on 4xx client errors', async () => {
+    const clientError = {
+      response: {
+        status: 404,
+      },
+      message: 'Not Found',
+    };
+
+    const mockFn = jest.fn().mockRejectedValue(clientError);
+
+    await expect(
+      retryWithBackoff(mockFn, {
+        maxRetries: 3,
+        initialDelayMs: 100,
+      })
+    ).rejects.toEqual(clientError);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw error after exhausting all retries', async () => {
+    const error = new Error('Network error');
+    const mockFn = jest.fn().mockRejectedValue(error);
+
+    const promise = retryWithBackoff(mockFn, {
+      maxRetries: 2,
+      initialDelayMs: 100,
+    });
+
+    // Run all timers and wait for promise to settle
+    const resultPromise = promise.catch((e) => e);
+    await jest.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result).toEqual(error);
+    expect(mockFn).toHaveBeenCalledTimes(3); // Initial + 2 retries
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalledWith('All 2 retry attempts exhausted');
+  });
+
+  it('should use exponential backoff', async () => {
+    const mockFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Fail 1'))
+      .mockRejectedValueOnce(new Error('Fail 2'))
+      .mockResolvedValueOnce('success');
+
+    const promise = retryWithBackoff(mockFn, {
+      maxRetries: 3,
+      initialDelayMs: 1000,
+      backoffMultiplier: 2,
+    });
+
+    // First retry should wait 1000ms
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(mockFn).toHaveBeenCalledTimes(2);
+
+    // Second retry should wait 2000ms
+    await jest.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('should respect maxDelayMs', async () => {
+    const mockFn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Fail 1'))
+      .mockRejectedValueOnce(new Error('Fail 2'))
+      .mockRejectedValueOnce(new Error('Fail 3'))
+      .mockResolvedValueOnce('success');
+
+    const promise = retryWithBackoff(mockFn, {
+      maxRetries: 4,
+      initialDelayMs: 1000,
+      maxDelayMs: 3000,
+      backoffMultiplier: 2,
+    });
+
+    // First retry: 1000ms
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(mockFn).toHaveBeenCalledTimes(2);
+
+    // Second retry: 2000ms
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(mockFn).toHaveBeenCalledTimes(3);
+
+    // Third retry: should be capped at 3000ms instead of 4000ms
+    await jest.advanceTimersByTimeAsync(3000);
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledTimes(4);
+  });
+
+  it('should use custom retryableErrors function', async () => {
+    const customError = new Error('Custom non-retryable error');
+    const mockFn = jest.fn().mockRejectedValue(customError);
+
+    await expect(
+      retryWithBackoff(mockFn, {
+        maxRetries: 3,
+        retryableErrors: (error) => error.message !== 'Custom non-retryable error',
+      })
+    ).rejects.toThrow('Custom non-retryable error');
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/daemon/src/utils/index.ts
+++ b/packages/daemon/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './wallet';
 export * from './date';
 export * from './helpers';
 export * from './aws';
+export * from './retry';

--- a/packages/daemon/src/utils/retry.ts
+++ b/packages/daemon/src/utils/retry.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import logger from '../logger';
+
+export interface RetryOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffMultiplier?: number;
+  retryableErrors?: (error: any) => boolean;
+}
+
+const DEFAULT_OPTIONS: Required<RetryOptions> = {
+  maxRetries: 3,
+  initialDelayMs: 1000,
+  maxDelayMs: 10000,
+  backoffMultiplier: 2,
+  retryableErrors: (error: any) => {
+    // Retry on network errors and 5xx server errors
+    if (error.response) {
+      // HTTP error response received
+      return error.response.status >= 500 && error.response.status < 600;
+    }
+    // Network error (no response received)
+    return true;
+  },
+};
+
+/**
+ * Sleep utility function
+ */
+const sleep = (ms: number): Promise<void> => new Promise(resolve => {
+  setTimeout(resolve, ms);
+});
+
+/**
+ * Calculate the delay for the next retry attempt using exponential backoff
+ */
+const calculateDelay = (
+  attempt: number,
+  initialDelayMs: number,
+  maxDelayMs: number,
+  backoffMultiplier: number
+): number => {
+  const delay = initialDelayMs * (backoffMultiplier ** attempt);
+  return Math.min(delay, maxDelayMs);
+};
+
+/**
+ * Retry a function with exponential backoff
+ *
+ * @param fn - The async function to retry
+ * @param options - Retry configuration options
+ * @returns Promise that resolves with the function result or rejects with the last error
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const config = { ...DEFAULT_OPTIONS, ...options };
+  let lastError: any;
+
+  for (let attempt = 0; attempt <= config.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      // Check if we should retry this error
+      if (!config.retryableErrors(error)) {
+        logger.debug('Error is not retryable, throwing immediately');
+        throw error;
+      }
+
+      // Check if we've exhausted all retries
+      if (attempt === config.maxRetries) {
+        logger.error(`All ${config.maxRetries} retry attempts exhausted`);
+        throw error;
+      }
+
+      // Calculate delay and wait before next retry
+      const delay = calculateDelay(
+        attempt,
+        config.initialDelayMs,
+        config.maxDelayMs,
+        config.backoffMultiplier
+      );
+
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      logger.warn(
+        `Retry attempt ${attempt + 1}/${config.maxRetries} failed. ` +
+        `Retrying in ${delay}ms. Error: ${errorMsg}`
+      );
+
+      await sleep(delay);
+    }
+  }
+
+  // This should never be reached, but TypeScript needs it
+  throw lastError;
+}


### PR DESCRIPTION
### Acceptance Criteria
- The `checkForMissedEvents` service implements a retry mechanism with exponential backoff
- Network errors and 5xx server errors trigger automatic retries (up to 10 attempts)
- Exponential backoff starts at 1 second and caps at 10 seconds maximum delay
- After exhausting all 10 retries (~75 seconds total), the service transitions to ERROR state with appropriate error logging
- Production errors like "Network error - Connection refused" will now trigger automatic retries instead of immediate failure

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
