### PR TITLE
fix: add error logging to sendTxProposal handler

### DIFF
--- a/packages/wallet-service/src/api/txProposalSend.ts
+++ b/packages/wallet-service/src/api/txProposalSend.ts
@@ -36,6 +36,7 @@ import middy from '@middy/core';
 import cors from '@middy/http-cors';
 import config from '@src/config';
 import errorHandler from '@src/api/middlewares/errorHandler';
+import createDefaultLogger from '@src/logger';
 
 const mysql = getDbConnection();
 
@@ -114,6 +115,8 @@ export const send: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (wa
     }
   }
 
+  const logger = createDefaultLogger();
+
   try {
     const response: ApiResponse = await new Promise((resolve) => {
       hathorLib.txApi.pushTx(txHex, false, resolve);
@@ -139,6 +142,12 @@ export const send: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (wa
       }),
     };
   } catch (e) {
+    logger.error('Failed to send tx proposal', {
+      txProposalId,
+      error: e.message,
+      txHex,
+    });
+
     // Update status and release UTXOs atomically
     try {
       await beginTransaction(mysql);
@@ -155,7 +164,10 @@ export const send: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (wa
       await commitTransaction(mysql);
     } catch (txError) {
       await rollbackTransaction(mysql);
-      // Log the transaction error but still return the original send error
+      logger.error('Failed to update tx proposal status after send error', {
+        txProposalId,
+        txError: txError.message,
+      });
     }
 
     return closeDbAndGetError(mysql, ApiError.TX_PROPOSAL_SEND_ERROR, {


### PR DESCRIPTION
### Motivation

The `sendTxProposalApi` Lambda had zero application-level logging. When `pushTx` failed, the fullnode rejection reason was only returned to the client but never logged to CloudWatch, making server-side debugging impossible.

### Acceptance Criteria

- [x] Log the fullnode error when `pushTx` fails (txProposalId, error message, txHex)
- [x] Log the DB error if updating proposal status to `send_error` also fails

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.