### PR TITLE
feat: include genesisBlockHash in version endpoint response

### DIFF
--- a/packages/wallet-service/src/nodeConfig.ts
+++ b/packages/wallet-service/src/nodeConfig.ts
@@ -57,6 +57,7 @@ export function convertApiVersionData(data: FullNodeApiVersionResponse): FullNod
     decimalPlaces: data.decimal_places ?? constants.DECIMAL_PLACES,
     nativeTokenName: data.native_token?.name ?? constants.DEFAULT_NATIVE_TOKEN_CONFIG.name,
     nativeTokenSymbol: data.native_token?.symbol ?? constants.DEFAULT_NATIVE_TOKEN_CONFIG.symbol,
+    genesisBlockHash: data.genesis_block_hash ?? null,
   };
 }
 

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -101,6 +101,7 @@ export interface FullNodeVersionData {
   decimalPlaces: number;
   nativeTokenName: string;
   nativeTokenSymbol: string;
+  genesisBlockHash: string | null;
 }
 
 /**

--- a/packages/wallet-service/tests/nodeConfig.test.ts
+++ b/packages/wallet-service/tests/nodeConfig.test.ts
@@ -76,6 +76,7 @@ test('convertApiVersionData', async () => {
     decimalPlaces: 2,
     nativeTokenName: 'Hathor',
     nativeTokenSymbol: 'HTR',
+    genesisBlockHash: null,
   });
 
   expect(convertApiVersionData(VERSION_DATA)).toStrictEqual({
@@ -93,6 +94,7 @@ test('convertApiVersionData', async () => {
     decimalPlaces: VERSION_DATA.decimal_places,
     nativeTokenName: VERSION_DATA.native_token.name,
     nativeTokenSymbol: VERSION_DATA.native_token.symbol,
+    genesisBlockHash: VERSION_DATA.genesis_block_hash,
   });
 });
 


### PR DESCRIPTION
### Motivation

The `/version` endpoint was dropping `genesis_block_hash` from the fullnode response during conversion. The mobile wallet needs this field to persist registered tokens per network across network changes.

### Acceptance Criteria

- [ ] `/version` endpoint response includes `genesisBlockHash` field
- [ ] `genesisBlockHash` is `null` when the fullnode does not provide it (older versions)
- [ ] Existing fields in the response are unchanged

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added genesis block hash information to fullnode version data, enabling enhanced blockchain verification and identification capabilities within the wallet service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->