### PR TITLE
fix: HTR token seed migration

### DIFF
--- a/db/seeders/20250416132150-add-htr-token.js
+++ b/db/seeders/20250416132150-add-htr-token.js
@@ -2,6 +2,16 @@
 
 module.exports = {
   up: async (queryInterface) => {
+    // Check if HTR token already exists
+    const [existing] = await queryInterface.sequelize.query(
+      "SELECT id FROM token WHERE id = '00'"
+    );
+
+    if (existing.length > 0) {
+      console.log('HTR token already exists, skipping.');
+      return;
+    }
+
     // Count unique transactions for HTR
     const [results] = await queryInterface.sequelize.query(
       "SELECT COUNT(DISTINCT tx_id) AS count FROM tx_output WHERE token_id = '00'"

--- a/db/seeders/20250416132150-add-htr-token.js
+++ b/db/seeders/20250416132150-add-htr-token.js
@@ -14,6 +14,7 @@ module.exports = {
       name: 'Hathor',
       symbol: 'HTR',
       transactions: htrTxCount,
+      version: 0, // TokenVersion.NATIVE
     }]);
   },
 


### PR DESCRIPTION
### Motivation

We were getting an error when running the seeds:

```
> yarn dlx sequelize-cli db:seed:all


Sequelize CLI [Node: 22.14.0, CLI: 6.6.5, ORM: 6.37.2]

Loaded configuration file "db/config.js".
Using environment "production".
== 20250416132150-add-htr-token: migrating =======

ERROR: Validation error
```

### Acceptance Criteria

- The seed migration that adds the HTR token should correctly set its version field.
- The seed migration should run without errors on a clean DB.

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
