### PR TITLE
feat(daemon): stop failing with TOKEN_CREATED events

### DIFF
--- a/packages/daemon/__tests__/machines/SyncMachine.test.ts
+++ b/packages/daemon/__tests__/machines/SyncMachine.test.ts
@@ -571,6 +571,42 @@ describe('Event handling', () => {
     expect(currentState.matches(`${SYNC_MACHINE_STATES.CONNECTED}.${CONNECTED_STATES.handlingUnhandledEvent}`)).toBeTruthy();
   });
 
+  it('should handle TOKEN_CREATED events', () => {
+    const MockedFetchMachine = SyncMachine.withConfig({
+      guards: {
+        invalidPeerId: () => false,
+        invalidStreamId: () => false,
+        invalidNetwork: () => false,
+      },
+    });
+
+    let currentState = untilIdle(MockedFetchMachine);
+
+    currentState = MockedFetchMachine.transition(currentState, {
+      type: EventTypes.FULLNODE_EVENT,
+      event: {
+        type: 'EVENT',
+        stream_id: 'test-stream',
+        peer_id: 'test-peer',
+        network: 'testnet',
+        latest_event_id: 100,
+        event: {
+          id: 42,
+          timestamp: 1764886556.4163492,
+          type: 'TOKEN_CREATED',
+          data: {
+            token_uid: '00001eed7f8e446fed2147911656a659df8f3482aecd7a7dcb8f342d930107f7',
+            token_name: 'Test Token',
+            token_symbol: 'TST',
+          },
+          group_id: null,
+        },
+      } as unknown as FullNodeEvent,
+    });
+
+    expect(currentState.matches(`${SYNC_MACHINE_STATES.CONNECTED}.${CONNECTED_STATES.handlingUnhandledEvent}`)).toBeTruthy();
+  });
+
   it('should handle REORG_STARTED event', () => {
     const MockedFetchMachine = SyncMachine.withConfig({
       guards: {

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -174,7 +174,8 @@ export const metadataDiff = async (_context: Context, event: Event) => {
 };
 
 export const isBlock = (version: number): boolean => version === hathorLib.constants.BLOCK_VERSION
-  || version === hathorLib.constants.MERGED_MINED_BLOCK_VERSION;
+  || version === hathorLib.constants.MERGED_MINED_BLOCK_VERSION
+  || version === hathorLib.constants.POA_BLOCK_VERSION;
 
 export function isNanoContract(headers: EventTxHeader[]) {
   for (const header of headers) {

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -229,12 +229,26 @@ export const NcEventSchema = FullNodeEventBaseSchema.extend({
 });
 export type NcEvent = z.infer<typeof NcEventSchema>;
 
+// Short-term solution: Allow TOKEN_CREATED events to pass validation
+// They will be handled as unhandled events and ACKed
+export const TokenCreatedEventSchema = FullNodeEventBaseSchema.extend({
+  event: z.object({
+    id: z.number(),
+    timestamp: z.number(),
+    type: z.literal('TOKEN_CREATED'),
+    data: z.any(), // Permissive schema - we don't process these events yet
+    group_id: z.number().nullish(),
+  }),
+});
+export type TokenCreatedEvent = z.infer<typeof TokenCreatedEventSchema>;
+
 export const FullNodeEventSchema = z.union([
   TxDataWithoutMetaFullNodeEventSchema,
   StandardFullNodeEventSchema,
   ReorgFullNodeEventSchema,
   EmptyDataFullNodeEventSchema,
   NcEventSchema,
+  TokenCreatedEventSchema,
 ]);
 export type FullNodeEvent = z.infer<typeof FullNodeEventSchema>;
 


### PR DESCRIPTION
### Motivation

The wallet-service fullnode is updated with `TOKEN_CREATED` events.

This is a short-term solution to prevent the zod validation to fail and stop the sync

### Acceptance Criteria

- We must include the `TOKEN_CREATED` event in our zod schema
- We must ACK the event so the sync continues

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
