### PR TITLE
chore: bump version to v1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-service",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "workspaces": [
     "packages/common",
     "packages/daemon",


### PR DESCRIPTION
### Motivation

Bump the root `package.json` version from `1.12.0` to `1.13.0` in preparation for release candidate `v1.13.0-rc.1+beta`.

Includes the following features/fixes merged to `master` since `v1.12.0`:

- #342 feat: event downloader + balance replay debug script
- #369 feat: daemon monitoring layer
- #385 feat: include genesisBlockHash in version endpoint response
- #383 feat: OpenTelemetry distributed tracing (daemon + Lambdas)
- #384 fix: allow numeric lockExpires in push notification validation
- #386 chore: Docker image build on CI
- #387 fix: add error logging to sendTxProposal handler
- #388 fix: add error logging to silent catch blocks in API handlers
- #389 fix: correct package.json path in daemon tracing
- #390 fix: do not fail daemon shutdown on OTel span flush errors

Follows the [wallet-service release guide](https://github.com/HathorNetwork/ops-tools/blob/master/docs/release-guides/wallet-service.md#release-candidate).

### Acceptance Criteria

- Root `package.json` version is `1.13.0`.
- No other source changes included.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.