### PR TITLE
bump: v1.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet-service",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "workspaces": [
     "packages/common",
     "packages/daemon",


### PR DESCRIPTION
### Motivation

Bump the root `package.json` version from `1.13.0` to `1.14.0` in preparation for release candidate `v1.14.0-rc.1`.

Includes the following features/fixes merged to `master` since `v1.13.0`:

- https://github.com/HathorNetwork/hathor-wallet-service/pull/399
- https://github.com/HathorNetwork/hathor-wallet-service/pull/382
- https://github.com/HathorNetwork/hathor-wallet-service/pull/394
- https://github.com/HathorNetwork/hathor-wallet-service/pull/376
- https://github.com/HathorNetwork/hathor-wallet-service/pull/400

Follows the [wallet-service release guide](https://github.com/HathorNetwork/ops-tools/blob/master/docs/release-guides/wallet-service.md#release-candidate).

### Acceptance Criteria

- Root `package.json` version is `1.14.0`.
- No other source changes included.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.