### PR TITLE
chore: added a composite index to tx_output to reduce query time

### DIFF
--- a/db/migrations/20251201104138-add-tx-output-utxo-lookup-index.js
+++ b/db/migrations/20251201104138-add-tx-output-utxo-lookup-index.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    // Check if index exists
+    const [indexes] = await queryInterface.sequelize.query(`
+      SELECT COUNT(DISTINCT index_name) as count
+      FROM information_schema.statistics
+      WHERE table_schema = DATABASE()
+        AND table_name = 'tx_output'
+        AND index_name = 'idx_tx_output_utxo_lookup';
+    `);
+
+    // Only create if it doesn't exist
+    if (indexes[0].count === 0) {
+      await queryInterface.sequelize.query(`
+        CREATE INDEX idx_tx_output_utxo_lookup
+        ON tx_output (address, token_id, spent_by, voided, locked, authorities);
+      `);
+    }
+  },
+
+  down: async (queryInterface) => {
+    // Check if index exists before dropping
+    const [indexes] = await queryInterface.sequelize.query(`
+      SELECT COUNT(DISTINCT index_name) as count
+      FROM information_schema.statistics
+      WHERE table_schema = DATABASE()
+        AND table_name = 'tx_output'
+        AND index_name = 'idx_tx_output_utxo_lookup';
+    `);
+
+    if (indexes[0].count > 0) {
+      await queryInterface.sequelize.query(`
+        DROP INDEX idx_tx_output_utxo_lookup ON tx_output;
+      `);
+    }
+  },
+};


### PR DESCRIPTION
### Motivation

### Problem

The following query was taking ~90 seconds to execute:

```sql
UPDATE `address_balance`
SET `unlocked_authorities` = (
    SELECT BIT_OR(`authorities`)
    FROM `tx_output`
    WHERE `address` = 'HH5As5aLtzFkcbmbXZmE65wSd22GqPWq2T'
      AND `token_id` = '00'
      AND `locked` = FALSE
      AND `spent_by` IS NULL
      AND `voided` = FALSE
)
WHERE `address` = 'HH5As5aLtzFkcbmbXZmE65wSd22GqPWq2T'
  AND `token_id` = '00'
```

### Root Cause

MySQL was choosing `tx_output_spent_by_idx`, scanning ~1M rows (all unspent UTXOs) and filtering by address/token_id afterward.

### Solution

Add a composite covering index:
```sql
CREATE INDEX idx_tx_output_utxo_lookup 
ON tx_output (address, token_id, spent_by, voided, locked, authorities);
```

### Results

| Metric | Before | After |
|--------|--------|-------|
| Index used | `spent_by_idx` | `idx_tx_output_utxo_lookup` |
| Rows scanned | 1,002,812 | 270,830 |
| Filtered | 6.25% | 100% |
| Extra | Using index condition; Using where | Using index (covering) |

Query time expected to drop from ~90s to milliseconds.


### Index disk usage

On the current database with ~7.1M rows, the new index idx_tx_output_utxo_lookup uses ~1.26 GB.
At 10x scale (~71M rows), estimated size: ~12.6 GB.



### Acceptance Criteria

- We should check if the index already exist before creating it because the index was already created in `mainnet-staging`

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
