### PR TITLE
fix(migrations): coerce COUNT result to Number before comparison

### DIFF
--- a/db/migrations/20251201104138-add-tx-output-utxo-lookup-index.js
+++ b/db/migrations/20251201104138-add-tx-output-utxo-lookup-index.js
@@ -12,7 +12,7 @@ module.exports = {
     `);
 
     // Only create if it doesn't exist
-    if (indexes[0].count === 0) {
+    if (Number(indexes[0].count) === 0) {
       await queryInterface.sequelize.query(`
         CREATE INDEX idx_tx_output_utxo_lookup
         ON tx_output (address, token_id, spent_by, voided, locked, authorities);
@@ -30,7 +30,7 @@ module.exports = {
         AND index_name = 'idx_tx_output_utxo_lookup';
     `);
 
-    if (indexes[0].count > 0) {
+    if (Number(indexes[0].count) > 0) {
       await queryInterface.sequelize.query(`
         DROP INDEX idx_tx_output_utxo_lookup ON tx_output;
       `);

--- a/db/migrations/20260108100000-add-tx-output-locked-heightlock-index.js
+++ b/db/migrations/20260108100000-add-tx-output-locked-heightlock-index.js
@@ -12,7 +12,7 @@ module.exports = {
     `);
 
     // Only create if it doesn't exist
-    if (indexes[0].count === 0) {
+    if (Number(indexes[0].count) === 0) {
       await queryInterface.sequelize.query(`
         CREATE INDEX idx_tx_output_locked_heightlock
         ON tx_output (locked, heightlock);
@@ -30,7 +30,7 @@ module.exports = {
         AND index_name = 'idx_tx_output_locked_heightlock';
     `);
 
-    if (indexes[0].count > 0) {
+    if (Number(indexes[0].count) > 0) {
       await queryInterface.sequelize.query(`
         DROP INDEX idx_tx_output_locked_heightlock ON tx_output;
       `);

--- a/db/migrations/20260108100001-add-tx-output-locked-timelock-index.js
+++ b/db/migrations/20260108100001-add-tx-output-locked-timelock-index.js
@@ -12,7 +12,7 @@ module.exports = {
     `);
 
     // Only create if it doesn't exist
-    if (indexes[0].count === 0) {
+    if (Number(indexes[0].count) === 0) {
       await queryInterface.sequelize.query(`
         CREATE INDEX idx_tx_output_locked_timelock
         ON tx_output (locked, timelock);
@@ -30,7 +30,7 @@ module.exports = {
         AND index_name = 'idx_tx_output_locked_timelock';
     `);
 
-    if (indexes[0].count > 0) {
+    if (Number(indexes[0].count) > 0) {
       await queryInterface.sequelize.query(`
         DROP INDEX idx_tx_output_locked_timelock ON tx_output;
       `);

--- a/db/migrations/20260108100002-add-address-tx-history-addr-voided-token-index.js
+++ b/db/migrations/20260108100002-add-address-tx-history-addr-voided-token-index.js
@@ -12,7 +12,7 @@ module.exports = {
     `);
 
     // Only create if it doesn't exist
-    if (indexes[0].count === 0) {
+    if (Number(indexes[0].count) === 0) {
       await queryInterface.sequelize.query(`
         CREATE INDEX idx_address_tx_history_addr_voided_token
         ON address_tx_history (address, voided, token_id);
@@ -30,7 +30,7 @@ module.exports = {
         AND index_name = 'idx_address_tx_history_addr_voided_token';
     `);
 
-    if (indexes[0].count > 0) {
+    if (Number(indexes[0].count) > 0) {
       await queryInterface.sequelize.query(`
         DROP INDEX idx_address_tx_history_addr_voided_token ON address_tx_history;
       `);


### PR DESCRIPTION
## Summary

- `db/config.js` sets `bigNumberStrings: true` for all environments, causing mysql2 to return `COUNT()` values as **strings** (`"0"`) instead of JavaScript numbers (`0`)
- Four index-creation migrations used strict equality (`=== 0` / `> 0`) against that string value — `"0" === 0` is `false` in JS, so the `CREATE INDEX` block was **always skipped**
- Migrations completed without error and were recorded in `SequelizeMeta`, but the indexes were never actually created

### Affected migrations

| Migration | Index |
|-----------|-------|
| `20251201104138-add-tx-output-utxo-lookup-index` | `idx_tx_output_utxo_lookup` |
| `20260108100000-add-tx-output-locked-heightlock-index` | `idx_tx_output_locked_heightlock` |
| `20260108100001-add-tx-output-locked-timelock-index` | `idx_tx_output_locked_timelock` |
| `20260108100002-add-address-tx-history-addr-voided-token-index` | `idx_address_tx_history_addr_voided_token` |

### Fix

Wrap the `COUNT()` result with `Number()` before comparing, so both string and numeric returns work correctly:

```diff
- if (indexes[0].count === 0) {
+ if (Number(indexes[0].count) === 0) {
```

## Manual remediation required for existing databases

Since these migrations have already run and won't execute again, the missing indexes must be created manually on any affected database (staging, production, etc.):

```sql
CREATE INDEX idx_tx_output_utxo_lookup
  ON tx_output (address, token_id, spent_by, voided, locked, authorities);

CREATE INDEX idx_tx_output_locked_heightlock
  ON tx_output (locked, heightlock);

CREATE INDEX idx_tx_output_locked_timelock
  ON tx_output (locked, timelock);

CREATE INDEX idx_address_tx_history_addr_voided_token
  ON address_tx_history (address, voided, token_id);
```

## Test plan

- [x] Apply the manual SQL above to any existing affected database and confirm all 4 indexes appear
- [x] Spin up a fresh database and run all migrations — confirm all 4 indexes are created
- [x] Run the existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database index handling logic for enhanced stability and type consistency across migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->