### PR TITLE
fix: detecting diff error swallowing

### DIFF
--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -861,7 +861,7 @@ describe('metadataDiff', () => {
 
     await expect(metadataDiff({} as any, event as any)).rejects.toThrow('Mock Error');
     expect(mockDb.destroy).toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalledWith('e', new Error('Mock Error'));
+    expect(logger.error).toHaveBeenCalledWith('metadataDiff error', new Error('Mock Error'));
   });
 
   it('should handle transaction transactions that are not voided anymore', async () => {

--- a/packages/daemon/src/machines/SyncMachine.ts
+++ b/packages/daemon/src/machines/SyncMachine.ts
@@ -207,6 +207,7 @@ export const SyncMachine = Machine<Context, any, Event>({
               invoke: {
                 src: 'metadataDiff',
                 onDone: { actions: ['metadataDecided'] },
+                onError: `#${SYNC_MACHINE_STATES.ERROR}`,
               },
               on: {
                 METADATA_DECIDED: [

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -470,10 +470,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
     await mysql.commit();
   } catch (e) {
     await mysql.rollback();
-    console.error('Error handling vertex accepted', {
-      error: (e as Error).message,
-      stack: (e as Error).stack,
-    });
+    logger.error('Error handling vertex accepted', e);
 
     throw e;
   } finally {

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -96,9 +96,11 @@ export const METADATA_DIFF_EVENT_TYPES = {
 const DUPLICATE_TX_ALERT_GRACE_PERIOD = 10; // seconds
 
 export const metadataDiff = async (_context: Context, event: Event) => {
-  const mysql = await getDbConnection();
+  let mysql;
 
   try {
+    mysql = await getDbConnection();
+
     const fullNodeEvent = event.event as StandardFullNodeEvent;
     const {
       hash,
@@ -166,10 +168,12 @@ export const metadataDiff = async (_context: Context, event: Event) => {
       originalEvent: event,
     };
   } catch (e) {
-    logger.error('e', e);
+    logger.error('metadataDiff error', e);
     return Promise.reject(e);
   } finally {
-    mysql.destroy();
+    if (mysql) {
+      mysql.destroy();
+    }
   }
 };
 


### PR DESCRIPTION
## Motivation

The wallet-service-daemon got stuck in the detectingDiff state for 12+ hours on testnet-india (2025-12-15). Root cause analysis revealed that xstate silently swallows errors from invoked services when no onError handler is defined, and this behavior produces no logs in production mode (`NODE_ENV=production`). The metadataDiff invoke was the only one missing an onError handler.

Additionally, getDbConnection() was outside the try/catch block.

## Acceptance Criteria

- Add onError handler to detectingDiff invoke so errors transition to ERROR state instead of being silently swallowed
- Move getDbConnection() inside try/catch in metadataDiff so connection errors are properly logged
- Audit all other invoke states - confirmed all others already have onError handlers


### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
