### PR TITLE
fix: get total supply null value

### DIFF
--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -2639,7 +2639,11 @@ export const getTotalSupply = async (
     throw new Error('Total supply query returned no results');
   }
 
-  return BigInt(results[0].value as string);
+  // SUM() returns NULL when no rows match the WHERE clause.
+  // This is valid for tokens that exist but have no wallet-owned UTXOs
+  // (e.g., nano contract tokens held entirely by the contract).
+  const value = results[0].value as string | null;
+  return BigInt(value ?? '0');
 };
 
 /**

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -2525,6 +2525,10 @@ test('getTotalSupply', async () => {
   expect(await getTotalSupply(mysql, 'token2')).toStrictEqual(25n);
   expect(await getTotalSupply(mysql, 'token1')).toStrictEqual(35n);
 
+  // Token with no UTXOs returns 0n (e.g., nano contract token held by contract)
+  // SQL SUM() returns NULL when no rows match, which we handle gracefully
+  expect(await getTotalSupply(mysql, 'token-with-no-utxos')).toStrictEqual(0n);
+
   const mysqlQuerySpy = jest.spyOn(mysql, 'query');
   mysqlQuerySpy.mockImplementationOnce(() => Promise.resolve({ length: null }));
 

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -2542,6 +2542,41 @@ test('getTotalSupply', async () => {
   );
 });
 
+test('getTotalSupply returns 0n for nano contract token with no wallet-owned UTXOs', async () => {
+  expect.hasAssertions();
+
+  // Simulate a token created by a nano contract
+  // The daemon indexes it in the token table via TOKEN_CREATED event
+  const nanoContractToken = {
+    id: 'nc_token_abc123',
+    name: 'NanoContractToken',
+    symbol: 'NCT',
+  };
+
+  await storeTokenInformation(
+    mysql,
+    nanoContractToken.id,
+    nanoContractToken.name,
+    nanoContractToken.symbol,
+    TokenVersion.FEE,
+  );
+
+  // Verify the token exists in the database
+  const storedToken = await getTokenInformation(mysql, nanoContractToken.id);
+  expect(storedToken).not.toBeNull();
+  expect(storedToken?.id).toBe(nanoContractToken.id);
+  expect(storedToken?.name).toBe(nanoContractToken.name);
+  expect(storedToken?.symbol).toBe(nanoContractToken.symbol);
+
+  // No UTXOs are added for this token because it's held by the contract,
+  // not by any wallet address that wallet-service tracks.
+  // This is the key scenario: token exists but has zero wallet-owned supply.
+
+  // getTotalSupply should return 0n instead of crashing with BigInt(null)
+  const totalSupply = await getTotalSupply(mysql, nanoContractToken.id);
+  expect(totalSupply).toStrictEqual(0n);
+});
+
 test('getExpiredTimelocksUtxos', async () => {
   expect.hasAssertions();
 


### PR DESCRIPTION
### Motivation

The getTokenDetails API endpoint (GET /wallet/tokens/{id}/details) crashes with TypeError: Cannot convert null to a BigInt when querying tokens that exist but have no UTXOs owned by wallet addresses.

This occurs for tokens created via nano contracts where the initial mint goes to the contract, not to a wallet address. The daemon correctly indexes the token in the token table, but no UTXOs exist in tx_output for that token since wallet-service only tracks wallet-owned UTXOs. 

### Acceptance Criteria

- getTotalSupply() returns 0n when token exists but has no wallet-owned UTXOs 
- GET /wallet/tokens/{id}/details returns totalSupply: 0 instead of crashing  for nano contract tokens

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed total-supply reporting so tokens with no transaction history or wallet-held outputs now show 0 instead of an error or missing value.

* **Tests**
  * Added tests covering total-supply edge cases: tokens with no activity, tokens created by contracts with no wallet UTXOs, and undefined-token error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->