### PR TITLE
feat(daemon): accepting FULL_NODE_CRASHED event on zod

### DIFF
--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -45,6 +45,7 @@ export enum FullNodeEventTypes {
   REORG_STARTED = 'REORG_STARTED',
   REORG_FINISHED = 'REORG_FINISHED',
   NC_EVENT = 'NC_EVENT',
+  FULL_NODE_CRASHED = 'FULL_NODE_CRASHED',
 }
 
 /**
@@ -62,6 +63,7 @@ const EmptyDataFullNodeEvents = z.union([
   z.literal('LOAD_STARTED'),
   z.literal('LOAD_FINISHED'),
   z.literal('REORG_FINISHED'),
+  z.literal('FULL_NODE_CRASHED'),
 ]);
 
 export const FullNodeEventTypesSchema = z.nativeEnum(FullNodeEventTypes);


### PR DESCRIPTION
### Acceptance Criteria

- Added the `FULL_NODE_CRASHED` event to the zod schema validation so it doesn't crash
- This event will be skipped since it will fall on the catch-all handler

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
