### PR TITLE
CI: remove nano-testnets

### DIFF
--- a/.codebuild/build.sh
+++ b/.codebuild/build.sh
@@ -154,93 +154,6 @@ deploy_hathor_network_account() {
     fi;
 }
 
-deploy_nano_testnet() {
-    # Deploys the releases and release-candidates to our nano-testnet environment
-
-    # We deploy only the Lambdas here, because the daemon used in nano-testnet is the same as
-    # the one built in the hathor-network account, since it runs there as well
-
-    echo "Building git ref ${GIT_REF_TO_DEPLOY}..."
-
-    # This will match both releases and release-candidates
-    if expr "${GIT_REF_TO_DEPLOY}" : "v.*" >/dev/null; then
-        make migrate;
-        make deploy-lambdas-nano-testnet;
-
-        send_slack_message "New version deployed to nano-testnet-alpha: ${GIT_REF_TO_DEPLOY}"
-    elif expr "${MANUAL_DEPLOY}" : "true" >/dev/null; then
-        make migrate;
-        make deploy-lambdas-nano-testnet;
-
-        send_slack_message "Branch manually deployed to nano-testnet-alpha: ${GIT_REF_TO_DEPLOY}"
-    elif expr "${ROLLBACK}" : "true" >/dev/null; then
-        make migrate;
-        make deploy-lambdas-nano-testnet;
-
-        send_slack_message "Rollback performed on nano-tesnet-alpha to: ${GIT_REF_TO_DEPLOY}";
-    else
-        echo "We don't deploy ${GIT_REF_TO_DEPLOY} to nano-testnet-alpha. Nothing to do.";
-    fi;
-}
-
-deploy_nano_testnet_bravo() {
-    # Deploys the releases and release-candidates to our nano-testnet-bravo environment
-
-    # We deploy only the Lambdas here, because the image for the daemon used in nano-testnet is
-    # the same as the one built in the hathor-network account, since it runs there as well
-
-    echo "Building git ref ${GIT_REF_TO_DEPLOY}..."
-
-    # This will match both releases and release-candidates
-    if expr "${GIT_REF_TO_DEPLOY}" : "v.*" >/dev/null; then
-        make migrate;
-        make deploy-lambdas-nano-testnet-bravo;
-
-        send_slack_message "New version deployed to nano-testnet-bravo: ${GIT_REF_TO_DEPLOY}"
-    elif expr "${MANUAL_DEPLOY}" : "true" >/dev/null; then
-        make migrate;
-        make deploy-lambdas-nano-testnet-bravo;
-
-        send_slack_message "Branch manually deployed to nano-testnet-bravo: ${GIT_REF_TO_DEPLOY}"
-    elif expr "${ROLLBACK}" : "true" >/dev/null; then
-        make migrate;
-        make deploy-lambdas-nano-testnet-bravo;
-
-        send_slack_message "Rollback performed on nano-tesnet-bravo to: ${GIT_REF_TO_DEPLOY}";
-    else
-        echo "We don't deploy ${GIT_REF_TO_DEPLOY} to nano-testnet-bravo. Nothing to do.";
-    fi;
-}
-
-deploy_nano_testnet_hackaton() {
-    # Deploys the releases and release-candidates to our nano-testnet-hackaton environment
-
-    # We deploy only the Lambdas here, because the daemon used in nano-testnet-hackaton is the same as
-    # the one built in the hathor-network account, since it runs there as well
-
-    echo "Building git ref ${GIT_REF_TO_DEPLOY}..."
-
-    # This will match both releases and release-candidates
-    if expr "${GIT_REF_TO_DEPLOY}" : "v.*" >/dev/null; then
-        make migrate;
-        make deploy-lambdas-nano-testnet-hackaton;
-
-        send_slack_message "New version deployed to nano-testnet-hackaton: ${GIT_REF_TO_DEPLOY}"
-    elif expr "${MANUAL_DEPLOY}" : "true" >/dev/null; then
-        make migrate;
-        make deploy-lambdas-nano-testnet-hackaton;
-
-        send_slack_message "Branch manually deployed to nano-testnet-hackaton: ${GIT_REF_TO_DEPLOY}"
-    elif expr "${ROLLBACK}" : "true" >/dev/null; then
-        make migrate;
-        make deploy-lambdas-nano-testnet-hackaton;
-
-        send_slack_message "Rollback performed on nano-tesnet-hackaton to: ${GIT_REF_TO_DEPLOY}";
-    else
-        echo "We don't deploy ${GIT_REF_TO_DEPLOY} to nano-testnet-hackaton. Nothing to do.";
-    fi;
-}
-
 deploy_ekvilibro_mainnet() {
     # Deploys the releases to our ekvilibro-mainnet environment
 
@@ -340,15 +253,6 @@ case $option in
     # This will be triggered from /.codebuild/buildspec.yml in this repo
     hathor-network)
         deploy_hathor_network_account
-        ;;
-    nano-testnet)
-        deploy_nano_testnet
-        ;;
-    nano-testnet-bravo)
-        deploy_nano_testnet_bravo
-        ;;
-    nano-testnet-hackaton)
-        deploy_nano_testnet_hackaton
         ;;
     ekvilibro-testnet)
         deploy_ekvilibro_testnet


### PR DESCRIPTION
### Motivation

We removed some of our nano-testntes

### Acceptance Criteria

- We should remove the logic to deploy to the removed nano-testnets from our CI/CD

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
