### PR TITLE
fix(daemon): added poa block to isBlock check

### DIFF
--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -178,7 +178,8 @@ export const metadataDiff = async (_context: Context, event: Event) => {
 };
 
 export const isBlock = (version: number): boolean => version === hathorLib.constants.BLOCK_VERSION
-  || version === hathorLib.constants.MERGED_MINED_BLOCK_VERSION;
+  || version === hathorLib.constants.MERGED_MINED_BLOCK_VERSION
+  || version === hathorLib.constants.POA_BLOCK_VERSION;
 
 export function isNanoContract(headers: EventTxHeader[]) {
   for (const header of headers) {


### PR DESCRIPTION
### Motivation

PoA blocks are being stored with height = null in the Ekvlibro mainnet

### Acceptance Criteria

- PoA blocks should be considered in the `isBlock` method so they get their height set.

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
