### PR TITLE
fix: native token should allow version field

### DIFF
--- a/packages/wallet-service/src/schemas.ts
+++ b/packages/wallet-service/src/schemas.ts
@@ -35,6 +35,7 @@ export const FullnodeVersionSchema = Joi.object<FullNodeApiVersionResponse>({
   native_token: Joi.object({
     name: Joi.string().min(1).max(30).required(),
     symbol: Joi.string().min(1).max(5).required(),
+    version: Joi.number().integer(),
   }),
 }).unknown(true);
 


### PR DESCRIPTION
### Motivation

Fix the crash on the Wallet Service `testnet` after the `version field` has been added to the Fullnode `/version` endpoint

A `joi` validation on the lambda side expects the `native_token` object to not have the new `version` property, which it now has.

Current fullnode response:
```json
{
   "version":"0.70.0-rc.1",
   "network":"testnet-india",
   "nano_contracts_enabled":true,
   "min_weight":8,
   "min_tx_weight":8,
   "min_tx_weight_coefficient":0.0,
   "min_tx_weight_k":0.0,
   "token_deposit_percentage":0.01,
   "reward_spend_min_blocks":300,
   "max_number_inputs":255,
   "max_number_outputs":255,
   "decimal_places":2,
   "genesis_block_hash":"000001b7d5abc44d3828529654e8d830eeca1cd0e313032be1b8e9dfe31052ee",
   "genesis_tx1_hash":"00768e4df506979bb14e0efc16748d9306fa176de54e86069d115e74b26957df",
   "genesis_tx2_hash":"00306abcedddfa21707e7920fe324a997e3a311a959a18724c7e8cfd0468c164",
   "native_token":{
      "name":"Hathor",
      "symbol":"HTR",
      "version":0
   }
}
```

Source: https://github.com/HathorNetwork/hathor-wallet-service/blob/bb9779721bbf26f571924559c2fe3aea7daca014/packages/wallet-service/src/schemas.ts#L35-L38

This makes it break with 
```json
{
  "level":"error",
  "message":"[wallet-service-india-getVersionData] Unhandled error on /version: Error: \"native_token.version\" is not allowed"
}
```


### Acceptance Criteria

- Adds the field `version` to the expected fullnode `native_token` object

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced native token configuration validation to support version field tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->