### PR TITLE
feat: increase seqnum

### DIFF
--- a/packages/wallet-service/src/api/txProposalCreate.ts
+++ b/packages/wallet-service/src/api/txProposalCreate.ts
@@ -17,6 +17,7 @@ import {
   getWallet,
   getWalletAddresses,
   getWalletAddressDetail,
+  incrementAddressSeqnum,
   markUtxosWithProposalId,
 } from '@src/db';
 import {
@@ -135,6 +136,11 @@ export const create = middy(walletIdProxyHandler(async (walletId, event) => {
     // Nano contract transactions might have empty inputs
     if (inputUtxos.length > 0) {
       await markUtxosWithProposalId(mysql, txProposalId, inputUtxos);
+    }
+
+    if (tx.isNanoContract()) {
+      const nanoHeader = tx.getNanoHeaders()[0];
+      await incrementAddressSeqnum(mysql, walletId, nanoHeader.address.base58);
     }
 
     await commitTransaction(mysql);

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -449,6 +449,22 @@ export const getWalletAddressDetail = async (mysql: ServerlessMysql, walletId: s
 };
 
 /**
+ * Increment the seqnum of an address.
+ *
+ * @param mysql - Database connection
+ * @param walletId - Wallet id
+ * @param address - Address to increment seqnum for
+ */
+export const incrementAddressSeqnum = async (mysql: ServerlessMysql, walletId: string, address: string): Promise<void> => {
+  await mysql.query(`
+    UPDATE \`address\`
+       SET \`seqnum\` = \`seqnum\` + 1
+     WHERE \`wallet_id\` = ?
+         AND \`address\` = ?`,
+    [walletId, address]);
+};
+
+/**
  * Initialize a wallet's transaction history.
  *
  * @remarks

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -19,6 +19,7 @@ import {
   getUtxosLockedAtHeight,
   getWallet,
   getWalletAddressDetail,
+  incrementAddressSeqnum,
   getWalletAddresses,
   getWalletTokens,
   getWalletBalances,
@@ -924,6 +925,33 @@ test('getWalletAddressDetail', async () => {
 
   const detailNull = await getWalletAddressDetail(mysql, walletId, ADDRESSES[8]);
   expect(detailNull).toBeNull();
+});
+
+test('incrementAddressSeqnum', async () => {
+  expect.hasAssertions();
+  const walletId = 'walletId';
+
+  await addToAddressTable(mysql, [{
+    address: ADDRESSES[0],
+    index: 0,
+    walletId,
+    transactions: 0,
+    seqnum: 5,
+  }]);
+
+  // seqnum should start at 5
+  const before = await getWalletAddressDetail(mysql, walletId, ADDRESSES[0]);
+  expect(before.seqnum).toBe(5);
+
+  // increment and verify
+  await incrementAddressSeqnum(mysql, walletId, ADDRESSES[0]);
+  const after1 = await getWalletAddressDetail(mysql, walletId, ADDRESSES[0]);
+  expect(after1.seqnum).toBe(6);
+
+  // increment again
+  await incrementAddressSeqnum(mysql, walletId, ADDRESSES[0]);
+  const after2 = await getWalletAddressDetail(mysql, walletId, ADDRESSES[0]);
+  expect(after2.seqnum).toBe(7);
 });
 
 test('getWalletBalances', async () => {


### PR DESCRIPTION
### Motivation

When users call `GET /wallet/address/info` to get seqnum before submitting nano contract transactions, the daemon syncs events slowly, so multiple rapid calls return the same seqnum, causing transaction conflicts.

### Acceptance Criteria

- `txProposalCreate` increments the caller address's seqnum when the transaction is a nano contract
- The increment happens atomically within the existing transaction block alongside tx proposal creation and UTXO marking


### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
