### PR TITLE
fix: increase retry attempts when getting events from fullnodes

### DIFF
--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -859,7 +859,9 @@ export const checkForMissedEvents = async (context: Context): Promise<{ hasNewEv
         return res;
       },
       {
-        maxRetries: 3,
+        // It's possible that the fullnode is under high load or having intermittent issues,
+        // so we use a higher number of retries to give it a chance to recover
+        maxRetries: 10,
         initialDelayMs: 1000,
         maxDelayMs: 10000,
         backoffMultiplier: 2,

--- a/packages/daemon/src/utils/retry.ts
+++ b/packages/daemon/src/utils/retry.ts
@@ -16,7 +16,7 @@ export interface RetryOptions {
 }
 
 const DEFAULT_OPTIONS: Required<RetryOptions> = {
-  maxRetries: 3,
+  maxRetries: 5,
   initialDelayMs: 1000,
   maxDelayMs: 10000,
   backoffMultiplier: 2,


### PR DESCRIPTION
### Acceptance Criteria

- We should use a higher number of attemps when retrying getting events from the fullnode, because it could be under high load or facing temporary issues

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
