### PR TITLE
fix: allow numeric lockExpires in push notification validation

### DIFF
--- a/packages/wallet-service/src/api/txPushNotificationRequested.ts
+++ b/packages/wallet-service/src/api/txPushNotificationRequested.ts
@@ -54,7 +54,7 @@ class TxPushNotificationRequestValidator {
       unlockedAmount: Joi.number().required(),
       lockedAuthorities: TxPushNotificationRequestValidator.authoritiesSchema,
       unlockedAuthorities: TxPushNotificationRequestValidator.authoritiesSchema,
-      lockExpires: Joi.number().integer().min(0).valid(null),
+      lockExpires: Joi.number().integer().min(0).allow(null),
       total: Joi.number().required(),
     }),
   ).required();

--- a/packages/wallet-service/tests/txPushNotificationRequested.test.ts
+++ b/packages/wallet-service/tests/txPushNotificationRequested.test.ts
@@ -596,6 +596,55 @@ describe('failure', () => {
   });
 });
 
+describe('validation lockExpires', () => {
+  it('should accept a numeric lockExpires timestamp', async () => {
+    expect.hasAssertions();
+
+    const walletId = 'wallet1';
+    await addToWalletTable(mysql, [buildWallet({ id: walletId })]);
+
+    const deviceId = 'device1';
+    const pushDevice = {
+      deviceId,
+      walletId,
+      pushProvider: PushProvider.ANDROID,
+      enablePush: true,
+      enableShowAmounts: false,
+    };
+
+    await storeTokenInformation(mysql, 'token1', 'token1', 'T1', TokenVersion.DEPOSIT);
+    await registerPushDevice(mysql, pushDevice);
+
+    const txId = 'txId1';
+
+    const sendEvent = buildEvent(walletId, txId, [
+      {
+        tokenId: 'token1',
+        tokenSymbol: 'T1',
+        lockExpires: 1709596800,
+        lockedAmount: 10,
+        lockedAuthorities: {
+          melt: false,
+          mint: false,
+        },
+        total: 10,
+        totalAmountSent: 10,
+        unlockedAmount: 0,
+        unlockedAuthorities: {
+          melt: false,
+          mint: false,
+        },
+      },
+    ]);
+    const sendContext = { awsRequestId: '123' } as Context;
+
+    const result = await handleRequest(sendEvent, sendContext, null) as { success: boolean, message?: string, details?: unknown };
+
+    expect(result.success).toStrictEqual(true);
+    expect(spyOnInvokeSendNotification).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('validation StringMap<WalletBalanceValue>', () => {
   it('should validate map format', async () => {
     expect.hasAssertions();


### PR DESCRIPTION
## Summary
- Fixes Opsgenie alert #50062: "Invalid payload while handling push notification request"
- The Joi schema used `.valid(null)` for `lockExpires`, which creates a whitelist accepting **only** `null` — rejecting valid numeric timestamps from time-locked outputs
- Changed to `.allow(null)` so both `null` and non-negative integers are accepted
- Added test case for numeric `lockExpires` values

## Test plan
- [ ] Verify existing push notification tests still pass
- [ ] Confirm the new test with numeric `lockExpires` passes
- [ ] Deploy and verify the Opsgenie alert stops recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed wallet service validation to properly accept null values for lock expiration timestamps in push notification requests.

* **Tests**
  * Added test coverage to verify correct handling and processing of expiration timestamps in push notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->