### PR TITLE
test(wallet-service): harden /version contract

### DIFF
--- a/packages/wallet-service/src/fullnode.ts
+++ b/packages/wallet-service/src/fullnode.ts
@@ -32,7 +32,7 @@ export const create = (baseURL = BASE_URL) => {
       throw new Error(error.message);
     }
 
-    return value as FullNodeApiVersionResponse;
+    return value;
   };
 
   const downloadTx = async (txId: string) => {

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -126,7 +126,7 @@ export interface FullNodeApiVersionResponse {
   genesis_block_hash?: string,
   genesis_tx1_hash?: string,
   genesis_tx2_hash?: string,
-  native_token?: { name: string, symbol: string };
+  native_token?: { name: string, symbol: string, version?: number };
 }
 
 export interface TxProposal {

--- a/packages/wallet-service/tests/fullnode.test.ts
+++ b/packages/wallet-service/tests/fullnode.test.ts
@@ -2,6 +2,10 @@ import fullnode from '@src/fullnode';
 import { defaultTestVersionData } from '@tests/utils';
 
 describe('version', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('returns parsed payload when native_token includes the version field', async () => {
     expect.hasAssertions();
 

--- a/packages/wallet-service/tests/fullnode.test.ts
+++ b/packages/wallet-service/tests/fullnode.test.ts
@@ -1,37 +1,55 @@
 import fullnode from '@src/fullnode';
 import { defaultTestVersionData } from '@tests/utils';
 
-test('version returns parsed payload when the response matches the schema', async () => {
-  expect.hasAssertions();
+describe('version', () => {
+  test('returns parsed payload when native_token includes the version field', async () => {
+    expect.hasAssertions();
 
-  const payload = {
-    ...defaultTestVersionData(),
-    native_token: { name: 'Hathor', symbol: 'HTR', version: 0 },
-  };
-  const apiGetSpy = jest.spyOn(fullnode.api, 'get');
-  apiGetSpy.mockImplementation(() => Promise.resolve({
-    status: 200,
-    data: payload,
-  }));
+    const payload = {
+      ...defaultTestVersionData(),
+      native_token: { name: 'Hathor', symbol: 'HTR', version: 0 },
+    };
+    const apiGetSpy = jest.spyOn(fullnode.api, 'get');
+    apiGetSpy.mockImplementation(() => Promise.resolve({
+      status: 200,
+      data: payload,
+    }));
 
-  const response = await fullnode.version();
-  expect(response).toStrictEqual(payload);
-});
+    const response = await fullnode.version();
+    expect(response).toStrictEqual(payload);
+  });
 
-test('version throws when the response fails schema validation', async () => {
-  expect.hasAssertions();
+  test('returns parsed payload when native_token omits the version field', async () => {
+    expect.hasAssertions();
 
-  const invalidPayload = {
-    ...defaultTestVersionData(),
-    native_token: { name: 'Hathor', symbol: 'HTR', version: 1.5 },
-  };
-  const apiGetSpy = jest.spyOn(fullnode.api, 'get');
-  apiGetSpy.mockImplementation(() => Promise.resolve({
-    status: 200,
-    data: invalidPayload,
-  }));
+    // defaultTestVersionData() returns a payload whose native_token has no `version`.
+    const payload = defaultTestVersionData();
+    const apiGetSpy = jest.spyOn(fullnode.api, 'get');
+    apiGetSpy.mockImplementation(() => Promise.resolve({
+      status: 200,
+      data: payload,
+    }));
 
-  await expect(fullnode.version()).rejects.toThrow(/native_token\.version/);
+    const response = await fullnode.version();
+    expect(response).toStrictEqual(payload);
+    expect(response.native_token).not.toHaveProperty('version');
+  });
+
+  test('throws when the response fails schema validation', async () => {
+    expect.hasAssertions();
+
+    const invalidPayload = {
+      ...defaultTestVersionData(),
+      native_token: { name: 'Hathor', symbol: 'HTR', version: 1.5 },
+    };
+    const apiGetSpy = jest.spyOn(fullnode.api, 'get');
+    apiGetSpy.mockImplementation(() => Promise.resolve({
+      status: 200,
+      data: invalidPayload,
+    }));
+
+    await expect(fullnode.version()).rejects.toThrow(/native_token\.version/);
+  });
 });
 
 test('downloadTx', async () => {

--- a/packages/wallet-service/tests/fullnode.test.ts
+++ b/packages/wallet-service/tests/fullnode.test.ts
@@ -1,43 +1,28 @@
 import fullnode from '@src/fullnode';
-import { FullNodeApiVersionResponse } from '@src/types';
-
-const VALID_VERSION_PAYLOAD: FullNodeApiVersionResponse = {
-  version: '0.70.0-rc.1',
-  network: 'testnet-india',
-  nano_contracts_enabled: true,
-  min_weight: 8,
-  min_tx_weight: 8,
-  min_tx_weight_coefficient: 0,
-  min_tx_weight_k: 0,
-  token_deposit_percentage: 0.01,
-  reward_spend_min_blocks: 300,
-  max_number_inputs: 255,
-  max_number_outputs: 255,
-  decimal_places: 2,
-  genesis_block_hash: '000001b7d5abc44d3828529654e8d830eeca1cd0e313032be1b8e9dfe31052ee',
-  genesis_tx1_hash: '00768e4df506979bb14e0efc16748d9306fa176de54e86069d115e74b26957df',
-  genesis_tx2_hash: '00306abcedddfa21707e7920fe324a997e3a311a959a18724c7e8cfd0468c164',
-  native_token: { name: 'Hathor', symbol: 'HTR', version: 0 },
-};
+import { defaultTestVersionData } from '@tests/utils';
 
 test('version returns parsed payload when the response matches the schema', async () => {
   expect.hasAssertions();
 
+  const payload = {
+    ...defaultTestVersionData(),
+    native_token: { name: 'Hathor', symbol: 'HTR', version: 0 },
+  };
   const apiGetSpy = jest.spyOn(fullnode.api, 'get');
   apiGetSpy.mockImplementation(() => Promise.resolve({
     status: 200,
-    data: VALID_VERSION_PAYLOAD,
+    data: payload,
   }));
 
   const response = await fullnode.version();
-  expect(response).toStrictEqual(VALID_VERSION_PAYLOAD);
+  expect(response).toStrictEqual(payload);
 });
 
 test('version throws when the response fails schema validation', async () => {
   expect.hasAssertions();
 
   const invalidPayload = {
-    ...VALID_VERSION_PAYLOAD,
+    ...defaultTestVersionData(),
     native_token: { name: 'Hathor', symbol: 'HTR', version: 1.5 },
   };
   const apiGetSpy = jest.spyOn(fullnode.api, 'get');

--- a/packages/wallet-service/tests/fullnode.test.ts
+++ b/packages/wallet-service/tests/fullnode.test.ts
@@ -1,4 +1,53 @@
 import fullnode from '@src/fullnode';
+import { FullNodeApiVersionResponse } from '@src/types';
+
+const VALID_VERSION_PAYLOAD: FullNodeApiVersionResponse = {
+  version: '0.70.0-rc.1',
+  network: 'testnet-india',
+  nano_contracts_enabled: true,
+  min_weight: 8,
+  min_tx_weight: 8,
+  min_tx_weight_coefficient: 0,
+  min_tx_weight_k: 0,
+  token_deposit_percentage: 0.01,
+  reward_spend_min_blocks: 300,
+  max_number_inputs: 255,
+  max_number_outputs: 255,
+  decimal_places: 2,
+  genesis_block_hash: '000001b7d5abc44d3828529654e8d830eeca1cd0e313032be1b8e9dfe31052ee',
+  genesis_tx1_hash: '00768e4df506979bb14e0efc16748d9306fa176de54e86069d115e74b26957df',
+  genesis_tx2_hash: '00306abcedddfa21707e7920fe324a997e3a311a959a18724c7e8cfd0468c164',
+  native_token: { name: 'Hathor', symbol: 'HTR', version: 0 },
+};
+
+test('version returns parsed payload when the response matches the schema', async () => {
+  expect.hasAssertions();
+
+  const apiGetSpy = jest.spyOn(fullnode.api, 'get');
+  apiGetSpy.mockImplementation(() => Promise.resolve({
+    status: 200,
+    data: VALID_VERSION_PAYLOAD,
+  }));
+
+  const response = await fullnode.version();
+  expect(response).toStrictEqual(VALID_VERSION_PAYLOAD);
+});
+
+test('version throws when the response fails schema validation', async () => {
+  expect.hasAssertions();
+
+  const invalidPayload = {
+    ...VALID_VERSION_PAYLOAD,
+    native_token: { name: 'Hathor', symbol: 'HTR', version: 1.5 },
+  };
+  const apiGetSpy = jest.spyOn(fullnode.api, 'get');
+  apiGetSpy.mockImplementation(() => Promise.resolve({
+    status: 200,
+    data: invalidPayload,
+  }));
+
+  await expect(fullnode.version()).rejects.toThrow(/native_token\.version/);
+});
 
 test('downloadTx', async () => {
   expect.hasAssertions();

--- a/packages/wallet-service/tests/schemas.test.ts
+++ b/packages/wallet-service/tests/schemas.test.ts
@@ -1,10 +1,8 @@
 import { FullnodeVersionSchema } from '@src/schemas';
 import { defaultTestVersionData } from '@tests/utils';
 
-// Regression guard for the testnet outage that motivated PR 420: the
-// fullnode added `native_token.version` and the lambda crashed because the
-// nested object did not allow it. Locking the modern payload in as a
-// passing case prevents that fix from being reverted by accident.
+// Regression guard: the `native_token.version` is not available in all live fullnode instances.
+// The Wallet Service must be able to handle both cases.
 test('FullnodeVersionSchema regression: native_token.version is accepted', () => {
   const payload = {
     ...defaultTestVersionData(),

--- a/packages/wallet-service/tests/schemas.test.ts
+++ b/packages/wallet-service/tests/schemas.test.ts
@@ -1,43 +1,23 @@
 import { FullnodeVersionSchema } from '@src/schemas';
-import { FullNodeApiVersionResponse } from '@src/types';
-
-const VALID_PAYLOAD: FullNodeApiVersionResponse = {
-  version: '0.70.0-rc.1',
-  network: 'testnet-india',
-  nano_contracts_enabled: true,
-  min_weight: 8,
-  min_tx_weight: 8,
-  min_tx_weight_coefficient: 0,
-  min_tx_weight_k: 0,
-  token_deposit_percentage: 0.01,
-  reward_spend_min_blocks: 300,
-  max_number_inputs: 255,
-  max_number_outputs: 255,
-  decimal_places: 2,
-  genesis_block_hash: '000001b7d5abc44d3828529654e8d830eeca1cd0e313032be1b8e9dfe31052ee',
-  genesis_tx1_hash: '00768e4df506979bb14e0efc16748d9306fa176de54e86069d115e74b26957df',
-  genesis_tx2_hash: '00306abcedddfa21707e7920fe324a997e3a311a959a18724c7e8cfd0468c164',
-  native_token: {
-    name: 'Hathor',
-    symbol: 'HTR',
-    version: 0,
-  },
-};
+import { defaultTestVersionData } from '@tests/utils';
 
 // Regression guard for the testnet outage that motivated PR 420: the
 // fullnode added `native_token.version` and the lambda crashed because the
 // nested object did not allow it. Locking the modern payload in as a
 // passing case prevents that fix from being reverted by accident.
-test('FullnodeVersionSchema regression: PR 420 testnet payload validates', () => {
-  const { error, value } = FullnodeVersionSchema.validate(VALID_PAYLOAD);
+test('FullnodeVersionSchema regression: native_token.version is accepted', () => {
+  const payload = {
+    ...defaultTestVersionData(),
+    native_token: { name: 'Hathor', symbol: 'HTR', version: 0 },
+  };
+  const { error, value } = FullnodeVersionSchema.validate(payload);
   expect(error).toBeUndefined();
   expect(value.native_token).toEqual({ name: 'Hathor', symbol: 'HTR', version: 0 });
 });
 
 test('FullnodeVersionSchema accepts a legacy fullnode payload without native_token.version', () => {
-  const { native_token, ...rest } = VALID_PAYLOAD;
-  const legacy = { ...rest, native_token: { name: native_token!.name, symbol: native_token!.symbol } };
-  const { error } = FullnodeVersionSchema.validate(legacy);
+  // defaultTestVersionData() returns a payload whose native_token has no `version`.
+  const { error } = FullnodeVersionSchema.validate(defaultTestVersionData());
   expect(error).toBeUndefined();
 });
 
@@ -46,8 +26,8 @@ test('FullnodeVersionSchema accepts a legacy fullnode payload without native_tok
 // outage) surfaces fullnode schema drift.
 test('FullnodeVersionSchema rejects unknown fields under native_token', () => {
   const payload = {
-    ...VALID_PAYLOAD,
-    native_token: { ...VALID_PAYLOAD.native_token, icon: 'data:image/png;base64,...' },
+    ...defaultTestVersionData(),
+    native_token: { name: 'Hathor', symbol: 'HTR', version: 0, icon: 'data:image/png;base64,...' },
   };
   const { error } = FullnodeVersionSchema.validate(payload);
   expect(error).toBeDefined();
@@ -56,7 +36,7 @@ test('FullnodeVersionSchema rejects unknown fields under native_token', () => {
 
 test('FullnodeVersionSchema rejects a non-integer native_token.version', () => {
   const payload = {
-    ...VALID_PAYLOAD,
+    ...defaultTestVersionData(),
     native_token: { name: 'Hathor', symbol: 'HTR', version: 1.5 },
   };
   const { error } = FullnodeVersionSchema.validate(payload);

--- a/packages/wallet-service/tests/schemas.test.ts
+++ b/packages/wallet-service/tests/schemas.test.ts
@@ -1,0 +1,65 @@
+import { FullnodeVersionSchema } from '@src/schemas';
+import { FullNodeApiVersionResponse } from '@src/types';
+
+const VALID_PAYLOAD: FullNodeApiVersionResponse = {
+  version: '0.70.0-rc.1',
+  network: 'testnet-india',
+  nano_contracts_enabled: true,
+  min_weight: 8,
+  min_tx_weight: 8,
+  min_tx_weight_coefficient: 0,
+  min_tx_weight_k: 0,
+  token_deposit_percentage: 0.01,
+  reward_spend_min_blocks: 300,
+  max_number_inputs: 255,
+  max_number_outputs: 255,
+  decimal_places: 2,
+  genesis_block_hash: '000001b7d5abc44d3828529654e8d830eeca1cd0e313032be1b8e9dfe31052ee',
+  genesis_tx1_hash: '00768e4df506979bb14e0efc16748d9306fa176de54e86069d115e74b26957df',
+  genesis_tx2_hash: '00306abcedddfa21707e7920fe324a997e3a311a959a18724c7e8cfd0468c164',
+  native_token: {
+    name: 'Hathor',
+    symbol: 'HTR',
+    version: 0,
+  },
+};
+
+// Regression guard for the testnet outage that motivated PR 420: the
+// fullnode added `native_token.version` and the lambda crashed because the
+// nested object did not allow it. Locking the modern payload in as a
+// passing case prevents that fix from being reverted by accident.
+test('FullnodeVersionSchema regression: PR 420 testnet payload validates', () => {
+  const { error, value } = FullnodeVersionSchema.validate(VALID_PAYLOAD);
+  expect(error).toBeUndefined();
+  expect(value.native_token).toEqual({ name: 'Hathor', symbol: 'HTR', version: 0 });
+});
+
+test('FullnodeVersionSchema accepts a legacy fullnode payload without native_token.version', () => {
+  const { native_token, ...rest } = VALID_PAYLOAD;
+  const legacy = { ...rest, native_token: { name: native_token!.name, symbol: native_token!.symbol } };
+  const { error } = FullnodeVersionSchema.validate(legacy);
+  expect(error).toBeUndefined();
+});
+
+// Design-intent guard: native_token is intentionally strict — any unknown
+// field there fails validation so a contract test (and not a production
+// outage) surfaces fullnode schema drift.
+test('FullnodeVersionSchema rejects unknown fields under native_token', () => {
+  const payload = {
+    ...VALID_PAYLOAD,
+    native_token: { ...VALID_PAYLOAD.native_token, icon: 'data:image/png;base64,...' },
+  };
+  const { error } = FullnodeVersionSchema.validate(payload);
+  expect(error).toBeDefined();
+  expect(error!.message).toMatch(/native_token\.icon/);
+});
+
+test('FullnodeVersionSchema rejects a non-integer native_token.version', () => {
+  const payload = {
+    ...VALID_PAYLOAD,
+    native_token: { name: 'Hathor', symbol: 'HTR', version: 1.5 },
+  };
+  const { error } = FullnodeVersionSchema.validate(payload);
+  expect(error).toBeDefined();
+  expect(error!.message).toMatch(/native_token\.version/);
+});


### PR DESCRIPTION
### Motivation

Completes the follow-up work after HathorNetwork/hathor-wallet-service#420, which was a one-line emergency bugfix (allowing `native_token.version` on the fullnode `/version` payload). The fix shipped narrow on purpose; both CodeRabbit and Copilot flagged that it left loose ends — TypeScript typing and tests. This PR closes those out, scoped tightly to `native_token.version`.

### Changes

- **Type alignment** — `FullNodeApiVersionResponse.native_token` gains `version?: number` so the TS type matches the Joi schema. The `as FullNodeApiVersionResponse` cast in `fullnode.ts` is dropped (it was masking the drift; `Joi.object<T>()` already types the validator's output).
- **Schema unit tests** (new `tests/schemas.test.ts`, 4 cases) — first direct coverage of `FullnodeVersionSchema`, all scoped to the `native_token.version` field:
  - **PR 420 regression guard:** the modern testnet payload (with `native_token.version: 0`) validates.
  - Legacy payload (no `native_token.version`) validates.
  - Unknown fields under `native_token` fail validation (design intent — keep nested object strict).
  - Non-integer `native_token.version` (e.g. `1.5`) fails validation.
- **`fullnode.version()` tests** (extend `tests/fullnode.test.ts`) — happy-path and schema-rejection cases that verify the schema wiring inside `fullnode.ts` actually runs and throws. Rejection case uses a `native_token.version` violation.

### Out of scope (intentionally)

A live-fullnode contract test (that would fail CI when the `/version` response drifts) was considered and removed from this PR, since there is no existing precedent for tests making real HTTP calls in the wallet-service workspace — PR HathorNetwork/hathor-wallet-service#394 went the other direction. That can be a separate PR if we want to introduce that pattern.

### Acceptance Criteria

- `FullnodeVersionSchema` accepts the post-PR 420 `native_token` payload and rejects misuse of the new `version` field; covered by unit tests.
- `FullNodeApiVersionResponse` reflects the schema, removing the type cast that was hiding the drift.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native token responses now optionally include a version property for richer metadata.

* **Refactor**
  * Version handling updated to return the validated result directly for clearer, safer responses.

* **Tests**
  * Added tests for modern and legacy native-token payloads, strict schema validation, and rejection on invalid version values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-wallet-service/pull/428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->