### PR TITLE
fix(daemon): crash when fully synced and no new events arrive

### DIFF
--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -1675,12 +1675,42 @@ describe('checkForMissedEvents', () => {
     );
   });
 
-  it('should throw error when context has no event', async () => {
+  it('should throw error when context has no event and no initialEventId', async () => {
     const context = {};
 
     await expect(checkForMissedEvents(context as any))
       .rejects
-      .toThrow('No event in context when checking for missed events');
+      .toThrow('No event in context and no initialEventId when checking for missed events');
+  });
+
+  it('should use initialEventId when context.event is null', async () => {
+    const mockResponse = {
+      status: 200,
+      data: {
+        events: [],
+        latest_event_id: 25717039,
+      },
+    };
+
+    (axios.get as jest.Mock).mockResolvedValue(mockResponse);
+
+    const context = {
+      event: null,
+      initialEventId: 25717039,
+    };
+
+    const result = await checkForMissedEvents(context as any);
+
+    expect(result.hasNewEvents).toBe(false);
+    expect(axios.get).toHaveBeenCalledWith(
+      expect.stringContaining('/event'),
+      expect.objectContaining({
+        params: {
+          last_ack_event_id: 25717039,
+          size: 1,
+        },
+      }),
+    );
   });
 
   it('should handle API response with non-array events field', async () => {

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -1078,11 +1078,11 @@ export const handleTokenCreated = async (context: Context) => {
  * This is used to detect if we lost an event due to network packet loss
  */
 export const checkForMissedEvents = async (context: Context): Promise<{ hasNewEvents: boolean; events: any[] }> => {
-  if (!context.event) {
-    throw new Error('No event in context when checking for missed events');
-  }
+  const lastAckEventId = context.event?.event.id ?? context.initialEventId;
 
-  const lastAckEventId = context.event.event.id;
+  if (lastAckEventId === null || lastAckEventId === undefined) {
+    throw new Error('No event in context and no initialEventId when checking for missed events');
+  }
   const fullnodeUrl = getFullnodeHttpUrl();
 
   logger.debug(`Checking for missed events after event ID ${lastAckEventId}`);


### PR DESCRIPTION
### Motivation

The daemon crashes on startup when the fullnode has no new events to send (i.e. the daemon is fully synced).

Here is the sequence of events that leads to the crash:

1. The daemon starts and calls `fetchInitialState`, which reads the last synced event ID from the database (e.g. `25717039`).
2. It connects to the fullnode websocket and sends a `START_STREAM` message with `last_ack_event_id: 25717039`.
3. Since the fullnode has no new events after that ID, it sends nothing back. This is expected behavior from the fullnode.
4. The daemon enters the `CONNECTED.idle` state and waits. After 20 seconds (the `ACK_TIMEOUT`), it transitions to `CONNECTED.checkingForMissedEvents` to verify that no events were lost due to network issues.
5. `checkForMissedEvents` tries to read `context.event.event.id` to know which event ID to check from. However, `context.event` is `null` because no fullnode event was ever received in this session.
6. The service throws `Error('No event in context when checking for missed events')`, which causes the state machine to transition to `ERROR` and the daemon stops.

The root cause is that `checkForMissedEvents` assumes `context.event` has been populated by a prior `storeEvent` action, but this is not true when the daemon is fully synced and no events arrive before `ACK_TIMEOUT` fires.

The `startStream` action already handles this case correctly by falling back to `context.initialEventId`:

```typescript
const lastAckEventId = get(context, 'event.event.id', context.initialEventId);
```

This fix applies the same pattern to `checkForMissedEvents`: use `context.event.event.id` if available, otherwise fall back to `context.initialEventId`. It only throws if both are missing, which would indicate a real initialization problem.

### Acceptance Criteria

- The daemon should not crash when fully synced and no new events arrive from the fullnode
- `checkForMissedEvents` should use `context.initialEventId` as a fallback when `context.event` is null
- The missed events check should still work correctly by querying the fullnode HTTP API with the right event ID

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.