### PR TITLE
fix(daemon): flatten unexpected error logs

### DIFF
--- a/packages/daemon/__tests__/actors/MonitoringActor.test.ts
+++ b/packages/daemon/__tests__/actors/MonitoringActor.test.ts
@@ -468,7 +468,9 @@ describe('MonitoringActor', () => {
       config['BALANCE_VALIDATION_ENABLED'] = true;
       const mockLoggerError = jest.spyOn(logger, 'error');
 
-      (db.getDbConnection as jest.Mock).mockRejectedValueOnce(new Error('DB connection failed'));
+      const error = new Error('DB connection failed');
+      error.stack = 'Error: DB connection failed\n    at runBalanceValidation (MonitoringActor.ts:1:1)';
+      (db.getDbConnection as jest.Mock).mockRejectedValueOnce(error);
 
       MonitoringActor(mockCallback, mockReceive, config);
       sendEvent('CONNECTED');
@@ -477,7 +479,7 @@ describe('MonitoringActor', () => {
       await flushPromises();
 
       expect(mockLoggerError).toHaveBeenCalledWith(
-        expect.stringContaining('Balance validation error'),
+        '[monitoring] Balance validation error: Error: DB connection failed | at runBalanceValidation (MonitoringActor.ts:1:1)',
       );
     });
 

--- a/packages/daemon/__tests__/actors/WebSocketActor.test.ts
+++ b/packages/daemon/__tests__/actors/WebSocketActor.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { ZodError } from 'zod';
+import WebSocketActor from '../../src/actors/WebSocketActor';
+import logger from '../../src/logger';
+
+type MockSocketInstance = {
+  url: string;
+  onopen?: () => void;
+  onmessage?: (event: { data: string }) => void;
+  onerror?: (error: unknown) => void;
+  onclose?: () => void;
+  close: jest.Mock;
+  ping: jest.Mock;
+  send: jest.Mock;
+  terminate: jest.Mock;
+  on: jest.Mock;
+};
+
+const socketInstances: MockSocketInstance[] = [];
+
+jest.mock('../../src/logger', () => ({
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+}));
+
+jest.mock('../../src/utils', () => ({
+  getFullnodeWsUrl: jest.fn(() => 'ws://fullnode.example/v1a/event_ws'),
+}));
+
+jest.mock('ws', () => ({
+  WebSocket: class {
+    public onopen?: () => void;
+    public onmessage?: (event: { data: string }) => void;
+    public onerror?: (error: unknown) => void;
+    public onclose?: () => void;
+
+    public readonly close = jest.fn(() => {
+      this.onclose?.();
+    });
+    public readonly ping = jest.fn();
+    public readonly send = jest.fn();
+    public readonly terminate = jest.fn();
+    public readonly on = jest.fn();
+
+    constructor(public readonly url: string) {
+      socketInstances.push(this as unknown as MockSocketInstance);
+    }
+  },
+}));
+
+describe('WebSocketActor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    socketInstances.length = 0;
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('should log the raw payload and throw the original ZodError on invalid events', () => {
+    const callback = jest.fn();
+    const receive = jest.fn();
+
+    WebSocketActor(callback, receive);
+
+    const socket = socketInstances[0];
+    const invalidPayload = JSON.stringify({
+      type: 'EVENT',
+      peer_id: 'peer-id',
+      network: 'testnet',
+      event: {
+        id: 1,
+        timestamp: 1,
+        type: 'VERTEX_METADATA_CHANGED',
+        data: {
+          hash: 'hash',
+          nonce: 1,
+          timestamp: 1,
+          signal_bits: 0,
+          version: 1,
+          weight: 1,
+          inputs: [
+            {
+              tx_id: 'tx-id',
+              index: 0,
+              spent_output: {
+                type: 'shielded',
+              },
+            },
+          ],
+          outputs: [],
+          parents: [],
+          tokens: [],
+          token_name: null,
+          token_symbol: null,
+          metadata: {
+            hash: 'hash',
+            voided_by: [],
+            first_block: null,
+            height: 1,
+          },
+        },
+      },
+    });
+
+    let thrownError: unknown;
+
+    try {
+      socket.onmessage?.({ data: invalidPayload });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(ZodError);
+    expect(logger.error).toHaveBeenCalledWith(`Could not parse event: ${invalidPayload}`);
+  });
+
+  it('should log websocket errors on a single line', () => {
+    const callback = jest.fn();
+    const receive = jest.fn();
+
+    WebSocketActor(callback, receive);
+
+    const socket = socketInstances[0];
+    const error = new Error('socket failure');
+    error.stack = 'Error: socket failure\n    at connect (WebSocketActor.ts:1:1)';
+
+    socket.onerror?.(error);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Socket errored: Error: socket failure | at connect (WebSocketActor.ts:1:1)'
+    );
+  });
+});

--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -122,6 +122,7 @@ jest.mock('../../src/utils', () => ({
   getFullnodeHttpUrl: jest.fn(),
   invokeOnTxPushNotificationRequestedLambda: jest.fn(),
   sendMessageSQS: jest.fn(),
+  sendRealtimeTx: jest.fn().mockResolvedValue(undefined),
   getWalletBalancesForTx: jest.fn(),
   generateAddresses: jest.fn(),
   retryWithBackoff: jest.fn((fn) => fn()),
@@ -696,6 +697,67 @@ describe('handleVertexAccepted', () => {
     expect(invokeOnTxPushNotificationRequestedLambda).toHaveBeenCalled();
     expect(mockDb.commit).toHaveBeenCalled();
     expect(mockDb.release).toHaveBeenCalled();
+  });
+
+  it('should log push notification failures on a single line', async () => {
+    const context = {
+      event: {
+        event: {
+          data: {
+            hash: 'hashValue',
+            metadata: {
+              height: 123,
+              first_block: true,
+              voided_by: [],
+            },
+            timestamp: new Date().getTime(),
+            version: 1,
+            weight: 17.17,
+            outputs: [],
+            inputs: [1],
+            tokens: [],
+          },
+          id: 'idValue',
+        },
+      },
+      rewardMinBlocks: 300,
+      txCache: {
+        get: jest.fn(),
+        set: jest.fn(),
+      },
+    };
+
+    (getConfig as jest.Mock).mockReturnValue({
+      PUSH_NOTIFICATION_ENABLED: true,
+      NEW_TX_SQS: 'http://nowhere.com',
+    });
+
+    (addOrUpdateTx as jest.Mock).mockReturnValue(Promise.resolve());
+    (getTransactionById as jest.Mock).mockResolvedValue(null);
+    (prepareOutputs as jest.Mock).mockReturnValue([]);
+    (prepareInputs as jest.Mock).mockReturnValue([]);
+    (getAddressBalanceMap as jest.Mock).mockReturnValue({});
+    (getUtxosLockedAtHeight as jest.Mock).mockResolvedValue([]);
+    (hashTxData as jest.Mock).mockReturnValue('hashedData');
+    (getAddressWalletInfo as jest.Mock).mockResolvedValue({
+      'address1': {
+        walletId: 'wallet1',
+        xpubkey: 'xpubkey1',
+        maxGap: 10
+      },
+    });
+    (getWalletBalancesForTx as jest.Mock).mockResolvedValue({ 'mockWallet': {} });
+
+    const error = new Error('push notification failure');
+    error.stack = 'Error: push notification failure\n    at invoke (lambda.ts:1:1)';
+    (invokeOnTxPushNotificationRequestedLambda as jest.Mock).mockRejectedValue(error);
+
+    await handleVertexAccepted(context as any, {} as any);
+    await Promise.resolve();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error on invokeOnTxPushNotificationRequestedLambda invocation: Error: push notification failure | at invoke (lambda.ts:1:1)'
+    );
   });
 
   it('should handle token creation tx without storing token info (tokens created via TOKEN_CREATED event)', async () => {

--- a/packages/daemon/__tests__/utils/error.test.ts
+++ b/packages/daemon/__tests__/utils/error.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { FullNodeEventSchema } from '../../src/types/event';
+import { buildErrorLogMessage, formatErrorForLog, registerProcessErrorHandlers } from '../../src/utils/error';
+
+describe('error utils', () => {
+  it('should serialize nested zod errors onto a single line', () => {
+    const parseResult = FullNodeEventSchema.safeParse({
+      type: 'EVENT',
+      peer_id: 'peer-id',
+      network: 'testnet',
+      event: {
+        id: 1,
+        timestamp: 1,
+        type: 'VERTEX_METADATA_CHANGED',
+        data: {
+          hash: 'hash',
+          nonce: 1,
+          timestamp: 1,
+          signal_bits: 0,
+          version: 1,
+          weight: 1,
+          inputs: [
+            {
+              tx_id: 'tx-id',
+              index: 0,
+              spent_output: {
+                type: 'shielded',
+              },
+            },
+          ],
+          outputs: [],
+          parents: [],
+          tokens: [],
+          token_name: null,
+          token_symbol: null,
+          metadata: {
+            hash: 'hash',
+            voided_by: [],
+            first_block: null,
+            height: 1,
+          },
+        },
+      },
+    });
+
+    expect(parseResult.success).toBe(false);
+
+    if (parseResult.success) {
+      throw new Error('Expected invalid payload to fail schema validation');
+    }
+
+    const message = formatErrorForLog(parseResult.error);
+
+    expect(message).toContain('Zod validation failed:');
+    expect(message).toContain('event.data.inputs.0.spent_output');
+    expect(message).not.toContain('\n');
+  });
+
+  it('should serialize stack traces onto a single line', () => {
+    const error = new Error('boom');
+    error.stack = 'Error: boom\n    at first (file.ts:1:1)\n    at second (file.ts:2:2)';
+
+    expect(buildErrorLogMessage('Unhandled exception', error)).toBe(
+      'Unhandled exception: Error: boom | at first (file.ts:1:1) | at second (file.ts:2:2)'
+    );
+  });
+
+  it('should register fatal handlers that log one-line messages', () => {
+    const handlers: Partial<Record<'uncaughtException' | 'unhandledRejection', (reason: unknown) => void>> = {};
+    const processLike = {
+      on: jest.fn((event: 'uncaughtException' | 'unhandledRejection', handler: (reason: unknown) => void) => {
+        handlers[event] = handler;
+      }),
+    };
+    const logger = { error: jest.fn() };
+    const exit = jest.fn();
+
+    registerProcessErrorHandlers(processLike, logger, exit);
+
+    const error = new Error('fatal');
+    error.stack = 'Error: fatal\n    at main (index.ts:1:1)';
+
+    handlers.uncaughtException?.(error);
+    handlers.unhandledRejection?.('bad\nnews');
+
+    expect(processLike.on).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenNthCalledWith(1, 'Unhandled exception: Error: fatal | at main (index.ts:1:1)');
+    expect(logger.error).toHaveBeenNthCalledWith(2, 'Unhandled promise rejection: bad | news');
+    expect(exit).toHaveBeenNthCalledWith(1, 1);
+    expect(exit).toHaveBeenNthCalledWith(2, 1);
+  });
+});

--- a/packages/daemon/src/actors/MonitoringActor.ts
+++ b/packages/daemon/src/actors/MonitoringActor.ts
@@ -10,6 +10,7 @@ import getConfig from '../config';
 import { addAlert, Severity } from '@wallet-service/common';
 import { Event, EventTypes } from '../types';
 import { getDbConnection } from '../db';
+import { buildErrorLogMessage } from '../utils/error';
 
 /**
  * MonitoringActor
@@ -107,7 +108,7 @@ export default (callback: any, receive: any, config = getConfig()) => {
         { timeoutMs: String(stuckTimeoutMs) },
         logger,
       ).catch((err: Error) =>
-        logger.error(`[monitoring] Failed to send stuck-processing alert: ${err.message}`),
+        logger.error(buildErrorLogMessage('[monitoring] Failed to send stuck-processing alert', err)),
       );
     }, stuckTimeoutMs);
   };
@@ -152,7 +153,7 @@ export default (callback: any, receive: any, config = getConfig()) => {
         },
         logger,
       ).catch((err: Error) =>
-        logger.error(`[monitoring] Failed to send reconnection storm alert: ${err.message}`),
+        logger.error(buildErrorLogMessage('[monitoring] Failed to send reconnection storm alert', err)),
       );
     }
   };
@@ -257,18 +258,14 @@ export default (callback: any, receive: any, config = getConfig()) => {
         logger.info('[monitoring] Balance validation complete, no mismatches found');
       }
     } catch (err) {
-      const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
-      logger.error(`[monitoring] Balance validation error: ${detail}`);
+      logger.error(buildErrorLogMessage('[monitoring] Balance validation error', err));
     } finally {
       if (mysql) {
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (mysql as any).release();
         } catch (releaseErr) {
-          const detail = releaseErr instanceof Error
-            ? (releaseErr.stack ?? releaseErr.message)
-            : String(releaseErr);
-          logger.warn(`[monitoring] Balance validation: connection release failed: ${detail}`);
+          logger.warn(buildErrorLogMessage('[monitoring] Balance validation: connection release failed', releaseErr));
         }
       }
     }

--- a/packages/daemon/src/actors/WebSocketActor.ts
+++ b/packages/daemon/src/actors/WebSocketActor.ts
@@ -11,6 +11,7 @@ import { get } from 'lodash';
 import logger from '../logger';
 import { getFullnodeWsUrl } from '../utils';
 import { bigIntUtils } from '@hathor/wallet-lib';
+import { buildErrorLogMessage } from '../utils/error';
 
 const PING_TIMEOUT = 30000; // 30s timeout
 const PING_INTERVAL = 5000; // Will ping every 5s
@@ -73,7 +74,7 @@ export default (callback: any, receive: any) => {
     );
     if (!parseResult.success) {
       logger.error(`Could not parse event: ${socketEvent.data.toString()}`);
-      throw new Error(parseResult.error.message);
+      throw parseResult.error;
     }
     const event = parseResult.data;
     const type = get(event, 'event.type');
@@ -92,8 +93,7 @@ export default (callback: any, receive: any) => {
   };
 
   socket.onerror = (e) => {
-    logger.error('Socket erroed');
-    logger.error(e);
+    logger.error(buildErrorLogMessage('Socket errored', e));
   };
 
   socket.onclose = () => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -13,6 +13,9 @@ import { SyncMachine } from './machines';
 import logger from './logger';
 import { checkEnvVariables } from './config';
 import { bigIntUtils } from '@hathor/wallet-lib';
+import { registerProcessErrorHandlers } from './utils/error';
+
+registerProcessErrorHandlers(process, logger, (code) => process.exit(code));
 
 const main = async () => {
   checkEnvVariables();

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -89,6 +89,7 @@ import {
 import getConfig, { VALIDATE_ADDRESS_BALANCES } from '../config';
 import logger from '../logger';
 import { invokeOnTxPushNotificationRequestedLambda, getDaemonUptime, retryWithBackoff } from '../utils';
+import { buildErrorLogMessage } from '../utils/error';
 import { addAlert, Severity } from '@wallet-service/common';
 import { JSONBigInt } from '@hathor/wallet-lib/lib/utils/bigint';
 
@@ -540,8 +541,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
               );
             }
           } catch (e) {
-            logger.error('Failed to send transaction to SQS queue');
-            logger.error(e);
+            logger.error(buildErrorLogMessage('Failed to send transaction to SQS queue', e));
           }
 
           try {
@@ -550,12 +550,11 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
               const { length: hasAffectWallets } = Object.keys(walletBalanceMap);
               if (hasAffectWallets) {
                 invokeOnTxPushNotificationRequestedLambda(walletBalanceMap)
-                  .catch((err: Error) => logger.error('Error on invokeOnTxPushNotificationRequestedLambda invocation', err));
+                  .catch((err: Error) => logger.error(buildErrorLogMessage('Error on invokeOnTxPushNotificationRequestedLambda invocation', err)));
               }
             }
           } catch (e) {
-            logger.error('Failed to send push notification to wallet-service lambda');
-            logger.error(e);
+            logger.error(buildErrorLogMessage('Failed to send push notification to wallet-service lambda', e));
           }
 
           const network = new hathorLib.Network(NETWORK);
@@ -563,7 +562,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
           // Call to process the data for NFT handling (if applicable)
           // This process is not critical, so we run it in a fire-and-forget manner, not waiting for the promise.
           NftUtils.processNftEvent(fullNodeData, STAGE, SERVERLESS_DEPLOY_PREFIX, network, logger)
-            .catch((err: unknown) => logger.error('[ALERT] Error processing NFT event', err));
+            .catch((err: unknown) => logger.error(buildErrorLogMessage('[ALERT] Error processing NFT event', err)));
         }
 
         // Need to check if there is a nano header and update the nc_address's seqnum if needed

--- a/packages/daemon/src/utils/error.ts
+++ b/packages/daemon/src/utils/error.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { ZodError, ZodIssue } from 'zod';
+
+type LoggerLike = {
+  error: (message: string) => void;
+};
+
+type ProcessEvent = 'uncaughtException' | 'unhandledRejection';
+
+type ProcessLike = {
+  on: (event: ProcessEvent, handler: (reason: unknown) => void) => unknown;
+};
+
+const MAX_ZOD_ISSUES = 5;
+
+const toSingleLine = (value: string): string => value
+  .replace(/\r?\n\s*/g, ' | ')
+  .replace(/\s{2,}/g, ' ')
+  .trim();
+
+const collectZodIssues = (error: ZodError): ZodIssue[] => {
+  const issues: ZodIssue[] = [];
+
+  const visit = (issue: ZodIssue) => {
+    if (issue.code === 'invalid_union') {
+      issue.unionErrors.forEach((unionError) => {
+        unionError.issues.forEach(visit);
+      });
+      return;
+    }
+
+    issues.push(issue);
+  };
+
+  error.issues.forEach(visit);
+
+  return issues;
+};
+
+const formatZodIssue = (issue: ZodIssue): string => {
+  const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+
+  return `${path}: ${toSingleLine(issue.message)}`;
+};
+
+export const formatErrorForLog = (error: unknown): string => {
+  if (error instanceof ZodError) {
+    const issues = collectZodIssues(error);
+    const visibleIssues = issues.slice(0, MAX_ZOD_ISSUES).map(formatZodIssue);
+    const hiddenIssues = issues.length - visibleIssues.length;
+    const suffix = hiddenIssues > 0 ? `; +${hiddenIssues} more issue(s)` : '';
+
+    return `Zod validation failed: ${visibleIssues.join('; ')}${suffix}`;
+  }
+
+  if (error instanceof Error) {
+    return toSingleLine(error.stack ?? error.message);
+  }
+
+  if (typeof error === 'string') {
+    return toSingleLine(error);
+  }
+
+  try {
+    return toSingleLine(JSON.stringify(error));
+  } catch {
+    return toSingleLine(String(error));
+  }
+};
+
+export const buildErrorLogMessage = (context: string, error: unknown): string => (
+  `${context}: ${formatErrorForLog(error)}`
+);
+
+export const registerProcessErrorHandlers = (
+  processLike: ProcessLike,
+  logger: LoggerLike,
+  exit: (code: number) => void,
+): void => {
+  processLike.on('uncaughtException', (error) => {
+    logger.error(buildErrorLogMessage('Unhandled exception', error));
+    exit(1);
+  });
+
+  processLike.on('unhandledRejection', (reason) => {
+    logger.error(buildErrorLogMessage('Unhandled promise rejection', reason));
+    exit(1);
+  });
+};


### PR DESCRIPTION
## Summary
- add a reusable one-line error formatter for daemon logging and fatal process handlers
- preserve raw Zod validation errors in the websocket actor and format remaining high-value daemon error sites onto one line
- add focused daemon regressions covering websocket, monitoring, service, and formatter behavior

## Validation
- yarn test --runTestsByPath __tests__/actors/MonitoringActor.test.ts __tests__/services/services.test.ts __tests__/utils/error.test.ts
- yarn test --runTestsByPath __tests__/utils/error.test.ts __tests__/actors/WebSocketActor.test.ts