### PR TITLE
feat(daemon): using the exp backoff util on metadataDiff

### DIFF
--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -1039,7 +1039,7 @@ describe('metadataDiff', () => {
 
     await expect(metadataDiff({} as any, event as any)).rejects.toThrow('Mock Error');
     expect(mockDb.destroy).toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalledWith('metadataDiff error', new Error('Mock Error'));
+    expect(logger.error).toHaveBeenCalledWith('metadataDiff error', { hash: 'mockHash', error: new Error('Mock Error') });
   });
 
   it('should handle transaction transactions that are not voided anymore', async () => {

--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -1028,6 +1028,7 @@ describe('metadataDiff', () => {
     const event = {
       event: {
         event: {
+          id: 123,
           data: {
             hash: 'mockHash',
             metadata: { voided_by: [], first_block: [] },
@@ -1039,7 +1040,7 @@ describe('metadataDiff', () => {
 
     await expect(metadataDiff({} as any, event as any)).rejects.toThrow('Mock Error');
     expect(mockDb.destroy).toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalledWith('metadataDiff error', { hash: 'mockHash', error: new Error('Mock Error') });
+    expect(logger.error).toHaveBeenCalledWith('metadataDiff error', { eventId: 123, error: new Error('Mock Error') });
   });
 
   it('should handle transaction transactions that are not voided anymore', async () => {

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -102,100 +102,120 @@ export const METADATA_DIFF_EVENT_TYPES = {
 const DUPLICATE_TX_ALERT_GRACE_PERIOD = 10; // seconds
 
 export const metadataDiff = async (_context: Context, event: Event) => {
-  let mysql;
+  const fullNodeEvent = event.event as StandardFullNodeEvent;
+  const {
+    hash,
+    metadata: { voided_by, first_block, nc_execution },
+  } = fullNodeEvent.event.data;
+
+  const isRetryableError = (error: any): boolean => {
+    const code = error?.code;
+    return code === 'ETIMEDOUT'
+      || code === 'ECONNREFUSED'
+      || code === 'ECONNRESET'
+      || code === 'PROTOCOL_CONNECTION_LOST';
+  };
 
   try {
-    mysql = await getDbConnection();
+    return await retryWithBackoff(
+      async () => {
+        let mysql;
+        try {
+          mysql = await getDbConnection();
+          const dbTx: DbTransaction | null = await getTransactionById(mysql, hash);
 
-    const fullNodeEvent = event.event as StandardFullNodeEvent;
-    const {
-      hash,
-      metadata: { voided_by, first_block, nc_execution },
-    } = fullNodeEvent.event.data;
-    const dbTx: DbTransaction | null = await getTransactionById(mysql, hash);
+          if (!dbTx) {
+            if (voided_by.length > 0) {
+              // No need to add voided transactions
+              return {
+                type: METADATA_DIFF_EVENT_TYPES.IGNORE,
+                originalEvent: event,
+              };
+            }
 
-    if (!dbTx) {
-      if (voided_by.length > 0) {
-        // No need to add voided transactions
-        return {
-          type: METADATA_DIFF_EVENT_TYPES.IGNORE,
-          originalEvent: event,
-        };
-      }
+            return {
+              type: METADATA_DIFF_EVENT_TYPES.TX_NEW,
+              originalEvent: event,
+            };
+          }
 
-      return {
-        type: METADATA_DIFF_EVENT_TYPES.TX_NEW,
-        originalEvent: event,
-      };
-    }
+          // Tx is voided
+          if (voided_by.length > 0) {
+            // Was it voided on the database?
+            if (!dbTx.voided) {
+              return {
+                type: METADATA_DIFF_EVENT_TYPES.TX_VOIDED,
+                originalEvent: event,
+              };
+            }
 
-    // Tx is voided
-    if (voided_by.length > 0) {
-      // Was it voided on the database?
-      if (!dbTx.voided) {
-        return {
-          type: METADATA_DIFF_EVENT_TYPES.TX_VOIDED,
-          originalEvent: event,
-        };
-      }
+            return {
+              type: METADATA_DIFF_EVENT_TYPES.IGNORE,
+              originalEvent: event,
+            };
+          }
 
-      return {
-        type: METADATA_DIFF_EVENT_TYPES.IGNORE,
-        originalEvent: event,
-      };
-    }
+          // Tx was voided in the database but is not anymore
+          if (dbTx.voided && voided_by.length <= 0) {
+            return {
+              type: METADATA_DIFF_EVENT_TYPES.TX_UNVOIDED,
+              originalEvent: event,
+            };
+          }
 
-    // Tx was voided in the database but is not anymore
-    if (dbTx.voided && voided_by.length <= 0) {
-      return {
-        type: METADATA_DIFF_EVENT_TYPES.TX_UNVOIDED,
-        originalEvent: event,
-      };
-    }
+          if (first_block
+            && first_block.length
+            && first_block.length > 0) {
+            if (!dbTx.height) {
+              return {
+                type: METADATA_DIFF_EVENT_TYPES.TX_FIRST_BLOCK,
+                originalEvent: event,
+              };
+            }
 
-    if (first_block
-      && first_block.length
-      && first_block.length > 0) {
-      if (!dbTx.height) {
-        return {
-          type: METADATA_DIFF_EVENT_TYPES.TX_FIRST_BLOCK,
-          originalEvent: event,
-        };
-      }
+            return {
+              type: METADATA_DIFF_EVENT_TYPES.IGNORE,
+              originalEvent: event,
+            };
+          }
 
-      return {
-        type: METADATA_DIFF_EVENT_TYPES.IGNORE,
-        originalEvent: event,
-      };
-    }
+          // Check if nc_execution changed from 'success' to something else.
+          // If the tx has nano-created tokens in the database (tokens where token_id != tx_id),
+          // those tokens were created when nc_execution was 'success'.
+          // If nc_execution is now NOT 'success', we should delete those tokens.
+          if (nc_execution !== 'success') {
+            const tokensCreated = await getTokensCreatedByTx(mysql, hash);
+            const nanoTokens = tokensCreated.filter(tokenId => tokenId !== hash);
 
-    // Check if nc_execution changed from 'success' to something else.
-    // If the tx has nano-created tokens in the database (tokens where token_id != tx_id),
-    // those tokens were created when nc_execution was 'success'.
-    // If nc_execution is now NOT 'success', we should delete those tokens.
-    if (nc_execution !== 'success') {
-      const tokensCreated = await getTokensCreatedByTx(mysql, hash);
-      const nanoTokens = tokensCreated.filter(tokenId => tokenId !== hash);
+            if (nanoTokens.length > 0) {
+              return {
+                type: METADATA_DIFF_EVENT_TYPES.NC_EXEC_VOIDED,
+                originalEvent: event,
+              };
+            }
+          }
 
-      if (nanoTokens.length > 0) {
-        return {
-          type: METADATA_DIFF_EVENT_TYPES.NC_EXEC_VOIDED,
-          originalEvent: event,
-        };
-      }
-    }
-
-    return {
-      type: METADATA_DIFF_EVENT_TYPES.IGNORE,
-      originalEvent: event,
-    };
+          return {
+            type: METADATA_DIFF_EVENT_TYPES.IGNORE,
+            originalEvent: event,
+          };
+        } finally {
+          if (mysql) {
+            mysql.destroy();
+          }
+        }
+      },
+      {
+        maxRetries: 5,
+        initialDelayMs: 1000,
+        maxDelayMs: 10000,
+        backoffMultiplier: 2,
+        retryableErrors: isRetryableError,
+      },
+    );
   } catch (e) {
-    logger.error('metadataDiff error', e);
+    logger.error('metadataDiff error', { hash, error: e });
     return Promise.reject(e);
-  } finally {
-    if (mysql) {
-      mysql.destroy();
-    }
   }
 };
 

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -214,7 +214,7 @@ export const metadataDiff = async (_context: Context, event: Event) => {
       },
     );
   } catch (e) {
-    logger.error('metadataDiff error', { hash, error: e });
+    logger.error('metadataDiff error', { eventId: fullNodeEvent.event.id, error: e });
     return Promise.reject(e);
   }
 };


### PR DESCRIPTION
### Motivation

Production incident on 2026-01-18: the daemon crashed with `ETIMEDOUT` in metadataDiff and required manual restart. The function had no retry logic, so a single transient DB connection timeout could have caused a fatal error.

### Acceptance Criteria

- `metadataDiff` retries on connection errors (ETIMEDOUT, ECONNREFUSED, ECONNRESET, PROTOCOL_CONNECTION_LOST)
- Up to 5 retries with exponential backoff (1s → 2s → 4s → 8s → 10s max)
- Non-retryable errors fail immediately (no unnecessary delays)
- Error logging includes transaction hash for debugging


### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
