### PR TITLE
feat(daemon): shielded DB helpers (PR 4/6)

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -26,6 +26,23 @@ export enum Severity {
   INFO = 'info',
 }
 
+/**
+ * Lightweight projection of a shielded output for the realtime `new-tx`
+ * payload. Shielded values are encrypted, so clients can't derive balances
+ * from the wire — they intersect `Transaction.addresses` with their own and
+ * refetch. This carries only what's safe and useful for that: the kind,
+ * token slot, and decoded address. The on-chain crypto blobs (commitment,
+ * range_proof, ephemeral_pubkey, …) are intentionally omitted.
+ */
+export interface RealtimeShieldedOutput {
+  mode: number;
+  // Present only for AmountShielded (mode 1); FullyShielded (mode 2) hides the
+  // token, so there is no token slot to report.
+  // eslint-disable-next-line camelcase
+  token_data?: number;
+  decoded: { address: string } | null;
+}
+
 export interface Transaction {
   // eslint-disable-next-line camelcase
   tx_id: string;
@@ -45,6 +62,12 @@ export interface Transaction {
   token_name?: string | null;
   // eslint-disable-next-line camelcase
   token_symbol?: string | null;
+  // Additive shielded-outputs realtime fields (see RealtimeShieldedOutput).
+  // `addresses` is the full involved-address set the daemon computed for the
+  // vertex; the client intersects it with its own addresses and refetches.
+  // eslint-disable-next-line camelcase
+  shielded_outputs?: RealtimeShieldedOutput[];
+  addresses?: string[];
 }
 
 export interface TxInput {

--- a/packages/daemon/__tests__/db/findShieldedAddressOwnership.test.ts
+++ b/packages/daemon/__tests__/db/findShieldedAddressOwnership.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Connection } from 'mysql2/promise';
+import {
+  findShieldedAddressOwnership,
+  getDbConnection,
+  upsertShieldedAddressObservation,
+} from '../../src/db';
+import { cleanDatabase } from '../utils';
+
+let mysql: Connection;
+
+beforeAll(async () => {
+  try {
+    mysql = await getDbConnection();
+  } catch (e) {
+    console.error('Failed to establish db connection', e);
+    throw e;
+  }
+});
+
+afterAll(() => {
+  mysql.destroy();
+});
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+});
+
+describe('findShieldedAddressOwnership', () => {
+  test('returns null when no row exists for the address', async () => {
+    expect.hasAssertions();
+
+    const result = await findShieldedAddressOwnership(mysql, 'WT4nMISSING');
+
+    expect(result).toBeNull();
+  });
+
+  test('returns null when the address exists but ownership / scan_privkey is NULL (unowned)', async () => {
+    expect.hasAssertions();
+
+    await upsertShieldedAddressObservation(mysql, 'WT4nUNOWNED');
+
+    const result = await findShieldedAddressOwnership(mysql, 'WT4nUNOWNED');
+
+    expect(result).toBeNull();
+  });
+
+  test('returns null when only a Legacy (bip32_account=0) row exists for the address', async () => {
+    expect.hasAssertions();
+
+    await mysql.query(
+      `INSERT INTO address (address, bip32_account, \`index\`, wallet_id, transactions)
+       VALUES (?, 0, 0, 'wallet_alice', 1)`,
+      ['WT4nTRANSPARENT'],
+    );
+
+    const result = await findShieldedAddressOwnership(mysql, 'WT4nTRANSPARENT');
+
+    expect(result).toBeNull();
+  });
+
+  test('returns ownership info when the shielded row has been claimed by a wallet', async () => {
+    expect.hasAssertions();
+
+    await upsertShieldedAddressObservation(mysql, 'WT4nOWNED');
+
+    // Simulate a wallet registration claiming this row: sets wallet_id,
+    // derivation slot (bip32_account = 2 = CTSpend), index, and scan key.
+    // The observation row started with bip32_account NULL, so the WHERE
+    // clause matches the row by address alone.
+    const scanPrivkey = Buffer.alloc(32, 0x42);
+    await mysql.query(
+      `UPDATE address
+         SET wallet_id = ?, bip32_account = ?, \`index\` = ?, scan_privkey = ?
+       WHERE address = ?`,
+      ['wallet_alice', 2, 7, scanPrivkey, 'WT4nOWNED'],
+    );
+
+    const result = await findShieldedAddressOwnership(mysql, 'WT4nOWNED');
+
+    expect(result).toMatchObject({
+      wallet_id: 'wallet_alice',
+      shielded_index: 7,
+    });
+    expect(result!.scan_privkey.equals(Buffer.alloc(32, 0x42))).toBe(true);
+  });
+});

--- a/packages/daemon/__tests__/db/findShieldedAddressOwnership.test.ts
+++ b/packages/daemon/__tests__/db/findShieldedAddressOwnership.test.ts
@@ -8,6 +8,7 @@
 import { Connection } from 'mysql2/promise';
 import {
   findShieldedAddressOwnership,
+  findShieldedAddressOwnershipBatch,
   getDbConnection,
   upsertShieldedAddressObservation,
 } from '../../src/db';
@@ -89,5 +90,66 @@ describe('findShieldedAddressOwnership', () => {
       shielded_index: 7,
     });
     expect(result!.scan_privkey.equals(Buffer.alloc(32, 0x42))).toBe(true);
+  });
+});
+
+describe('findShieldedAddressOwnershipBatch', () => {
+  // Promote an observation row to a wallet-claimed CTSpend row (bip32_account = 2),
+  // mirroring what a wallet registration does. The void path relies on this exact
+  // shape to decide whether a same-address row gets its balance reversed.
+  const claimAddress = async (address: string, index: number): Promise<void> => {
+    await upsertShieldedAddressObservation(mysql, address);
+    await mysql.query(
+      `UPDATE address
+         SET wallet_id = 'wallet_alice', bip32_account = 2, \`index\` = ?, scan_privkey = ?
+       WHERE address = ?`,
+      [index, Buffer.alloc(32, 0x42), address],
+    );
+  };
+
+  test('returns an empty map for an empty address list (early return, no query)', async () => {
+    expect.hasAssertions();
+
+    const result = await findShieldedAddressOwnershipBatch(mysql, []);
+
+    expect(result.size).toBe(0);
+  });
+
+  test('deduplicates a repeated address into a single map entry', async () => {
+    expect.hasAssertions();
+
+    await claimAddress('WT4nOWNED', 7);
+
+    const result = await findShieldedAddressOwnershipBatch(mysql, ['WT4nOWNED', 'WT4nOWNED']);
+
+    expect(result.size).toBe(1);
+    expect(result.get('WT4nOWNED')).toMatchObject({
+      wallet_id: 'wallet_alice',
+      shielded_index: 7,
+    });
+  });
+
+  test('omits existing-but-unowned rows (NULL scan_privkey / non-CTSpend account)', async () => {
+    expect.hasAssertions();
+
+    // Owned CTSpend row — must be present in the map.
+    await claimAddress('WT4nOWNED', 7);
+    // Observation row that no wallet has claimed: scan_privkey stays NULL.
+    await upsertShieldedAddressObservation(mysql, 'WT4nUNOWNED');
+    // Legacy (bip32_account = 0) row for an unrelated address.
+    await mysql.query(
+      `INSERT INTO address (address, bip32_account, \`index\`, wallet_id, transactions)
+       VALUES ('WT4nLEGACY', 0, 0, 'wallet_alice', 1)`,
+    );
+
+    const result = await findShieldedAddressOwnershipBatch(
+      mysql,
+      ['WT4nOWNED', 'WT4nUNOWNED', 'WT4nLEGACY'],
+    );
+
+    expect(result.size).toBe(1);
+    expect(result.has('WT4nOWNED')).toBe(true);
+    expect(result.has('WT4nUNOWNED')).toBe(false);
+    expect(result.has('WT4nLEGACY')).toBe(false);
   });
 });

--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -268,6 +268,8 @@ describe('tx output methods', () => {
       spentBy: null,
       txProposalId: null,
       txProposalIndex: null,
+      mode: 0,
+      recoveryState: null,
     });
 
     // empty list should be fine
@@ -292,6 +294,8 @@ describe('tx output methods', () => {
       spentBy: txId,
       txProposalId: null,
       txProposalIndex: null,
+      mode: 0,
+      recoveryState: null,
     });
 
     // if the tx output is not found, it should return null
@@ -309,6 +313,8 @@ describe('tx output methods', () => {
       heightlock: null,
       timelock: null,
       index,
+      mode: 0,
+      recoveryState: null,
     }));
 
     await unspendUtxos(mysql, txOutputs);
@@ -379,19 +385,20 @@ describe('tx output methods', () => {
 
     const txId = 'txId';
     const utxos: DbTxOutput[] = [
-      { txId, index: 0, tokenId: 'token1', address: 'address1', value: 5n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null },
-      { txId, index: 1, tokenId: 'token1', address: 'address1', value: 15n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null},
-      { txId, index: 2, tokenId: 'token1', address: 'address1', value: 25n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null },
-      { txId, index: 3, tokenId: 'token1', address: 'address1', value: 1n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null },
-      { txId, index: 4, tokenId: 'token1', address: 'address1', value: 3n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null },
+      { txId, index: 0, tokenId: 'token1', address: 'address1', value: 5n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null, mode: 0, recoveryState: null },
+      { txId, index: 1, tokenId: 'token1', address: 'address1', value: 15n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null, mode: 0, recoveryState: null },
+      { txId, index: 2, tokenId: 'token1', address: 'address1', value: 25n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null, mode: 0, recoveryState: null },
+      { txId, index: 3, tokenId: 'token1', address: 'address1', value: 1n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null, mode: 0, recoveryState: null },
+      { txId, index: 4, tokenId: 'token1', address: 'address1', value: 3n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null, mode: 0, recoveryState: null },
     ];
 
     // add to utxo table
     const outputs = utxos.map((utxo, index) => createOutput(
       index,
-      utxo.value,
+      // transparent fixture: value and tokenId are non-null
+      utxo.value!,
       utxo.address,
-      utxo.tokenId,
+      utxo.tokenId!,
       utxo.timelock,
       utxo.locked,
       0,
@@ -411,16 +418,17 @@ describe('tx output methods', () => {
     await addOrUpdateTx(mysql, txId, 0, 1, 1, 65);
 
     const utxos: DbTxOutput[] = [
-      { txId, index: 0, tokenId: 'token1', address: 'address1', value: 5n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null },
-      { txId, index: 1, tokenId: 'token1', address: 'address1', value: 15n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null},
+      { txId, index: 0, tokenId: 'token1', address: 'address1', value: 5n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null, mode: 0, recoveryState: null },
+      { txId, index: 1, tokenId: 'token1', address: 'address1', value: 15n, authorities: 0, timelock: 0, heightlock: null, locked: false, spentBy: null, txProposalIndex: null, txProposalId: null, mode: 0, recoveryState: null },
     ];
 
     // add to utxo table
     const outputs = utxos.map((utxo, index) => createOutput(
       index,
-      utxo.value,
+      // transparent fixture: value and tokenId are non-null
+      utxo.value!,
       utxo.address,
-      utxo.tokenId,
+      utxo.tokenId!,
       utxo.timelock,
       utxo.locked,
       0,
@@ -572,9 +580,18 @@ describe('address and wallet related tests', () => {
       address2: TokenBalanceMap.fromStringMap({ token1: { unlocked: 8n, locked: 0n, unlockedAuthorities: new Authorities(0b01) } }),
     };
 
+    // Pre-seed address2 too — updateAddressTablesWithTx no longer inserts
+    // address rows on its own. The involvement counter is owned by
+    // bumpAddressInvolvement, which is exercised separately.
+    await addToAddressTable(mysql, [
+      { address: address2, index: null, walletId: null, transactions: 0 },
+    ]);
+
     await updateAddressTablesWithTx(mysql, txId1, timestamp1, addrMap1);
-    await expect(checkAddressTable(mysql, 2, address1, null, null, 2)).resolves.toBe(true);
-    await expect(checkAddressTable(mysql, 2, address2, null, null, 1)).resolves.toBe(true);
+    // updateAddressTablesWithTx leaves `address.transactions` untouched;
+    // the pre-seeded values survive the call.
+    await expect(checkAddressTable(mysql, 2, address1, null, null, 1)).resolves.toBe(true);
+    await expect(checkAddressTable(mysql, 2, address2, null, null, 0)).resolves.toBe(true);
     await expect(checkAddressBalanceTable(mysql, 4, address1, token1, 10n, 0n, null, 1)).resolves.toBe(true);
     await expect(checkAddressBalanceTable(mysql, 4, address1, token2, 7n, 0n, null, 1)).resolves.toBe(true);
     await expect(checkAddressBalanceTable(mysql, 4, address1, token3, 2n, 0n, null, 1, 0b01, 0)).resolves.toBe(true);
@@ -595,8 +612,8 @@ describe('address and wallet related tests', () => {
     };
 
     await updateAddressTablesWithTx(mysql, txId2, timestamp2, addrMap2);
-    await expect(checkAddressTable(mysql, 2, address1, null, null, 3)).resolves.toBe(true);
-    await expect(checkAddressTable(mysql, 2, address2, null, null, 2)).resolves.toBe(true);
+    await expect(checkAddressTable(mysql, 2, address1, null, null, 1)).resolves.toBe(true);
+    await expect(checkAddressTable(mysql, 2, address2, null, null, 0)).resolves.toBe(true);
     // final balance for each (address,token)
     await expect(checkAddressBalanceTable(mysql, 5, address1, 'token1', 5n, 0n, null, 2)).resolves.toBe(true);
     await expect(checkAddressBalanceTable(mysql, 5, address1, 'token2', 7n, 0n, null, 1)).resolves.toBe(true);
@@ -679,6 +696,8 @@ describe('address and wallet related tests', () => {
       heightlock: null,
       locked: true,
       spentBy: null,
+      mode: 0,
+      recoveryState: null,
     }]);
     const newMap = TokenBalanceMap.fromStringMap({ [tokenId]: { unlocked: 0, locked: 0, unlockedAuthorities: new Authorities(0b10) } });
     await updateAddressLockedBalance(mysql, { [addr1]: newMap });
@@ -754,11 +773,15 @@ describe('address and wallet related tests', () => {
       addr3: wallet2,
     };
 
-    // populate address table
+    // populate address table; assign unique per-wallet indices so the
+    // (wallet_id, bip32_account, index) unique constraint isn't violated.
+    const walletIndexCounter: Record<string, number> = {};
     for (const [address, wallet] of Object.entries(finalMap)) {
+      const idx = walletIndexCounter[wallet.walletId] ?? 0;
+      walletIndexCounter[wallet.walletId] = idx + 1;
       await addToAddressTable(mysql, [{
         address,
-        index: 0,
+        index: idx,
         walletId: wallet.walletId,
         transactions: 0,
       }]);
@@ -998,10 +1021,12 @@ describe('address and wallet related tests', () => {
       walletId2: TokenBalanceMap.fromStringMap({ token2: { unlocked: 10, locked: 0 } }),
     };
     // the tx above removes an authority, which will trigger a "refresh" on the available authorities.
-    // Let's pretend there's another utxo with some authorities as well
+    // Let's pretend there's another utxo with some authorities as well. The
+    // (walletId, bip32_account=0, index) unique constraint requires a fresh
+    // index since addr1..addr3 already occupy 0..2.
     await addToAddressTable(mysql, [{
       address: 'address1',
-      index: 0,
+      index: 3,
       walletId,
       transactions: 1,
     }]);

--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -30,6 +30,9 @@ import {
   getTxOutputsFromTx,
   getUtxosLockedAtHeight,
   incrementTokensTxCount,
+  incrementTokenTotalSupply,
+  setTokenTotalSupply,
+  bumpAddressInvolvement,
   markUtxosAsVoided,
   storeTokenInformation,
   insertTokenCreation,
@@ -47,7 +50,7 @@ import {
   voidTransaction,
   voidAddressTransaction
 } from '../../src/db';
-import { Connection } from 'mysql2/promise';
+import { Connection, RowDataPacket } from 'mysql2/promise';
 import {
   ADDRESSES,
   addToAddressBalanceTable,
@@ -1725,5 +1728,133 @@ describe('token creation mapping methods', () => {
     // even though null != 'some-block' because token_id = tx_id
     const tokens = await getReexecNanoTokens(mysql, txId, 'some-block');
     expect(tokens).toHaveLength(0);
+  });
+});
+
+describe('incrementTokenTotalSupply', () => {
+  const tokenId = 'total-supply-token';
+
+  const getTotalSupply = async (id: string): Promise<bigint | null> => {
+    const [rows] = await mysql.query<RowDataPacket[]>(
+      'SELECT `total_supply` FROM `token` WHERE `id` = ?',
+      [id],
+    );
+    if (rows.length === 0) return null;
+    return BigInt(rows[0].total_supply);
+  };
+
+  const seedToken = async (initial: bigint): Promise<void> => {
+    await addToTokenTable(mysql, [
+      { id: tokenId, name: 'My Token', symbol: 'MTK', version: TokenVersion.DEPOSIT, transactions: 0 },
+    ]);
+    await setTokenTotalSupply(mysql, tokenId, initial);
+  };
+
+  test('applies a positive delta (mint)', async () => {
+    await seedToken(100n);
+
+    await incrementTokenTotalSupply(mysql, tokenId, 50n);
+
+    expect(await getTotalSupply(tokenId)).toEqual(150n);
+  });
+
+  test('applies a negative delta that stays non-negative (melt)', async () => {
+    await seedToken(100n);
+
+    await incrementTokenTotalSupply(mysql, tokenId, -40n);
+
+    expect(await getTotalSupply(tokenId)).toEqual(60n);
+  });
+
+  test('no-ops against a non-existent token row', async () => {
+    // No token row is seeded: the UPDATE matches zero rows and must not
+    // create one (the helper is UPDATE-only by contract).
+    await incrementTokenTotalSupply(mysql, 'missing-token', 25n);
+
+    expect(await getTotalSupply('missing-token')).toBeNull();
+  });
+
+  test('throws on underflow under STRICT_TRANS_TABLES', async () => {
+    await seedToken(10n);
+
+    // Pin the session mode so the test asserts the documented contract
+    // regardless of the server's ambient default, then restore it so the
+    // shared connection is left untouched for sibling tests.
+    const [[{ sql_mode: original }]] = await mysql.query<RowDataPacket[]>(
+      'SELECT @@SESSION.sql_mode AS sql_mode',
+    );
+    await mysql.query("SET SESSION sql_mode = 'STRICT_TRANS_TABLES'");
+    try {
+      await expect(
+        incrementTokenTotalSupply(mysql, tokenId, -20n),
+      ).rejects.toThrow();
+
+      // The rejected UPDATE left the supply untouched.
+      expect(await getTotalSupply(tokenId)).toEqual(10n);
+    } finally {
+      await mysql.query('SET SESSION sql_mode = ?', [original]);
+    }
+  });
+});
+
+describe('bumpAddressInvolvement', () => {
+  const addrA = ADDRESSES[0];
+  const addrB = ADDRESSES[1];
+
+  const getTransactions = async (address: string): Promise<number | null> => {
+    const [rows] = await mysql.query<RowDataPacket[]>(
+      'SELECT `transactions` FROM `address` WHERE `address` = ?',
+      [address],
+    );
+    if (rows.length === 0) return null;
+    return rows[0].transactions;
+  };
+
+  test('inserts new address rows with transactions = 1', async () => {
+    await bumpAddressInvolvement(mysql, [addrA, addrB]);
+
+    expect(await checkAddressTable(mysql, 2, addrA, null, null, 1)).toBe(true);
+    expect(await checkAddressTable(mysql, 2, addrB, null, null, 1)).toBe(true);
+  });
+
+  test('increments transactions on existing address rows', async () => {
+    await addToAddressTable(mysql, [
+      { address: addrA, index: null, walletId: null, transactions: 5 },
+    ]);
+
+    await bumpAddressInvolvement(mysql, [addrA]);
+
+    expect(await getTransactions(addrA)).toBe(6);
+  });
+
+  test('handles a mix of new and existing addresses in one call', async () => {
+    await addToAddressTable(mysql, [
+      { address: addrA, index: null, walletId: null, transactions: 2 },
+    ]);
+
+    await bumpAddressInvolvement(mysql, [addrA, addrB]);
+
+    expect(await getTransactions(addrA)).toBe(3);
+    expect(await getTransactions(addrB)).toBe(1);
+  });
+
+  test('bumps once per call (two calls => +2)', async () => {
+    await bumpAddressInvolvement(mysql, [addrA]);
+    await bumpAddressInvolvement(mysql, [addrA]);
+
+    expect(await getTransactions(addrA)).toBe(2);
+  });
+
+  test('accepts any iterable (Set) of addresses', async () => {
+    await bumpAddressInvolvement(mysql, new Set([addrA, addrB]));
+
+    expect(await getTransactions(addrA)).toBe(1);
+    expect(await getTransactions(addrB)).toBe(1);
+  });
+
+  test('no-ops on an empty set, creating no rows', async () => {
+    await bumpAddressInvolvement(mysql, []);
+
+    expect(await checkAddressTable(mysql, 0)).toBe(true);
   });
 });

--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -1435,6 +1435,73 @@ describe('voidTransaction', () => {
 
     await expect(voidTransaction(mysql, 'mysterious-transaction')).rejects.toThrow('Tried to void a transaction that is not in the database.');
   });
+
+  it('keeps a row whose transparent columns zero out but still holds shielded balance', async () => {
+    expect.hasAssertions();
+
+    // A single (address, token) row carries BOTH a transparent balance from
+    // this tx and an independent, already-recovered shielded balance. Voiding
+    // the transparent tx must drop the transparent columns to zero WITHOUT
+    // deleting the row — the shielded `= 0` guards on the cleanup DELETE are
+    // what keep the surviving shielded balance alive.
+    const mixedAddr = 'addr-mixed';
+    const mixedToken = 'token-mixed';
+
+    await addToTransactionTable(mysql, [{
+      txId,
+      timestamp: 0,
+      version: constants.BLOCK_VERSION,
+      voided: false,
+      height: 1,
+    }]);
+
+    // Seed the row directly so the shielded columns can be populated
+    // (addToAddressBalanceTable does not cover them).
+    await mysql.query(
+      `INSERT INTO address_balance
+         (address, token_id, total_received, unlocked_balance, locked_balance,
+          timelock_expires, unlocked_authorities, locked_authorities,
+          unlocked_shielded_balance, locked_shielded_balance, total_shielded_received,
+          transactions)
+       VALUES (?, ?, 49, 49, 0, NULL, 0, 0, 100, 0, 100, 1)`,
+      [mixedAddr, mixedToken],
+    );
+
+    await addToAddressTxHistoryTable(mysql, [{
+      address: mixedAddr,
+      txId,
+      tokenId: mixedToken,
+      balance: 49,
+      timestamp: 1,
+    }]);
+
+    // The void only reverses the transparent contribution; no shielded amount
+    // is carried, mirroring a purely transparent voided tx.
+    const addressBalance: StringMap<TokenBalanceMap> = {
+      [mixedAddr]: TokenBalanceMap.fromStringMap({
+        [mixedToken]: { totalSent: 49n, unlocked: 49n, locked: 0n },
+      }),
+    };
+
+    await voidTransaction(mysql, txId);
+    await voidAddressTransaction(mysql, txId, addressBalance, 1);
+
+    // Row survives the cleanup DELETE: transparent columns zeroed, shielded intact.
+    const [rows] = await mysql.query<any[]>(
+      `SELECT total_received, unlocked_balance, locked_balance,
+              unlocked_shielded_balance, locked_shielded_balance,
+              total_shielded_received, transactions
+         FROM address_balance WHERE address = ? AND token_id = ?`,
+      [mixedAddr, mixedToken],
+    );
+    expect(rows).toHaveLength(1);
+    expect(BigInt(rows[0].total_received)).toBe(0n);
+    expect(BigInt(rows[0].unlocked_balance)).toBe(0n);
+    expect(BigInt(rows[0].locked_balance)).toBe(0n);
+    expect(BigInt(rows[0].unlocked_shielded_balance)).toBe(100n);
+    expect(BigInt(rows[0].total_shielded_received)).toBe(100n);
+    expect(Number(rows[0].transactions)).toBe(0);
+  });
 });
 
 describe('address generation and index methods', () => {

--- a/packages/daemon/__tests__/db/insertShieldedTxOutputData.test.ts
+++ b/packages/daemon/__tests__/db/insertShieldedTxOutputData.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Connection } from 'mysql2/promise';
+import {
+  getDbConnection,
+  insertShieldedTxOutputData,
+  insertTxOutput,
+} from '../../src/db';
+import { cleanDatabase } from '../utils';
+import { ShieldedOutputMode, RecoveryState } from '@wallet-service/common';
+
+let mysql: Connection;
+
+beforeAll(async () => {
+  try {
+    mysql = await getDbConnection();
+  } catch (e) {
+    console.error('Failed to establish db connection', e);
+    throw e;
+  }
+});
+
+afterAll(() => {
+  mysql.destroy();
+});
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+});
+
+describe('insertShieldedTxOutputData', () => {
+  test('writes an AmountShielded satellite row (mode=1: token_data set, asset_* NULL)', async () => {
+    expect.hasAssertions();
+
+    await insertTxOutput(mysql, {
+      tx_id: 'T1',
+      index: 0,
+      mode: ShieldedOutputMode.AmountShielded,
+      address: 'WT4nB',
+      value: null,
+      token_id: '00',
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: RecoveryState.Unowned,
+    });
+
+    await insertShieldedTxOutputData(mysql, {
+      tx_id: 'T1',
+      index: 0,
+      mode: 1,
+      commitment: Buffer.alloc(33, 0xaa),
+      range_proof: Buffer.alloc(64, 0xbb),
+      script: Buffer.alloc(20, 0xcc),
+      ephemeral_pubkey: Buffer.alloc(33, 0xdd),
+      token_data: 1,
+    });
+
+    const [rows] = await mysql.execute(
+      'SELECT * FROM shielded_tx_output_data WHERE tx_id = ? AND `index` = ?',
+      ['T1', 0],
+    );
+    const result = rows as Array<{
+      tx_id: string;
+      index: number;
+      commitment: Buffer;
+      range_proof: Buffer;
+      script: Buffer;
+      ephemeral_pubkey: Buffer;
+      token_data: number | null;
+      asset_commitment: Buffer | null;
+      surjection_proof: Buffer | null;
+    }>;
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.commitment.equals(Buffer.alloc(33, 0xaa))).toBe(true);
+    expect(row.range_proof.equals(Buffer.alloc(64, 0xbb))).toBe(true);
+    expect(row.script.equals(Buffer.alloc(20, 0xcc))).toBe(true);
+    expect(row.ephemeral_pubkey.equals(Buffer.alloc(33, 0xdd))).toBe(true);
+    expect(row.token_data).toBe(1);
+    expect(row.asset_commitment).toBeNull();
+    expect(row.surjection_proof).toBeNull();
+  });
+
+  test('writes a FullyShielded satellite row (mode=2: asset_commitment + surjection_proof set, token_data NULL)', async () => {
+    expect.hasAssertions();
+
+    await insertTxOutput(mysql, {
+      tx_id: 'T2',
+      index: 0,
+      mode: ShieldedOutputMode.FullyShielded,
+      address: 'WT4nC',
+      value: null,
+      token_id: null,
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: RecoveryState.Unowned,
+    });
+
+    await insertShieldedTxOutputData(mysql, {
+      tx_id: 'T2',
+      index: 0,
+      mode: 2,
+      commitment: Buffer.alloc(33, 0xaa),
+      range_proof: Buffer.alloc(64, 0xbb),
+      script: Buffer.alloc(20, 0xcc),
+      ephemeral_pubkey: Buffer.alloc(33, 0xdd),
+      asset_commitment: Buffer.alloc(33, 0xee),
+      surjection_proof: Buffer.alloc(64, 0xff),
+    });
+
+    const [rows] = await mysql.execute(
+      'SELECT * FROM shielded_tx_output_data WHERE tx_id = ? AND `index` = ?',
+      ['T2', 0],
+    );
+    const result = rows as Array<{
+      tx_id: string;
+      index: number;
+      commitment: Buffer;
+      range_proof: Buffer;
+      script: Buffer;
+      ephemeral_pubkey: Buffer;
+      token_data: number | null;
+      asset_commitment: Buffer | null;
+      surjection_proof: Buffer | null;
+    }>;
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.commitment.equals(Buffer.alloc(33, 0xaa))).toBe(true);
+    expect(row.token_data).toBeNull();
+    expect(row.asset_commitment).not.toBeNull();
+    expect(row.asset_commitment!.equals(Buffer.alloc(33, 0xee))).toBe(true);
+    expect(row.surjection_proof).not.toBeNull();
+    expect(row.surjection_proof!.equals(Buffer.alloc(64, 0xff))).toBe(true);
+  });
+});

--- a/packages/daemon/__tests__/db/insertTxOutput.test.ts
+++ b/packages/daemon/__tests__/db/insertTxOutput.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Connection } from 'mysql2/promise';
+import {
+  getDbConnection,
+  getTxOutput,
+  insertTxOutput,
+} from '../../src/db';
+import { cleanDatabase } from '../utils';
+import { ShieldedOutputMode, RecoveryState } from '@wallet-service/common';
+
+let mysql: Connection;
+
+beforeAll(async () => {
+  try {
+    mysql = await getDbConnection();
+  } catch (e) {
+    console.error('Failed to establish db connection', e);
+    throw e;
+  }
+});
+
+afterAll(() => {
+  mysql.destroy();
+});
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+});
+
+describe('insertTxOutput', () => {
+  test('writes a transparent row with mode=0 and recovery_state=NULL', async () => {
+    expect.hasAssertions();
+
+    await insertTxOutput(mysql, {
+      tx_id: 'T0',
+      index: 0,
+      mode: ShieldedOutputMode.Transparent,
+      address: 'WT4nA',
+      value: 100n,
+      token_id: '00',
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: null,
+    });
+
+    const row = await getTxOutput(mysql, 'T0', 0, false);
+    expect(row).not.toBeNull();
+    expect(row!.mode).toBe(0);
+    expect(row!.recoveryState).toBeNull();
+    expect(row!.value).toBe(100n);
+    expect(row!.tokenId).toBe('00');
+  });
+
+  test('writes an unrecovered AmountShielded row with value NULL but token_id populated', async () => {
+    expect.hasAssertions();
+
+    await insertTxOutput(mysql, {
+      tx_id: 'T1',
+      index: 0,
+      mode: ShieldedOutputMode.AmountShielded,
+      address: 'WT4nB',
+      value: null,
+      token_id: '00',
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: RecoveryState.Unowned,
+    });
+
+    const row = await getTxOutput(mysql, 'T1', 0, false);
+    expect(row).not.toBeNull();
+    expect(row!.mode).toBe(1);
+    expect(row!.value).toBeNull();
+    expect(row!.tokenId).toBe('00');
+    expect(row!.recoveryState).toBe('unowned');
+  });
+
+  test('writes an unrecovered FullyShielded row with both value and token_id NULL', async () => {
+    expect.hasAssertions();
+
+    await insertTxOutput(mysql, {
+      tx_id: 'T2',
+      index: 0,
+      mode: ShieldedOutputMode.FullyShielded,
+      address: 'WT4nC',
+      value: null,
+      token_id: null,
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: RecoveryState.Unowned,
+    });
+
+    const row = await getTxOutput(mysql, 'T2', 0, false);
+    expect(row).not.toBeNull();
+    expect(row!.mode).toBe(2);
+    expect(row!.value).toBeNull();
+    expect(row!.tokenId).toBeNull();
+    expect(row!.recoveryState).toBe('unowned');
+  });
+});

--- a/packages/daemon/__tests__/db/markTxOutputRecovered.test.ts
+++ b/packages/daemon/__tests__/db/markTxOutputRecovered.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Connection } from 'mysql2/promise';
+import {
+  getDbConnection,
+  getTxOutput,
+  insertTxOutput,
+  markTxOutputRecovered,
+  markTxOutputRecoveryFailed,
+} from '../../src/db';
+import { cleanDatabase } from '../utils';
+import { ShieldedOutputMode, RecoveryState } from '@wallet-service/common';
+
+let mysql: Connection;
+
+beforeAll(async () => {
+  try {
+    mysql = await getDbConnection();
+  } catch (e) {
+    console.error('Failed to establish db connection', e);
+    throw e;
+  }
+});
+
+afterAll(() => {
+  mysql.destroy();
+});
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+  await mysql.query('DELETE FROM shielded_tx_output_data');
+});
+
+describe('markTxOutputRecovered / markTxOutputRecoveryFailed', () => {
+  test('markTxOutputRecovered promotes an unowned row to recovered with the decrypted value', async () => {
+    expect.hasAssertions();
+
+    await insertTxOutput(mysql, {
+      tx_id: 'T1',
+      index: 0,
+      mode: ShieldedOutputMode.AmountShielded,
+      address: 'WT4nB',
+      value: null,
+      token_id: '00',
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: RecoveryState.Unowned,
+    });
+
+    const result = await markTxOutputRecovered(mysql, 'T1', 0, {
+      value: 150n,
+      token_id: '00',
+    });
+    expect(result.affectedRows).toBe(1);
+
+    const row = await getTxOutput(mysql, 'T1', 0, false);
+    expect(row).not.toBeNull();
+    expect(row!.value).toBe(150n);
+    expect(row!.recoveryState).toBe('recovered');
+  });
+
+  test('markTxOutputRecovered is idempotent — second call is a no-op and does not overwrite', async () => {
+    expect.hasAssertions();
+
+    await insertTxOutput(mysql, {
+      tx_id: 'T1',
+      index: 0,
+      mode: ShieldedOutputMode.AmountShielded,
+      address: 'WT4nB',
+      value: null,
+      token_id: '00',
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: RecoveryState.Unowned,
+    });
+
+    const first = await markTxOutputRecovered(mysql, 'T1', 0, {
+      value: 150n,
+      token_id: '00',
+    });
+    expect(first.affectedRows).toBe(1);
+
+    const second = await markTxOutputRecovered(mysql, 'T1', 0, {
+      value: 999n,
+      token_id: '00',
+    });
+    expect(second.affectedRows).toBe(0);
+
+    const row = await getTxOutput(mysql, 'T1', 0, false);
+    expect(row).not.toBeNull();
+    expect(row!.value).toBe(150n);
+    expect(row!.recoveryState).toBe('recovered');
+  });
+
+  test('markTxOutputRecoveryFailed flips recovery_state to recovery_failed and leaves value null', async () => {
+    expect.hasAssertions();
+
+    await insertTxOutput(mysql, {
+      tx_id: 'T2',
+      index: 0,
+      mode: ShieldedOutputMode.AmountShielded,
+      address: 'WT4nB',
+      value: null,
+      token_id: '00',
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: RecoveryState.Unowned,
+    });
+
+    await markTxOutputRecoveryFailed(mysql, 'T2', 0);
+
+    const row = await getTxOutput(mysql, 'T2', 0, false);
+    expect(row).not.toBeNull();
+    expect(row!.value).toBeNull();
+    expect(row!.recoveryState).toBe('recovery_failed');
+  });
+});

--- a/packages/daemon/__tests__/db/updateTxOutputSpentBy-shielded.test.ts
+++ b/packages/daemon/__tests__/db/updateTxOutputSpentBy-shielded.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Connection } from 'mysql2/promise';
+import {
+  getDbConnection,
+  getTxOutput,
+  insertTxOutput,
+  updateTxOutputSpentBy,
+} from '../../src/db';
+import { TxInput } from '@wallet-service/common/src/types';
+import { cleanDatabase } from '../utils';
+import { ShieldedOutputMode, RecoveryState } from '@wallet-service/common';
+
+let mysql: Connection;
+
+beforeAll(async () => {
+  try {
+    mysql = await getDbConnection();
+  } catch (e) {
+    console.error('Failed to establish db connection', e);
+    throw e;
+  }
+});
+
+afterAll(() => {
+  mysql.destroy();
+});
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+  await mysql.query('DELETE FROM shielded_tx_output_data');
+});
+
+const buildInput = (txId: string, index: number): TxInput => ({
+  value: 0n,
+  token_data: 0,
+  script: '',
+  decoded: null,
+  token: '00',
+  tx_id: txId,
+  index,
+});
+
+describe('updateTxOutputSpentBy is kind-agnostic', () => {
+  test('marks a transparent (mode=0) row as spent', async () => {
+    expect.hasAssertions();
+
+    const prevTxId = 'PREV_TRANSPARENT';
+    const consumingTxId = 'CONSUMER_TX_T';
+
+    await insertTxOutput(mysql, {
+      tx_id: prevTxId,
+      index: 0,
+      mode: ShieldedOutputMode.Transparent,
+      address: 'WT4nB',
+      value: 100n,
+      token_id: '00',
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: null,
+    });
+
+    await updateTxOutputSpentBy(mysql, [buildInput(prevTxId, 0)], consumingTxId);
+
+    const row = await getTxOutput(mysql, prevTxId, 0, false);
+    expect(row).not.toBeNull();
+    expect(row!.spentBy).toBe(consumingTxId);
+    expect(row!.mode).toBe(ShieldedOutputMode.Transparent);
+    expect(row!.recoveryState).toBeNull();
+  });
+
+  test('marks a shielded recovered (mode=1) row as spent', async () => {
+    expect.hasAssertions();
+
+    const prevTxId = 'PREV_SHIELDED_RECOVERED';
+    const consumingTxId = 'CONSUMER_TX_S1';
+
+    await insertTxOutput(mysql, {
+      tx_id: prevTxId,
+      index: 0,
+      mode: ShieldedOutputMode.AmountShielded,
+      address: 'WT4nB',
+      value: 150n,
+      token_id: '00',
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: RecoveryState.Recovered,
+    });
+
+    await updateTxOutputSpentBy(mysql, [buildInput(prevTxId, 0)], consumingTxId);
+
+    const row = await getTxOutput(mysql, prevTxId, 0, false);
+    expect(row).not.toBeNull();
+    expect(row!.spentBy).toBe(consumingTxId);
+    expect(row!.mode).toBe(ShieldedOutputMode.AmountShielded);
+    expect(row!.recoveryState).toBe(RecoveryState.Recovered);
+    expect(row!.value).toBe(150n);
+  });
+
+  test('marks a shielded unowned (mode=1) row as spent regardless of recovery state', async () => {
+    expect.hasAssertions();
+
+    const prevTxId = 'PREV_SHIELDED_UNOWNED';
+    const consumingTxId = 'CONSUMER_TX_S2';
+
+    await insertTxOutput(mysql, {
+      tx_id: prevTxId,
+      index: 0,
+      mode: ShieldedOutputMode.AmountShielded,
+      address: 'WT4nB',
+      value: null,
+      token_id: null,
+      authorities: 0,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      voided: false,
+      recovery_state: RecoveryState.Unowned,
+    });
+
+    await updateTxOutputSpentBy(mysql, [buildInput(prevTxId, 0)], consumingTxId);
+
+    const row = await getTxOutput(mysql, prevTxId, 0, false);
+    expect(row).not.toBeNull();
+    expect(row!.spentBy).toBe(consumingTxId);
+    expect(row!.mode).toBe(ShieldedOutputMode.AmountShielded);
+    expect(row!.recoveryState).toBe(RecoveryState.Unowned);
+    expect(row!.value).toBeNull();
+  });
+});

--- a/packages/daemon/__tests__/db/upsertShieldedAddressObservation.test.ts
+++ b/packages/daemon/__tests__/db/upsertShieldedAddressObservation.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Connection } from 'mysql2/promise';
+import {
+  getDbConnection,
+  upsertShieldedAddressObservation,
+} from '../../src/db';
+import { cleanDatabase } from '../utils';
+
+let mysql: Connection;
+
+beforeAll(async () => {
+  try {
+    mysql = await getDbConnection();
+  } catch (e) {
+    console.error('Failed to establish db connection', e);
+    throw e;
+  }
+});
+
+afterAll(() => {
+  mysql.destroy();
+});
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+});
+
+interface AddressRow {
+  address: string;
+  wallet_id: string | null;
+  index: number | null;
+  bip32_account: number | null;
+  ct_address: string | null;
+  scan_privkey: Buffer | null;
+  catchup_state: 'pending' | 'running' | 'done' | null;
+  transactions: number;
+}
+
+describe('upsertShieldedAddressObservation', () => {
+  test('first observation inserts a unified address row with NULL bip32_account and transactions=0', async () => {
+    expect.hasAssertions();
+
+    await upsertShieldedAddressObservation(mysql, 'WT4nNEW');
+
+    const [rows] = await mysql.execute(
+      'SELECT * FROM address WHERE address = ?',
+      ['WT4nNEW'],
+    );
+    const result = rows as AddressRow[];
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.address).toBe('WT4nNEW');
+    // Observation leaves bip32_account NULL — the derivation account is
+    // unknown until a wallet registration claims the address.
+    expect(row.bip32_account).toBeNull();
+    expect(row.wallet_id).toBeNull();
+    expect(row.index).toBeNull();
+    expect(row.ct_address).toBeNull();
+    expect(row.scan_privkey).toBeNull();
+    expect(row.catchup_state).toBeNull();
+    // Observation no longer bumps transactions; the single canonical
+    // `transactions` bump per (address, tx) lives in
+    // `updateAddressTablesWithTx`, which only sees addresses that appear in
+    // the vertex's balance map.
+    expect(row.transactions).toBe(0);
+  });
+
+  test('second observation preserves ownership fields and does not bump transactions', async () => {
+    expect.hasAssertions();
+
+    await upsertShieldedAddressObservation(mysql, 'WT4nEXIST');
+
+    // Simulate a wallet registration claiming this row: sets wallet_id,
+    // derivation slot (bip32_account = 2 = CTSpend), index, and scan key.
+    const scanPrivkey = Buffer.alloc(32, 0x42);
+    await mysql.query(
+      `UPDATE address
+         SET wallet_id = ?, bip32_account = ?, scan_privkey = ?, \`index\` = ?
+       WHERE address = ?`,
+      ['wallet_alice', 2, scanPrivkey, 7, 'WT4nEXIST'],
+    );
+
+    await upsertShieldedAddressObservation(mysql, 'WT4nEXIST');
+
+    const [rows] = await mysql.execute(
+      'SELECT * FROM address WHERE address = ?',
+      ['WT4nEXIST'],
+    );
+    const result = rows as AddressRow[];
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    // Observation never bumps transactions; the row stays at 0 until
+    // `updateAddressTablesWithTx` increments it for vertices the address
+    // actually participates in. The claim's bip32_account / wallet_id /
+    // index / scan_privkey are untouched.
+    expect(row.transactions).toBe(0);
+    expect(row.bip32_account).toBe(2);
+    expect(row.wallet_id).toBe('wallet_alice');
+    expect(row.index).toBe(7);
+    expect(row.scan_privkey).not.toBeNull();
+    expect(row.scan_privkey!.equals(scanPrivkey)).toBe(true);
+  });
+});

--- a/packages/daemon/__tests__/mocks/ct-crypto-node.test.ts
+++ b/packages/daemon/__tests__/mocks/ct-crypto-node.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Replace the ctRewind wrapper with the deterministic mock for this test file.
+jest.mock('../../src/crypto/ctRewind', () => require('./ct-crypto-node').mockCtCrypto);
+
+import { resetCtCryptoMock, primeAmountRewind, primeFullyRewind } from './ct-crypto-node';
+import { rewindAmount, rewindFully } from '../../src/crypto/ctRewind';
+
+describe('ctRewind mock', () => {
+  beforeEach(() => resetCtCryptoMock());
+
+  it('primeAmountRewind makes rewindAmount return the primed value', () => {
+    const commitment = Buffer.alloc(33, 0xaa);
+    const ephem = Buffer.alloc(33, 0xbb);
+    const tokenUid = Buffer.alloc(32, 0xcc);
+    primeAmountRewind({ commitment, ephemeralPubkey: ephem, value: 1500n, tokenUid });
+
+    const r = rewindAmount({
+      scanPrivkey: Buffer.alloc(32),
+      ephemeralPubkey: ephem,
+      commitment,
+      rangeProof: Buffer.alloc(64),
+      tokenUid,
+    });
+    expect(r.value).toBe(1500n);
+  });
+
+  it('rewindAmount throws when no priming exists', () => {
+    expect(() =>
+      rewindAmount({
+        scanPrivkey: Buffer.alloc(32),
+        ephemeralPubkey: Buffer.alloc(33),
+        commitment: Buffer.alloc(33),
+        rangeProof: Buffer.alloc(64),
+        tokenUid: Buffer.alloc(32),
+      }),
+    ).toThrow();
+  });
+
+  it('primeFullyRewind makes rewindFully return the primed value and token uid', () => {
+    const commitment = Buffer.alloc(33, 0xdd);
+    const ephem = Buffer.alloc(33, 0xee);
+    const tokenUid = Buffer.from('aa'.repeat(32), 'hex');
+    primeFullyRewind({
+      commitment,
+      ephemeralPubkey: ephem,
+      value: 75n,
+      tokenUid,
+      assetCommitment: Buffer.alloc(33),
+    });
+
+    const r = rewindFully({
+      scanPrivkey: Buffer.alloc(32),
+      ephemeralPubkey: ephem,
+      commitment,
+      rangeProof: Buffer.alloc(64),
+      assetCommitment: Buffer.alloc(33),
+    });
+    expect(r.value).toBe(75n);
+    expect(r.tokenUid).toBe(tokenUid.toString('hex'));
+  });
+});

--- a/packages/daemon/__tests__/mocks/ct-crypto-node.ts
+++ b/packages/daemon/__tests__/mocks/ct-crypto-node.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Deterministic mock for the ctRewind wrapper used by integration tests.
+ *
+ * Calls to rewindAmount / rewindFully look up a priming map keyed by
+ * (commitment, ephemeralPubkey). Tests prime the map before exercising the
+ * daemon; unprimed calls throw.
+ *
+ * Tests that want this mock active should call:
+ *   jest.mock('../../src/crypto/ctRewind', () => require('<path>/ct-crypto-node').mockCtCrypto);
+ *
+ * The mock is NOT installed globally (no moduleNameMapper) — unit tests that
+ * need the real stub remain unaffected.
+ */
+
+interface AmountPriming {
+  commitment: Buffer;
+  ephemeralPubkey: Buffer;
+  value: bigint;
+  tokenUid: Buffer;
+}
+interface FullyPriming extends AmountPriming {
+  assetCommitment: Buffer;
+}
+
+const amountMap = new Map<string, AmountPriming>();
+const fullyMap = new Map<string, FullyPriming>();
+
+function key(commitment: Buffer, ephem: Buffer): string {
+  return commitment.toString('hex') + ':' + ephem.toString('hex');
+}
+
+export function resetCtCryptoMock(): void {
+  amountMap.clear();
+  fullyMap.clear();
+}
+
+export function primeAmountRewind(p: AmountPriming): void {
+  amountMap.set(key(p.commitment, p.ephemeralPubkey), p);
+}
+
+export function primeFullyRewind(p: FullyPriming): void {
+  fullyMap.set(key(p.commitment, p.ephemeralPubkey), p);
+}
+
+// The mock surface that stands in for ../../src/crypto/ctRewind.
+export const mockCtCrypto = {
+  rewindAmount(args: { ephemeralPubkey: Buffer; commitment: Buffer; [k: string]: unknown }) {
+    const p = amountMap.get(key(args.commitment, args.ephemeralPubkey));
+    if (!p) {
+      throw new Error('mock: no AmountShielded priming for (commitment, ephemeralPubkey)');
+    }
+    return {
+      value: p.value,
+      blindingFactor: Buffer.alloc(32),
+    };
+  },
+
+  rewindFully(args: { ephemeralPubkey: Buffer; commitment: Buffer; [k: string]: unknown }) {
+    const p = fullyMap.get(key(args.commitment, args.ephemeralPubkey));
+    if (!p) {
+      throw new Error('mock: no FullyShielded priming for (commitment, ephemeralPubkey)');
+    }
+    return {
+      value: p.value,
+      blindingFactor: Buffer.alloc(32),
+      tokenUid: p.tokenUid.toString('hex'),
+      assetBlindingFactor: Buffer.alloc(32),
+    };
+  },
+};

--- a/packages/daemon/__tests__/services/applyTokenSupplyUpdates.test.ts
+++ b/packages/daemon/__tests__/services/applyTokenSupplyUpdates.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pure-arithmetic unit tests for applyTokenSupplyUpdates. The DB writer
+ * (incrementTokenTotalSupply) is mocked, so these tests assert only the
+ * mint/melt/block-reward delta computation with no DB interaction.
+ */
+
+import hathorLib from '@hathor/wallet-lib';
+import { TxInput, TxOutputWithIndex } from '@wallet-service/common';
+
+jest.mock('../../src/db');
+
+// eslint-disable-next-line import/first
+import { applyTokenSupplyUpdates } from '../../src/services';
+// eslint-disable-next-line import/first
+import { incrementTokenTotalSupply } from '../../src/db';
+
+const mockIncrement = incrementTokenTotalSupply as jest.Mock;
+
+const TX_VERSION = 1; // any non-block version
+const BLOCK_VERSION = hathorLib.constants.BLOCK_VERSION;
+
+const output = (token: string, value: bigint, address = 'H1'): TxOutputWithIndex => ({
+  value,
+  token,
+  token_data: 0,
+  script: '',
+  spent_by: null,
+  index: 0,
+  decoded: { type: 'P2PKH', address, timelock: null },
+}) as unknown as TxOutputWithIndex;
+
+const input = (token: string, value: bigint): TxInput => ({
+  tx_id: 't',
+  index: 0,
+  value,
+  token,
+  token_data: 0,
+  script: '',
+  decoded: null,
+}) as unknown as TxInput;
+
+const mysql = {} as any;
+
+beforeEach(() => {
+  mockIncrement.mockClear();
+});
+
+describe('applyTokenSupplyUpdates', () => {
+  it('applies one signed delta per token for a multi-token tx', async () => {
+    // token A: 100 out - 0 in = +100; token B: 50 out - 20 in = +30.
+    await applyTokenSupplyUpdates(
+      mysql,
+      TX_VERSION,
+      [output('A', 100n), output('B', 50n)],
+      [input('B', 20n)],
+      0,
+    );
+
+    expect(mockIncrement).toHaveBeenCalledTimes(2);
+    expect(mockIncrement).toHaveBeenCalledWith(mysql, 'A', 100n);
+    expect(mockIncrement).toHaveBeenCalledWith(mysql, 'B', 30n);
+  });
+
+  it('does not write when the per-token delta is zero', async () => {
+    await applyTokenSupplyUpdates(
+      mysql,
+      TX_VERSION,
+      [output('A', 100n)],
+      [input('A', 100n)],
+      0,
+    );
+
+    expect(mockIncrement).not.toHaveBeenCalled();
+  });
+
+  it('does not write a block whose summed reward is zero', async () => {
+    await applyTokenSupplyUpdates(
+      mysql,
+      BLOCK_VERSION,
+      [output(hathorLib.constants.NATIVE_TOKEN_UID, 0n)],
+      [],
+      0,
+    );
+
+    expect(mockIncrement).not.toHaveBeenCalled();
+  });
+});

--- a/packages/daemon/__tests__/services/newTxRealtime.test.ts
+++ b/packages/daemon/__tests__/services/newTxRealtime.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Owned-wallet ingest triggers wallet-lib's gap-fill/address-derivation path,
+// which is slow against a real xpubkey; bump the timeout to match the other
+// DB-backed shielded suites.
+jest.setTimeout(30000);
+
+jest.mock('../../src/crypto/ctRewind', () => require('../mocks/ct-crypto-node').mockCtCrypto);
+
+const mockAddAlert = jest.fn();
+jest.mock('@wallet-service/common', () => {
+  const actual = jest.requireActual('@wallet-service/common');
+  return { ...actual, addAlert: mockAddAlert };
+});
+
+// Partial-mock the aws module so the outbound SQS / lambda calls are stubbed
+// while every other util (used heavily by handleVertexAccepted) stays real.
+jest.mock('../../src/utils/aws', () => {
+  const actual = jest.requireActual('../../src/utils/aws');
+  return {
+    ...actual,
+    sendRealtimeTx: jest.fn(),
+    invokeOnTxPushNotificationRequestedLambda: jest.fn(),
+  };
+});
+
+import * as db from '../../src/db';
+import { handleVertexAccepted } from '../../src/services';
+import { LRU, getWalletBalancesForTx, sortBalanceValueByAbsTotal } from '../../src/utils';
+import { sendRealtimeTx } from '../../src/utils/aws';
+import { cleanDatabase, XPUBKEY } from '../utils';
+import { TokenBalanceMap } from '@wallet-service/common';
+import { Connection } from 'mysql2/promise';
+import eventsFixture from '../__fixtures__/events';
+
+/**
+ * @jest-environment node
+ */
+
+let mysql: Connection;
+
+beforeAll(async () => {
+  mysql = await db.getDbConnection();
+});
+
+afterAll(async () => {
+  if (mysql) await mysql.destroy();
+});
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+  await mysql.query('DELETE FROM shielded_tx_output_data');
+  jest.clearAllMocks();
+});
+
+afterEach(async () => {
+  await mysql.query('DELETE FROM shielded_tx_output_data');
+});
+
+describe('handleVertexAccepted realtime new-tx payload', () => {
+  it('enqueues the involved addresses and a lightweight shielded_outputs projection', async () => {
+    expect.hasAssertions();
+
+    // VERTEX_WITH_SHIELDED carries a transparent output to WTransparentAddress1
+    // and a shielded output to WShieldedAddress1. Own the transparent address
+    // so the wallet is "seen" and sendRealtimeTx fires; the shielded output
+    // stays unowned (no rewind needed) but its address still rides in the
+    // involved-address set.
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WTransparentAddress1', 'wallet_alice', 0, 0, 0)`,
+    );
+
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    expect(sendRealtimeTx).toHaveBeenCalledTimes(1);
+    const [wallets, tx] = (sendRealtimeTx as jest.Mock).mock.calls[0];
+
+    expect(wallets).toEqual(['wallet_alice']);
+
+    // addresses: the full involved set (transparent + shielded), as an array.
+    expect(Array.isArray(tx.addresses)).toBe(true);
+    expect(tx.addresses).toEqual(
+      expect.arrayContaining(['WTransparentAddress1', 'WShieldedAddress1']),
+    );
+
+    // shielded_outputs: lightweight projection only — mode, token_data, decoded
+    // address; NO crypto blobs (commitment / range_proof / ephemeral_pubkey).
+    expect(tx.shielded_outputs).toEqual([
+      { mode: 1, token_data: 1, decoded: { address: 'WShieldedAddress1' } },
+    ]);
+    expect(tx.shielded_outputs[0]).not.toHaveProperty('commitment');
+    expect(tx.shielded_outputs[0]).not.toHaveProperty('range_proof');
+    expect(tx.shielded_outputs[0]).not.toHaveProperty('ephemeral_pubkey');
+  });
+
+  it('projects a FullyShielded (mode 2) output without token_data and rides its address', async () => {
+    expect.hasAssertions();
+
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WTransparentAddress1', 'wallet_alice', 0, 0, 0)`,
+    );
+
+    // Append a FullyShielded (mode 2) output to the mode-1 fixture. Mode 2 carries
+    // no token_data, so the projection must omit that field for this entry while
+    // still surfacing decoded.address and adding it to the involved-address set.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs.push({
+      mode: 2,
+      commitment: '0a'.repeat(33),
+      range_proof: '0b'.repeat(64),
+      script: '0c'.repeat(20),
+      ephemeral_pubkey: '0d'.repeat(33),
+      asset_commitment: '0e'.repeat(33),
+      surjection_proof: '0f'.repeat(64),
+      decoded: { address: 'WShieldedAddress2' },
+    });
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    expect(sendRealtimeTx).toHaveBeenCalledTimes(1);
+    const [, tx] = (sendRealtimeTx as jest.Mock).mock.calls[0];
+
+    // The mode-2 entry surfaces decoded.address with NO token_data; the mode-1
+    // entry keeps token_data.
+    expect(tx.shielded_outputs).toEqual([
+      { mode: 1, token_data: 1, decoded: { address: 'WShieldedAddress1' } },
+      { mode: 2, decoded: { address: 'WShieldedAddress2' } },
+    ]);
+    expect(tx.shielded_outputs[1]).not.toHaveProperty('token_data');
+
+    // the mode-2 address rides in the involved-address set
+    expect(tx.addresses).toEqual(
+      expect.arrayContaining(['WShieldedAddress2']),
+    );
+  });
+});
+
+describe('getWalletBalancesForTx shielded amounts (push payload)', () => {
+  it('carries the recovered shielded receive amount as shieldedAmount', async () => {
+    expect.hasAssertions();
+
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WCTSpend1', 'wallet_alice', 7, 2, 0)`,
+    );
+    await mysql.query(
+      `INSERT INTO token (id, name, symbol, total_supply) VALUES ('00', 'Hathor', 'HTR', 0)`,
+    );
+
+    // Unified balance map for the vertex: a recovered shielded HTR receive of
+    // 150 for the owned address (transparent columns stay zero).
+    const addressBalanceMap = {
+      WCTSpend1: TokenBalanceMap.fromShielded('00', 150n, false),
+    };
+    const tx = { tx_id: 'tx-shielded-push' } as any;
+
+    const result = await getWalletBalancesForTx(mysql, tx, addressBalanceMap);
+
+    expect(result.wallet_alice).toBeDefined();
+    const tokenBalance = result.wallet_alice.walletBalanceForTx[0];
+    expect(tokenBalance.tokenId).toBe('00');
+    // transparent total stays zero; the shielded receive rides in shieldedAmount.
+    expect(tokenBalance.total).toBe(0n);
+    expect(tokenBalance.shieldedAmount).toBe(150n);
+  });
+
+  it('reports shieldedAmount = 0 for a shielded spend (never negative)', async () => {
+    expect.hasAssertions();
+
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WCTSpend1', 'wallet_alice', 7, 2, 0)`,
+    );
+    await mysql.query(
+      `INSERT INTO token (id, name, symbol, total_supply) VALUES ('00', 'Hathor', 'HTR', 0)`,
+    );
+
+    // A shielded SPEND contributes a negative shielded delta; the gross-received
+    // accumulator (shieldedAmount) must stay 0, not go negative.
+    const addressBalanceMap = {
+      WCTSpend1: TokenBalanceMap.fromShielded('00', -150n, false),
+    };
+    const tx = { tx_id: 'tx-shielded-spend' } as any;
+
+    const result = await getWalletBalancesForTx(mysql, tx, addressBalanceMap);
+
+    const tokenBalance = result.wallet_alice.walletBalanceForTx[0];
+    expect(tokenBalance.total).toBe(0n);
+    expect(tokenBalance.shieldedAmount).toBe(0n);
+  });
+
+  it('reports gross received (not net) when the same token is both received and spent', async () => {
+    expect.hasAssertions();
+
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WCTSpend1', 'wallet_alice', 7, 2, 0)`,
+    );
+    await mysql.query(
+      `INSERT INTO token (id, name, symbol, total_supply) VALUES ('00', 'Hathor', 'HTR', 0)`,
+    );
+
+    // Same token, same tx: a shielded receive of 100 and a shielded spend of 300.
+    // The net shielded delta is -200, but shieldedAmount tracks GROSS received,
+    // so it must report 100 (not the -200 net, nor 0).
+    const addressBalanceMap = {
+      WCTSpend1: TokenBalanceMap.merge(
+        TokenBalanceMap.fromShielded('00', 100n, false),
+        TokenBalanceMap.fromShielded('00', -300n, false),
+      ),
+    };
+    const tx = { tx_id: 'tx-shielded-mixed' } as any;
+
+    const result = await getWalletBalancesForTx(mysql, tx, addressBalanceMap);
+
+    const tokenBalance = result.wallet_alice.walletBalanceForTx[0];
+    expect(tokenBalance.total).toBe(0n);
+    expect(tokenBalance.shieldedAmount).toBe(100n);
+  });
+});
+
+describe('sortBalanceValueByAbsTotal shielded-aware ordering', () => {
+  it('ranks a shielded receive ahead of a smaller transparent movement', () => {
+    expect.hasAssertions();
+
+    const transparent = { tokenId: 'T', total: 10n, shieldedAmount: 0n } as any;
+    const shielded = { tokenId: 'S', total: 0n, shieldedAmount: 500n } as any;
+
+    // Pre-shielded-aware sort keyed on abs(total) alone would leave the shielded
+    // entry (total 0) last; the combined-magnitude key must rank it first.
+    expect([transparent, shielded].sort(sortBalanceValueByAbsTotal)[0].tokenId).toBe('S');
+    expect([shielded, transparent].sort(sortBalanceValueByAbsTotal)[0].tokenId).toBe('S');
+  });
+
+  it('treats equal combined magnitude as a tie (returns 0, preserves order)', () => {
+    expect.hasAssertions();
+
+    // Both have combined magnitude 150: one all-transparent, one transparent +
+    // shielded. Equal magnitude must compare as 0 so the comparator honours the
+    // sort contract (the old `>= 0n` form wrongly returned -1 on ties).
+    const a = { tokenId: 'A', total: 150n, shieldedAmount: 0n } as any;
+    const b = { tokenId: 'B', total: 100n, shieldedAmount: 50n } as any;
+
+    expect(sortBalanceValueByAbsTotal(a, b)).toBe(0);
+    expect([a, b].sort(sortBalanceValueByAbsTotal).map((x) => x.tokenId)).toEqual(['A', 'B']);
+    expect([b, a].sort(sortBalanceValueByAbsTotal).map((x) => x.tokenId)).toEqual(['B', 'A']);
+  });
+});

--- a/packages/daemon/__tests__/services/services.test.ts
+++ b/packages/daemon/__tests__/services/services.test.ts
@@ -43,6 +43,8 @@ import {
 import logger from '../../src/logger';
 import {
   getAddressBalanceMap,
+  getInvolvedAddresses,
+  getUnifiedBalanceMap,
   prepareInputs,
   prepareOutputs,
   hashTxData,
@@ -94,6 +96,8 @@ jest.mock('../../src/db', () => ({
   updateTxOutputSpentBy: jest.fn(),
   incrementTokensTxCount: jest.fn(),
   updateAddressTablesWithTx: jest.fn(),
+  bumpAddressInvolvement: jest.fn(),
+  decrementAddressInvolvement: jest.fn(),
   getAddressWalletInfo: jest.fn(),
   generateAddresses: jest.fn(),
   addNewAddresses: jest.fn(),
@@ -104,12 +108,15 @@ jest.mock('../../src/db', () => ({
   getTokensCreatedByTx: jest.fn(() => []),
   deleteTokens: jest.fn(),
   insertTokenCreation: jest.fn(),
+  findShieldedAddressOwnershipBatch: jest.fn().mockResolvedValue(new Map()),
 }));
 
 jest.mock('../../src/utils', () => ({
   prepareOutputs: jest.fn(),
   prepareInputs: jest.fn(),
   getAddressBalanceMap: jest.fn(),
+  getInvolvedAddresses: jest.fn(() => new Set<string>()),
+  getUnifiedBalanceMap: jest.fn().mockResolvedValue({}),
   validateAddressBalances: jest.fn(),
   LRU: jest.fn(),
   unlockTimelockedUtxos: jest.fn(),
@@ -129,6 +136,11 @@ jest.mock('../../src/utils', () => ({
 
 jest.mock('@wallet-service/common', () => {
   const addAlertMock = jest.fn();
+  const ShieldedOutputMode = {
+    Transparent: 0,
+    AmountShielded: 1,
+    FullyShielded: 2,
+  };
   return {
     addAlert: addAlertMock,
     Severity: {
@@ -142,6 +154,15 @@ jest.mock('@wallet-service/common', () => {
       invokeNftHandlerLambda: jest.fn(),
       processNftEvent: jest.fn().mockReturnValue(Promise.resolve()),
     },
+    ShieldedOutputMode,
+    RecoveryState: {
+      Unowned: 'unowned',
+      Recovered: 'recovered',
+      RecoveryFailed: 'recovery_failed',
+    },
+    isShieldedMode: (mode: number) =>
+      mode === ShieldedOutputMode.AmountShielded
+        || mode === ShieldedOutputMode.FullyShielded,
   };
 });
 
@@ -679,6 +700,9 @@ describe('handleVertexAccepted', () => {
     (prepareOutputs as jest.Mock).mockReturnValue([]);
     (prepareInputs as jest.Mock).mockReturnValue([]);
     (getAddressBalanceMap as jest.Mock).mockReturnValue({});
+    // Non-empty involvement so the per-token / wallet branch executes.
+    (getInvolvedAddresses as jest.Mock).mockReturnValue(new Set(['address1']));
+    (getUnifiedBalanceMap as jest.Mock).mockResolvedValue({});
     (getUtxosLockedAtHeight as jest.Mock).mockResolvedValue([]);
     (hashTxData as jest.Mock).mockReturnValue('hashedData');
     (getAddressWalletInfo as jest.Mock).mockResolvedValue({

--- a/packages/daemon/__tests__/services/services_with_db.test.ts
+++ b/packages/daemon/__tests__/services/services_with_db.test.ts
@@ -544,9 +544,9 @@ describe('unspentTxOutputs function', () => {
 
     // Now unspent them
     const txOutputsToUnspent: DbTxOutput[] = [
-      { txId: txIdA, index: 0, tokenId, address, value: 50n, authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: spendingTx, txProposalId: null, txProposalIndex: null },
-      { txId: txIdB, index: 0, tokenId, address, value: 75n, authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: spendingTx, txProposalId: null, txProposalIndex: null },
-      { txId: txIdC, index: 0, tokenId, address, value: 100n, authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: spendingTx, txProposalId: null, txProposalIndex: null },
+      { txId: txIdA, index: 0, tokenId, address, value: 50n, authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: spendingTx, txProposalId: null, txProposalIndex: null, mode: 0, recoveryState: null },
+      { txId: txIdB, index: 0, tokenId, address, value: 75n, authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: spendingTx, txProposalId: null, txProposalIndex: null, mode: 0, recoveryState: null },
+      { txId: txIdC, index: 0, tokenId, address, value: 100n, authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: spendingTx, txProposalId: null, txProposalIndex: null, mode: 0, recoveryState: null },
     ];
 
     await unspendUtxos(mysql, txOutputsToUnspent);

--- a/packages/daemon/__tests__/services/services_with_db.test.ts
+++ b/packages/daemon/__tests__/services/services_with_db.test.ts
@@ -5,9 +5,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Owned-wallet shielded tests trigger wallet-lib's gap-fill / address-derivation
+// path inside handleVertexAccepted (the wallet seed uses a real xpubkey, so each
+// ownership check derives a window of addresses, ~7-8s per test). Jest's default
+// 5000ms timeout fails these in CI; bump to 30s to give headroom. Follow-up: skip
+// gap-fill in these tests by pre-seeding addresses or mocking the derivation.
+jest.setTimeout(30000);
+
+// Redirect the ct-crypto NAPI binding to the deterministic mock for ALL tests
+// in this file. The shielded recovery tests prime the mock; everything else
+// never touches it, so existing tests are unaffected.
+jest.mock('../../src/crypto/ctRewind', () => require('../mocks/ct-crypto-node').mockCtCrypto);
+
+// Stub addAlert so the recovery-failed path doesn't reach SQS; keep the rest
+// of @wallet-service/common live by spreading the real module.
+const mockAddAlert = jest.fn();
+jest.mock('@wallet-service/common', () => {
+  const actual = jest.requireActual('@wallet-service/common');
+  return {
+    ...actual,
+    addAlert: mockAddAlert,
+  };
+});
+
 import { TokenVersion } from '@hathor/wallet-lib';
 import * as db from '../../src/db';
-import { handleVoidedTx, voidTx, handleTokenCreated } from '../../src/services';
+import { handleVoidedTx, voidTx, handleTokenCreated, handleVertexAccepted, handleUnvoidedTx, handleVertexRemoved } from '../../src/services';
 import { LRU } from '../../src/utils';
 import {
   addOrUpdateTx,
@@ -26,9 +49,13 @@ import {
   getWalletBalance,
   insertWalletBalance,
   getWalletTxHistoryCount,
+  XPUBKEY,
 } from '../utils';
 import { DbTxOutput, EventTxInput } from '../../src/types';
 import { Connection } from 'mysql2/promise';
+import eventsFixture from '../__fixtures__/events';
+import { primeAmountRewind, primeFullyRewind, resetCtCryptoMock } from '../mocks/ct-crypto-node';
+import { Severity } from '@wallet-service/common';
 
 /**
  * @jest-environment node
@@ -160,7 +187,7 @@ describe('voidTransaction with input unspending', () => {
       script: 'dqkUH70YjKeoKdFwMX2TOYvGVbXOrKaIrA==',
     }];
 
-    await voidTx(mysql, txIdB, inputs, outputs, [tokenId], [], 1);
+    await voidTx(mysql, txIdB, inputs, outputs, [], [tokenId], [], 1);
 
     // Check if the UTXO from transaction A is unspent again
     utxo = await getTxOutput(mysql, txIdA, 0, false);
@@ -230,7 +257,7 @@ describe('voidTransaction with input unspending', () => {
       script: 'dqkUH70YjKeoKdFwMX2TOYvGVbXOrKaIrA==',
     }];
 
-    await voidTx(mysql, txIdC, inputs, outputs, [tokenId], [], 1);
+    await voidTx(mysql, txIdC, inputs, outputs, [], [tokenId], [], 1);
 
     // Check if UTXOs from transactions A and B are unspent again
     utxoA = await getTxOutput(mysql, txIdA, 0, true);
@@ -269,7 +296,7 @@ describe('voidTransaction with input unspending', () => {
     await updateTxOutputSpentBy(mysql, [inputB], txIdB);
     const outputB = createOutput(0, 100n, address2, tokenId);
     await addUtxos(mysql, txIdB, [outputB], null);
-    
+
     // Only update address transaction counts (not balances) to prevent negative decrements
     await mysql.query('INSERT INTO address (address, transactions) VALUES (?, 1) ON DUPLICATE KEY UPDATE transactions = transactions + 1', [address1]);
     await mysql.query('INSERT INTO address (address, transactions) VALUES (?, 1) ON DUPLICATE KEY UPDATE transactions = transactions + 1', [address2]);
@@ -280,8 +307,8 @@ describe('voidTransaction with input unspending', () => {
     await updateTxOutputSpentBy(mysql, [inputC], txIdC);
     const outputC = createOutput(0, 100n, address3, tokenId);
     await addUtxos(mysql, txIdC, [outputC], null);
-    
-    // Only update address transaction counts (not balances) to prevent negative decrements  
+
+    // Only update address transaction counts (not balances) to prevent negative decrements
     await mysql.query('INSERT INTO address (address, transactions) VALUES (?, 1) ON DUPLICATE KEY UPDATE transactions = transactions + 1', [address2]);
     await mysql.query('INSERT INTO address (address, transactions) VALUES (?, 1) ON DUPLICATE KEY UPDATE transactions = transactions + 1', [address3]);
 
@@ -295,6 +322,7 @@ describe('voidTransaction with input unspending', () => {
         token_data: 0,
         script: 'dqkUH70YjKeoKdFwMX2TOYvGVbXOrKaIrA==',
       }],
+      [],
       [tokenId],
       [],
       1
@@ -315,6 +343,7 @@ describe('voidTransaction with input unspending', () => {
         token_data: 0,
         script: 'dqkUH70YjKeoKdFwMX2TOYvGVbXOrKaIrA==',
       }],
+      [],
       [tokenId],
       [],
       1
@@ -376,7 +405,7 @@ describe('voidTransaction with input unspending', () => {
       script: 'dqkUH70YjKeoKdFwMX2TOYvGVbXOrKaIrA==',
     }];
 
-    await voidTx(mysql, txIdC, inputs, outputs, [tokenId], [], 1);
+    await voidTx(mysql, txIdC, inputs, outputs, [], [tokenId], [], 1);
 
     // The UTXO should still be spent by B, not unspent
     const utxo = await getTxOutput(mysql, txIdA, 0, false);
@@ -433,7 +462,7 @@ describe('voidTransaction with input unspending', () => {
       }
     ];
 
-    await voidTx(mysql, txIdB, inputs, outputs, [hathorToken, customToken], [], 1);
+    await voidTx(mysql, txIdB, inputs, outputs, [], [hathorToken, customToken], [], 1);
 
     // Both UTXOs should be unspent
     const utxo1 = await getTxOutput(mysql, txIdA, 0, true);
@@ -486,7 +515,7 @@ describe('voidTransaction with input unspending', () => {
       script: 'dqkUH70YjKeoKdFwMX2TOYvGVbXOrKaIrA==',
     }];
 
-    await voidTx(mysql, txIdB, inputs, outputs, [tokenId], [], 1);
+    await voidTx(mysql, txIdB, inputs, outputs, [], [tokenId], [], 1);
 
     // Verify the original UTXO is unspent again
     const unspentUtxo = await getTxOutput(mysql, txIdA, 0, true);
@@ -639,7 +668,7 @@ describe('wallet balance voiding bug', () => {
       script: 'dqkUH70YjKeoKdFwMX2TOYvGVbXOrKaIrA==',
     }];
 
-    await voidTx(mysql, txIdB, inputs, outputs, [tokenId], [], 1);
+    await voidTx(mysql, txIdB, inputs, outputs, [], [tokenId], [], 1);
 
     // Check wallet balance after voiding
     walletBalance = await getWalletBalance(mysql, walletId, tokenId);
@@ -725,7 +754,7 @@ describe('wallet balance voiding bug', () => {
       script: 'dqkUH70YjKeoKdFwMX2TOYvGVbXOrKaIrA==',
     }];
 
-    await voidTx(mysql, txId, inputs, voidOutputs, [tokenId], [], 1);
+    await voidTx(mysql, txId, inputs, voidOutputs, [], [tokenId], [], 1);
 
     // Check wallet balances after voiding
     wallet1Balance = await getWalletBalance(mysql, wallet1Id, tokenId);
@@ -794,7 +823,7 @@ describe('wallet balance voiding bug', () => {
       script: 'dqkUH70YjKeoKdFwMX2TOYvGVbXOrKaIrA==',
     }];
 
-    await voidTx(mysql, txId, inputs, outputs, [tokenId], [], 1);
+    await voidTx(mysql, txId, inputs, outputs, [], [tokenId], [], 1);
 
     // Check wallet balance after voiding
     walletBalance = await getWalletBalance(mysql, walletId, tokenId);
@@ -869,7 +898,7 @@ describe('wallet balance voiding bug', () => {
       spent_by: null,
     }];
 
-    await voidTx(mysql, txIdB, inputs, outputs, [tokenId], [], 1);
+    await voidTx(mysql, txIdB, inputs, outputs, [], [tokenId], [], 1);
 
     // Check that the tx_proposal marks have been cleared
     const utxoAfterVoid = await getTxOutput(mysql, txIdA, 0, false);
@@ -936,7 +965,7 @@ describe('wallet balance voiding bug', () => {
       spent_by: null,
     }];
 
-    await voidTx(mysql, txIdB, inputs, outputs, [tokenId], [], 1);
+    await voidTx(mysql, txIdB, inputs, outputs, [], [tokenId], [], 1);
 
     // Check that tx_proposal marks have been cleared for both inputs
     const utxo1AfterVoid = await getTxOutput(mysql, txIdA, 0, false);
@@ -978,7 +1007,7 @@ describe('wallet balance voiding bug', () => {
     expect(tokens).toHaveLength(3);
 
     // Void the transaction with empty inputs/outputs/tokens
-    await voidTx(mysql, txId, [], [], [], [], 1);
+    await voidTx(mysql, txId, [], [], [], [], [], 1);
 
     // Verify all tokens created by this tx were deleted
     token1 = await db.getTokenInformation(mysql, tokenId1);
@@ -2105,5 +2134,2153 @@ describe('handleTokenCreated with TokenVersion.FEE (token_version: 2)', () => {
     );
     expect(rows).toHaveLength(1);
     expect(rows[0].first_block).toBe(newBlock);
+  });
+});
+
+describe('handleVertexAccepted with shielded outputs', () => {
+  beforeEach(async () => {
+    // `shielded_tx_output_data` is not yet part of the shared cleanDatabase
+    // TABLES list; wipe it manually to keep this test isolated from
+    // neighbouring suites. Address rows live in the unified `address` table
+    // (observations carry NULL bip32_account; CTSpend rows once claimed
+    // carry 2) and are cleaned up by cleanDatabase.
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  afterEach(async () => {
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  it('writes the shielded tx_output, satellite, and unified address observation row', async () => {
+    expect.hasAssertions();
+
+    const fixture = eventsFixture.VERTEX_WITH_SHIELDED;
+    const txHash = fixture.event.data.hash;
+    const shieldedOutput = fixture.event.data.shielded_outputs[0];
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    // The fixture has 1 transparent output and 1 shielded mode=1 output.
+    // Concatenated index of the shielded entry: 1 (after 1 transparent at idx 0).
+    const txOutput = await getTxOutput(mysql, txHash, 1, false);
+    expect(txOutput).not.toBeNull();
+    expect(txOutput!.mode).toBe(1);
+    expect(txOutput!.recoveryState).toBe('unowned');
+    expect(txOutput!.value).toBeNull();
+
+    // Verify satellite row.
+    const [satelliteRows] = await mysql.query<any[]>(
+      'SELECT * FROM `shielded_tx_output_data` WHERE `tx_id` = ? AND `index` = ?',
+      [txHash, 1],
+    );
+    expect(satelliteRows).toHaveLength(1);
+    expect(satelliteRows[0].token_data).toBe(shieldedOutput.token_data);
+
+    // Verify the shielded address observation row landed on the unified
+    // `address` table with NULL bip32_account (unclaimed; derivation account
+    // is set only when a wallet registration claims the row) and NULL
+    // wallet_id. `transactions` is bumped to 1 by the central involvement
+    // helper that runs once per vertex against the wire-level
+    // involved-addresses set, which always includes every shielded output's
+    // address regardless of ownership — observation itself still doesn't
+    // touch the counter.
+    const [shieldedAddrRows] = await mysql.query<any[]>(
+      'SELECT * FROM `address` WHERE `address` = ?',
+      [shieldedOutput.decoded.address],
+    );
+    expect(shieldedAddrRows).toHaveLength(1);
+    expect(shieldedAddrRows[0].bip32_account).toBeNull();
+    expect(shieldedAddrRows[0].wallet_id).toBeNull();
+    expect(shieldedAddrRows[0].transactions).toBe(1);
+
+    // Transparent output at concatenated index 0 is still written by the existing
+    // addUtxos path with mode=0 and recovery_state=NULL.
+    const transparentOutput = await getTxOutput(mysql, txHash, 0, false);
+    expect(transparentOutput).not.toBeNull();
+    expect(transparentOutput!.mode).toBe(0);
+    expect(transparentOutput!.recoveryState).toBeNull();
+  });
+
+  it('recovers a matched AmountShielded output via in-line rewind', async () => {
+    expect.hasAssertions();
+
+    // Clone the fixture and set token_data=0 so resolveShieldedTokenId() maps
+    // it to the native token (HTR). The default fixture uses token_data=1 with
+    // an empty `tokens[]`, which resolves to null and would force the failure
+    // path — that's the second test below.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0].token_data = 0;
+    const txHash = fixture.event.data.hash;
+    const so = fixture.event.data.shielded_outputs[0];
+
+    // Seed an owned shielded address row on the unified `address` table so
+    // findShieldedAddressOwnership picks it up after
+    // upsertShieldedAddressObservation runs. `bip32_account = 2` discriminates
+    // the shielded scan-path row from any transparent row that might share
+    // the same P2PKH address.
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [so.decoded.address, Buffer.alloc(32, 0x42)],
+    );
+
+    resetCtCryptoMock();
+    mockAddAlert.mockClear();
+    primeAmountRewind({
+      commitment: Buffer.from(so.commitment, 'hex'),
+      ephemeralPubkey: Buffer.from(so.ephemeral_pubkey, 'hex'),
+      value: 150n,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const txOutput = await getTxOutput(mysql, txHash, 1, false);
+    expect(txOutput).not.toBeNull();
+    expect(txOutput!.recoveryState).toBe('recovered');
+    expect(txOutput!.value).toBe(150n);
+    expect(txOutput!.tokenId).toBe('00');
+    expect(mockAddAlert).not.toHaveBeenCalled();
+  });
+
+  it('recovers a matched FullyShielded output, taking token_id from the rewind result', async () => {
+    expect.hasAssertions();
+
+    // FullyShielded (mode=2) is a distinct correctness fork from AmountShielded:
+    // the token uid is NOT on the wire (`token_data` is absent) — it comes back
+    // from the rewind itself (`r.tokenUid`). Swap the fixture's mode=1 output
+    // for a mode=2 one carrying asset_commitment / surjection_proof.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0] = {
+      mode: 2,
+      commitment: '02'.repeat(33),
+      range_proof: '03'.repeat(64),
+      script: '04'.repeat(20),
+      ephemeral_pubkey: '05'.repeat(33),
+      asset_commitment: '06'.repeat(33),
+      surjection_proof: '07'.repeat(64),
+      decoded: {
+        address: 'WShieldedAddress1',
+      },
+    };
+    const txHash = fixture.event.data.hash;
+    const so = fixture.event.data.shielded_outputs[0];
+
+    // Seed an owned shielded address so findShieldedAddressOwnership matches
+    // and the in-line rewind runs (bip32_account = 2 = CTSpend).
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [so.decoded.address, Buffer.alloc(32, 0x42)],
+    );
+
+    resetCtCryptoMock();
+    mockAddAlert.mockClear();
+    // Prime a distinctive custom token uid. resolveShieldedTokenId is never
+    // consulted on this path, so asserting this exact value proves the token_id
+    // was sourced from the rewind result rather than the wire.
+    const fullyTokenUid = Buffer.alloc(32, 0xab);
+    primeFullyRewind({
+      commitment: Buffer.from(so.commitment, 'hex'),
+      ephemeralPubkey: Buffer.from(so.ephemeral_pubkey, 'hex'),
+      value: 4242n,
+      tokenUid: fullyTokenUid,
+      assetCommitment: Buffer.from(so.asset_commitment, 'hex'),
+    });
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const txOutput = await getTxOutput(mysql, txHash, 1, false);
+    expect(txOutput).not.toBeNull();
+    expect(txOutput!.mode).toBe(2);
+    expect(txOutput!.recoveryState).toBe('recovered');
+    expect(txOutput!.value).toBe(4242n);
+    expect(txOutput!.tokenId).toBe('ab'.repeat(32));
+    expect(mockAddAlert).not.toHaveBeenCalled();
+  });
+
+  it('writes shielded amount columns on the unified address_balance row for recovered shielded outputs', async () => {
+    expect.hasAssertions();
+
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0].token_data = 0;
+    const so = fixture.event.data.shielded_outputs[0];
+    const shieldedAddress = so.decoded.address;
+
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [shieldedAddress, Buffer.alloc(32, 0x42)],
+    );
+
+    resetCtCryptoMock();
+    mockAddAlert.mockClear();
+    primeAmountRewind({
+      commitment: Buffer.from(so.commitment, 'hex'),
+      ephemeralPubkey: Buffer.from(so.ephemeral_pubkey, 'hex'),
+      value: 150n,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const [rows] = await mysql.query<any[]>(
+      `SELECT unlocked_balance, locked_balance, total_received,
+              unlocked_shielded_balance, locked_shielded_balance,
+              total_shielded_received, transactions
+         FROM address_balance
+        WHERE address = ? AND token_id = ?`,
+      [shieldedAddress, '00'],
+    );
+    expect(rows).toHaveLength(1);
+    expect(BigInt(rows[0].unlocked_balance)).toBe(0n);
+    expect(BigInt(rows[0].locked_balance)).toBe(0n);
+    expect(BigInt(rows[0].total_received)).toBe(0n);
+    expect(BigInt(rows[0].unlocked_shielded_balance)).toBe(150n);
+    expect(BigInt(rows[0].locked_shielded_balance)).toBe(0n);
+    expect(BigInt(rows[0].total_shielded_received)).toBe(150n);
+    expect(rows[0].transactions).toBe(1);
+
+    // The unified `address` row gets exactly ONE transactions bump from the
+    // single central path in updateAddressTablesWithTx. The observation
+    // upsert that ran earlier in handleVertexAccepted must not bump it.
+    const [addrRows] = await mysql.query<any[]>(
+      'SELECT `transactions` FROM `address` WHERE `address` = ? AND `bip32_account` = 2',
+      [shieldedAddress],
+    );
+    expect(addrRows).toHaveLength(1);
+    expect(addrRows[0].transactions).toBe(1);
+  });
+
+  it('routes timelocked shielded credits to the locked_shielded_balance column', async () => {
+    expect.hasAssertions();
+
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0].token_data = 0;
+    // Set a timelock well in the future so `isOutputLocked` deterministically
+    // returns true regardless of test wall-clock timing.
+    const futureTimelock = Math.floor(Date.now() / 1000) + 3600;
+    fixture.event.data.shielded_outputs[0].decoded.timelock = futureTimelock;
+
+    const so = fixture.event.data.shielded_outputs[0];
+    const txHash = fixture.event.data.hash;
+    const shieldedAddress = so.decoded.address;
+
+    // Seed wallet + owned shielded address so the recovery path runs and the
+    // wallet_balance credit lands. The wallet row also unblocks the central
+    // `updateWalletTablesWithTx` bump for the seeded shielded-credit entry.
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [shieldedAddress, Buffer.alloc(32, 0x42)],
+    );
+
+    resetCtCryptoMock();
+    mockAddAlert.mockClear();
+    primeAmountRewind({
+      commitment: Buffer.from(so.commitment, 'hex'),
+      ephemeralPubkey: Buffer.from(so.ephemeral_pubkey, 'hex'),
+      value: 150n,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    // The shielded `tx_output` row carries the timelock verbatim and `locked = 1`.
+    const txOutput = await getTxOutput(mysql, txHash, 1, false);
+    expect(txOutput).not.toBeNull();
+    expect(txOutput!.locked).toBe(true);
+    expect(txOutput!.timelock).toBe(futureTimelock);
+
+    // The credit lands in the locked_shielded_balance column on
+    // address_balance — the unlocked column stays at zero.
+    const [addrBalRows] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, locked_shielded_balance, total_shielded_received
+         FROM address_balance
+        WHERE address = ? AND token_id = ?`,
+      [shieldedAddress, '00'],
+    );
+    expect(addrBalRows).toHaveLength(1);
+    expect(BigInt(addrBalRows[0].unlocked_shielded_balance)).toBe(0n);
+    expect(BigInt(addrBalRows[0].locked_shielded_balance)).toBe(150n);
+    expect(BigInt(addrBalRows[0].total_shielded_received)).toBe(150n);
+
+    // wallet_balance mirrors the same split: locked column carries the
+    // credit, unlocked stays at zero.
+    const [walletBalRows] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, locked_shielded_balance, total_shielded_received
+         FROM wallet_balance
+        WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', '00'],
+    );
+    expect(walletBalRows).toHaveLength(1);
+    expect(BigInt(walletBalRows[0].unlocked_shielded_balance)).toBe(0n);
+    expect(BigInt(walletBalRows[0].locked_shielded_balance)).toBe(150n);
+    expect(BigInt(walletBalRows[0].total_shielded_received)).toBe(150n);
+  });
+
+  it('does NOT write address_balance for unrecovered shielded outputs', async () => {
+    expect.hasAssertions();
+
+    const fixture = eventsFixture.VERTEX_WITH_SHIELDED;
+    const shieldedAddress = fixture.event.data.shielded_outputs[0].decoded.address;
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const [rows] = await mysql.query<any[]>(
+      `SELECT * FROM address_balance WHERE address = ?`,
+      [shieldedAddress],
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('writes wallet_balance shielded columns for recovered shielded outputs', async () => {
+    expect.hasAssertions();
+
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0].token_data = 0;
+    const so = fixture.event.data.shielded_outputs[0];
+    const shieldedAddress = so.decoded.address;
+
+    // wallet_alice must exist for getAddressWalletInfo's INNER JOIN to find
+    // the shielded address. The seedShieldedAddressBalanceEntries augmentation
+    // routes the shielded credit through the central transactions bump, which
+    // needs the wallet row to resolve.
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [shieldedAddress, Buffer.alloc(32, 0x42)],
+    );
+
+    resetCtCryptoMock();
+    mockAddAlert.mockClear();
+    primeAmountRewind({
+      commitment: Buffer.from(so.commitment, 'hex'),
+      ephemeralPubkey: Buffer.from(so.ephemeral_pubkey, 'hex'),
+      value: 150n,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const [rows] = await mysql.query<any[]>(
+      `SELECT unlocked_balance, locked_balance,
+              unlocked_shielded_balance, locked_shielded_balance,
+              total_received, total_shielded_received, transactions
+         FROM wallet_balance
+        WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', '00'],
+    );
+    expect(rows).toHaveLength(1);
+    expect(BigInt(rows[0].unlocked_balance)).toBe(0n);
+    expect(BigInt(rows[0].locked_balance)).toBe(0n);
+    expect(BigInt(rows[0].unlocked_shielded_balance)).toBe(150n);
+    expect(BigInt(rows[0].locked_shielded_balance)).toBe(0n);
+    expect(BigInt(rows[0].total_received)).toBe(0n);
+    expect(BigInt(rows[0].total_shielded_received)).toBe(150n);
+    expect(rows[0].transactions).toBe(1);
+  });
+
+  it('does NOT write wallet_balance for unrecovered shielded outputs', async () => {
+    expect.hasAssertions();
+
+    const fixture = eventsFixture.VERTEX_WITH_SHIELDED;
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const [rows] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_balance WHERE wallet_id = ?`,
+      ['wallet_alice'],
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('writes wallet_tx_history with shielded_balance_delta for recovered shielded outputs', async () => {
+    expect.hasAssertions();
+
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0].token_data = 0;
+    const txHash = fixture.event.data.hash;
+    const so = fixture.event.data.shielded_outputs[0];
+    const shieldedAddress = so.decoded.address;
+
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [shieldedAddress, Buffer.alloc(32, 0x42)],
+    );
+
+    resetCtCryptoMock();
+    mockAddAlert.mockClear();
+    primeAmountRewind({
+      commitment: Buffer.from(so.commitment, 'hex'),
+      ephemeralPubkey: Buffer.from(so.ephemeral_pubkey, 'hex'),
+      value: 150n,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const [rows] = await mysql.query<any[]>(
+      `SELECT balance, shielded_balance_delta
+         FROM wallet_tx_history
+        WHERE wallet_id = ? AND tx_id = ?`,
+      ['wallet_alice', txHash],
+    );
+    expect(rows).toHaveLength(1);
+    expect(BigInt(rows[0].balance)).toBe(0n);
+    expect(BigInt(rows[0].shielded_balance_delta)).toBe(150n);
+  });
+
+  it('does NOT write wallet_tx_history for unrecovered shielded outputs', async () => {
+    expect.hasAssertions();
+
+    const fixture = eventsFixture.VERTEX_WITH_SHIELDED;
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const [rows] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_tx_history WHERE wallet_id = ?`,
+      ['wallet_alice'],
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('bumps address_balance and wallet_balance transactions for shielded-credit-only vertices', async () => {
+    // A shielded-credit-only vertex (no transparent inputs/outputs) must
+    // still bump `address_balance.transactions` and `wallet_balance.transactions`
+    // for the credited (address, token) pair. The shielded credit helpers
+    // themselves no longer carry that bump — the canonical single bump per
+    // (address, tx) / (wallet, tx) lives in updateAddressTablesWithTx /
+    // updateWalletTablesWithTx, which only see addresses in the balance map.
+    // handleVertexAccepted seeds zero-delta entries for shielded-credited
+    // addresses so the central bump fires; this test pins that behaviour.
+    expect.hasAssertions();
+
+    // Clone the fixture and strip the transparent output so the vertex's
+    // only owned touch is the shielded credit. token_data=0 routes the
+    // primed rewind to the native token.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.outputs = [];
+    fixture.event.data.shielded_outputs[0].token_data = 0;
+    const so = fixture.event.data.shielded_outputs[0];
+    const shieldedAddress = so.decoded.address;
+
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [shieldedAddress, Buffer.alloc(32, 0x42)],
+    );
+
+    resetCtCryptoMock();
+    mockAddAlert.mockClear();
+    primeAmountRewind({
+      commitment: Buffer.from(so.commitment, 'hex'),
+      ephemeralPubkey: Buffer.from(so.ephemeral_pubkey, 'hex'),
+      value: 150n,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const [addrRows] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received, transactions
+         FROM address_balance
+        WHERE address = ? AND token_id = ?`,
+      [shieldedAddress, '00'],
+    );
+    expect(addrRows).toHaveLength(1);
+    expect(BigInt(addrRows[0].unlocked_shielded_balance)).toBe(150n);
+    expect(BigInt(addrRows[0].total_shielded_received)).toBe(150n);
+    expect(addrRows[0].transactions).toBe(1);
+
+    const [walletRows] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received, transactions
+         FROM wallet_balance
+        WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', '00'],
+    );
+    expect(walletRows).toHaveLength(1);
+    expect(BigInt(walletRows[0].unlocked_shielded_balance)).toBe(150n);
+    expect(BigInt(walletRows[0].total_shielded_received)).toBe(150n);
+    expect(walletRows[0].transactions).toBe(1);
+  });
+
+  it('marks recovery_failed and emits an alert when the rewind throws', async () => {
+    expect.hasAssertions();
+
+    // Use the fixture as-is: token_data=1 with empty tokens[] makes
+    // resolveShieldedTokenId() return null, which the recovery block treats
+    // as a hard failure (throws inside the try, jumping to the catch).
+    const fixture = eventsFixture.VERTEX_WITH_SHIELDED;
+    const txHash = fixture.event.data.hash;
+    const so = fixture.event.data.shielded_outputs[0];
+
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [so.decoded.address, Buffer.alloc(32, 0x42)],
+    );
+
+    resetCtCryptoMock();
+    mockAddAlert.mockClear();
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const txOutput = await getTxOutput(mysql, txHash, 1, false);
+    expect(txOutput).not.toBeNull();
+    expect(txOutput!.recoveryState).toBe('recovery_failed');
+
+    expect(mockAddAlert).toHaveBeenCalledTimes(1);
+    const [title, , severity, metadata] = mockAddAlert.mock.calls[0];
+    expect(title).toBe('Shielded recovery failed');
+    expect(severity).toBe(Severity.MAJOR);
+    expect(metadata).toMatchObject({ tx_id: txHash, index: 1 });
+  });
+});
+
+describe('handleVertexAccepted with shielded spends', () => {
+  // The previously-recovered shielded UTXO that the spending vertex consumes.
+  const PREV_TX_ID = '1'.repeat(64);
+  const PREV_INDEX = 5;
+  const SHIELDED_ADDRESS = 'WShieldedSpendAddr';
+  const SPEND_TX_ID = '2'.repeat(64);
+  const TOKEN_ID = '00';
+  const SEEDED_VALUE = 400n;
+
+  // Build a NEW_VERTEX_ACCEPTED event that spends PREV_TX_ID:PREV_INDEX as an
+  // AmountShielded input with no outputs / shielded_outputs. The shielded
+  // fields just need to be valid hex; the reversal path doesn't crack them
+  // (it only reads spent_output.mode and the local tx_output row).
+  const buildSpendingVertex = () => ({
+    type: 'EVENT',
+    event: {
+      stream_id: 'stream-shielded-spend',
+      network: 'mainnet',
+      peer_id: 'peer-shielded-spend',
+      id: 200,
+      timestamp: 1700000100.0,
+      type: 'NEW_VERTEX_ACCEPTED',
+      data: {
+        hash: SPEND_TX_ID,
+        nonce: 12345,
+        timestamp: 1700000000,
+        version: 1,
+        weight: 21.5,
+        signal_bits: 0,
+        inputs: [{
+          tx_id: PREV_TX_ID,
+          index: PREV_INDEX,
+          spent_output: {
+            mode: 1,
+            commitment: '02'.repeat(33),
+            range_proof: '03'.repeat(64),
+            script: '04'.repeat(20),
+            ephemeral_pubkey: '05'.repeat(33),
+            token_data: 0,
+            decoded: {
+              address: SHIELDED_ADDRESS,
+            },
+          },
+        }],
+        outputs: [],
+        shielded_outputs: [],
+        parents: [
+          '16ba3dbe424c443e571b00840ca54b9ff4cff467e10b6a15536e718e2008f952',
+          '33e14cb555a96967841dcbe0f95e9eab5810481d01de8f4f73afb8cce365e869',
+        ],
+        tokens: [],
+        token_name: null,
+        token_symbol: null,
+        metadata: {
+          hash: SPEND_TX_ID,
+          voided_by: [],
+          first_block: null,
+          height: 101,
+        },
+        aux_pow: null,
+      },
+      group_id: null,
+    },
+    latest_event_id: 201,
+  });
+
+  // Seed the previously-recovered shielded UTXO: a tx_output row in mode=1 /
+  // recovered state plus the address_balance row that earlier recovery would
+  // have written. The wallet_balance row is seeded separately because the
+  // unowned-path test still wants it (to assert it stays untouched).
+  //
+  // The seeded address_balance row carries the shielded amount on the
+  // *_shielded_balance columns of the unified (address, token_id) row;
+  // transparent columns stay at zero (the recovery path on a fresh receive
+  // never writes the transparent columns).
+  const seedRecoveredShieldedUtxo = async () => {
+    await mysql.query(
+      `INSERT INTO tx_output
+         (tx_id, \`index\`, mode, address, value, token_id, authorities,
+          timelock, heightlock, locked, voided, spent_by, recovery_state)
+       VALUES (?, ?, 1, ?, ?, ?, 0, NULL, NULL, FALSE, FALSE, NULL, 'recovered')`,
+      [PREV_TX_ID, PREV_INDEX, SHIELDED_ADDRESS, SEEDED_VALUE.toString(), TOKEN_ID],
+    );
+
+    await mysql.query(
+      `INSERT INTO address_balance
+         (address, token_id,
+          unlocked_balance, locked_balance, total_received,
+          unlocked_shielded_balance, locked_shielded_balance, total_shielded_received,
+          transactions)
+       VALUES (?, ?, 0, 0, 0, ?, 0, ?, 1)`,
+      [SHIELDED_ADDRESS, TOKEN_ID, SEEDED_VALUE.toString(), SEEDED_VALUE.toString()],
+    );
+  };
+
+  const seedWalletBalance = async () => {
+    await mysql.query(
+      `INSERT INTO wallet_balance
+         (wallet_id, token_id,
+          unlocked_balance, locked_balance, total_received,
+          unlocked_shielded_balance, locked_shielded_balance,
+          total_shielded_received, transactions)
+       VALUES ('wallet_alice', ?, 0, 0, 0, ?, 0, ?, 1)`,
+      [TOKEN_ID, SEEDED_VALUE.toString(), SEEDED_VALUE.toString()],
+    );
+  };
+
+  beforeEach(async () => {
+    // `shielded_tx_output_data` is not in the shared cleanDatabase TABLES
+    // list; wipe it manually to stay isolated from neighbouring suites.
+    // Shielded address rows live in the unified `address` table now and
+    // are cleaned up by cleanDatabase.
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  afterEach(async () => {
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  it('reverses the shielded balance when a shielded UTXO is spent', async () => {
+    expect.hasAssertions();
+
+    // wallet_alice must exist for getAddressWalletInfo's INNER JOIN to find
+    // the shielded address row. The central transactions bump for the spend
+    // vertex flows through that lookup.
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    // Owned shielded address row (bip32_account = 2) on the unified `address`
+    // table so findShieldedAddressOwnership returns the owning wallet for
+    // SHIELDED_ADDRESS.
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 1)`,
+      [SHIELDED_ADDRESS, Buffer.alloc(32, 0x42)],
+    );
+    await seedRecoveredShieldedUtxo();
+    await seedWalletBalance();
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildSpendingVertex(),
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    // wallet_balance: shielded balance decremented by 400 → 0, but
+    // total_shielded_received is a lifetime credit accumulator and must NOT
+    // be decremented by a spend; it stays at the seeded 400. The wallet's
+    // transactions counter ticks up by 1 (1 from seed + 1 canonical bump
+    // for the spend vertex, driven by the transparent stub `prepareInputs`
+    // emits for the shielded input).
+    const [walletBalanceRows] = await mysql.query<any[]>(
+      `SELECT unlocked_balance, locked_balance,
+              unlocked_shielded_balance, locked_shielded_balance,
+              total_shielded_received, transactions
+         FROM wallet_balance
+        WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', TOKEN_ID],
+    );
+    expect(walletBalanceRows).toHaveLength(1);
+    expect(BigInt(walletBalanceRows[0].unlocked_shielded_balance)).toBe(0n);
+    expect(BigInt(walletBalanceRows[0].locked_shielded_balance)).toBe(0n);
+    expect(BigInt(walletBalanceRows[0].total_shielded_received)).toBe(SEEDED_VALUE);
+    expect(Number(walletBalanceRows[0].transactions)).toBe(2);
+
+    // address_balance: shielded unlocked decremented to 0;
+    // total_shielded_received untouched (lifetime credits, not balance).
+    // transactions = 2 (1 from seed + 1 canonical bump for the spend
+    // vertex via the transparent stub).
+    const [addrBalanceRows] = await mysql.query<any[]>(
+      `SELECT unlocked_balance, locked_balance,
+              unlocked_shielded_balance, locked_shielded_balance,
+              total_received, total_shielded_received, transactions
+         FROM address_balance
+        WHERE address = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, TOKEN_ID],
+    );
+    expect(addrBalanceRows).toHaveLength(1);
+    expect(BigInt(addrBalanceRows[0].unlocked_balance)).toBe(0n);
+    expect(BigInt(addrBalanceRows[0].locked_balance)).toBe(0n);
+    expect(BigInt(addrBalanceRows[0].unlocked_shielded_balance)).toBe(0n);
+    expect(BigInt(addrBalanceRows[0].locked_shielded_balance)).toBe(0n);
+    expect(BigInt(addrBalanceRows[0].total_received)).toBe(0n);
+    expect(BigInt(addrBalanceRows[0].total_shielded_received)).toBe(SEEDED_VALUE);
+    expect(Number(addrBalanceRows[0].transactions)).toBe(2);
+
+    // wallet_tx_history: a new row tied to the spending tx with
+    // shielded_balance_delta = -400 and timestamp = the spending vertex's
+    // own timestamp (this row is created by the spend, so the INSERT path
+    // sets the timestamp column).
+    const [historyRows] = await mysql.query<any[]>(
+      `SELECT balance, shielded_balance_delta, timestamp
+         FROM wallet_tx_history
+        WHERE wallet_id = ? AND tx_id = ? AND token_id = ?`,
+      ['wallet_alice', SPEND_TX_ID, TOKEN_ID],
+    );
+    expect(historyRows).toHaveLength(1);
+    expect(BigInt(historyRows[0].shielded_balance_delta)).toBe(-SEEDED_VALUE);
+    expect(Number(historyRows[0].timestamp)).toBe(
+      buildSpendingVertex().event.data.timestamp,
+    );
+
+    // address_tx_history mirror: same (address, tx_id, token_id) row
+    // carries the signed shielded_balance_delta = -400 on the address grain.
+    const [addrHistoryRows] = await mysql.query<any[]>(
+      `SELECT balance, shielded_balance_delta, timestamp
+         FROM address_tx_history
+        WHERE address = ? AND tx_id = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, SPEND_TX_ID, TOKEN_ID],
+    );
+    expect(addrHistoryRows).toHaveLength(1);
+    expect(BigInt(addrHistoryRows[0].shielded_balance_delta)).toBe(-SEEDED_VALUE);
+    expect(Number(addrHistoryRows[0].timestamp)).toBe(
+      buildSpendingVertex().event.data.timestamp,
+    );
+
+    // The consumed tx_output is now marked spent by the spending vertex.
+    const prevOutput = await getTxOutput(mysql, PREV_TX_ID, PREV_INDEX, false);
+    expect(prevOutput).not.toBeNull();
+    expect(prevOutput!.spentBy).toBe(SPEND_TX_ID);
+  });
+
+  it('does NOT reverse when the spent shielded row is unowned', async () => {
+    expect.hasAssertions();
+
+    // No shielded ownership row on the `address` table →
+    // findShieldedAddressOwnership returns null and the reversal branch
+    // is skipped.
+    await seedRecoveredShieldedUtxo();
+    await seedWalletBalance();
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildSpendingVertex(),
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    // wallet_balance untouched.
+    const [walletBalanceRows] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, locked_shielded_balance,
+              total_shielded_received
+         FROM wallet_balance
+        WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', TOKEN_ID],
+    );
+    expect(walletBalanceRows).toHaveLength(1);
+    expect(BigInt(walletBalanceRows[0].unlocked_shielded_balance)).toBe(SEEDED_VALUE);
+    expect(BigInt(walletBalanceRows[0].locked_shielded_balance)).toBe(0n);
+    expect(BigInt(walletBalanceRows[0].total_shielded_received)).toBe(SEEDED_VALUE);
+
+    // address_balance shielded columns untouched on the unified row.
+    const [addrBalanceRows] = await mysql.query<any[]>(
+      `SELECT unlocked_balance, locked_balance,
+              unlocked_shielded_balance, locked_shielded_balance
+         FROM address_balance
+        WHERE address = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, TOKEN_ID],
+    );
+    expect(addrBalanceRows).toHaveLength(1);
+    expect(BigInt(addrBalanceRows[0].unlocked_shielded_balance)).toBe(SEEDED_VALUE);
+    expect(BigInt(addrBalanceRows[0].locked_shielded_balance)).toBe(0n);
+
+    // No wallet_tx_history row written for the spend.
+    const [historyRows] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_tx_history WHERE tx_id = ?`,
+      [SPEND_TX_ID],
+    );
+    expect(historyRows).toHaveLength(0);
+
+    // The kind-agnostic spent_by marking still ran.
+    const prevOutput = await getTxOutput(mysql, PREV_TX_ID, PREV_INDEX, false);
+    expect(prevOutput).not.toBeNull();
+    expect(prevOutput!.spentBy).toBe(SPEND_TX_ID);
+  });
+
+  it('does not produce a phantom (address, "") balance entry for a FullyShielded input', async () => {
+    // Regression for the FullyShielded-input phantom-row case. The wire
+    // payload for a FullyShielded spent_output carries no token uid, so
+    // the legacy prepareInputs path emitted a TxInput with token = '',
+    // which then flowed into getAddressBalanceMap and produced a
+    // (address, '') row in address_balance and an empty-string entry in
+    // token.transactions. After the unified-dispatch refactor those
+    // writes are sourced from the unified balance map, which never
+    // contains the empty token; this test pins that contract.
+    expect.hasAssertions();
+
+    // Wallet must exist for getAddressWalletInfo lookups in the spend
+    // path.
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+    // Owned shielded address row.
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 1)`,
+      [SHIELDED_ADDRESS, Buffer.alloc(32, 0x42)],
+    );
+    await seedRecoveredShieldedUtxo();
+    await seedWalletBalance();
+
+    // FullyShielded input: mode=2, no token_data, must carry
+    // asset_commitment + surjection_proof per the wire schema.
+    const fullyShieldedSpendEvent = {
+      type: 'EVENT',
+      event: {
+        stream_id: 'stream-shielded-fs-spend',
+        network: 'mainnet',
+        peer_id: 'peer-shielded-fs-spend',
+        id: 220,
+        timestamp: 1700000200.0,
+        type: 'NEW_VERTEX_ACCEPTED',
+        data: {
+          hash: SPEND_TX_ID,
+          nonce: 12345,
+          timestamp: 1700000000,
+          version: 1,
+          weight: 21.5,
+          signal_bits: 0,
+          inputs: [{
+            tx_id: PREV_TX_ID,
+            index: PREV_INDEX,
+            spent_output: {
+              mode: 2,
+              commitment: '02'.repeat(33),
+              range_proof: '03'.repeat(64),
+              script: '04'.repeat(20),
+              ephemeral_pubkey: '05'.repeat(33),
+              asset_commitment: '06'.repeat(33),
+              surjection_proof: '07'.repeat(64),
+              decoded: {
+                address: SHIELDED_ADDRESS,
+              },
+            },
+          }],
+          outputs: [],
+          shielded_outputs: [],
+          parents: [
+            '16ba3dbe424c443e571b00840ca54b9ff4cff467e10b6a15536e718e2008f952',
+            '33e14cb555a96967841dcbe0f95e9eab5810481d01de8f4f73afb8cce365e869',
+          ],
+          tokens: [],
+          token_name: null,
+          token_symbol: null,
+          metadata: {
+            hash: SPEND_TX_ID,
+            voided_by: [],
+            first_block: null,
+            height: 102,
+          },
+          aux_pow: null,
+        },
+        group_id: null,
+      },
+      latest_event_id: 221,
+    };
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fullyShieldedSpendEvent,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    // No phantom (address, '') row was ever written to address_balance.
+    const [phantomBalanceRows] = await mysql.query<any[]>(
+      `SELECT address, token_id FROM address_balance WHERE token_id = ''`,
+    );
+    expect(phantomBalanceRows).toHaveLength(0);
+
+    // No phantom empty-token row in `token`.
+    const [phantomTokenRows] = await mysql.query<any[]>(
+      `SELECT id, transactions FROM token WHERE id = ''`,
+    );
+    expect(phantomTokenRows).toHaveLength(0);
+
+    // The unified balance map picked up the negative shielded delta from
+    // the local tx_output lookup, so the shielded balance is reversed
+    // on the real (address, TOKEN_ID) row.
+    const [addrBalanceRows] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, locked_shielded_balance,
+              total_shielded_received, transactions
+         FROM address_balance
+        WHERE address = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, TOKEN_ID],
+    );
+    expect(addrBalanceRows).toHaveLength(1);
+    expect(BigInt(addrBalanceRows[0].unlocked_shielded_balance)).toBe(0n);
+    expect(BigInt(addrBalanceRows[0].locked_shielded_balance)).toBe(0n);
+    expect(BigInt(addrBalanceRows[0].total_shielded_received)).toBe(SEEDED_VALUE);
+
+    // Wallet balance row was also updated through the unified writer.
+    const [walletBalanceRows] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance FROM wallet_balance
+        WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', TOKEN_ID],
+    );
+    expect(walletBalanceRows).toHaveLength(1);
+    expect(BigInt(walletBalanceRows[0].unlocked_shielded_balance)).toBe(0n);
+  });
+});
+
+describe('handleVoidedTx with shielded', () => {
+  // The tx that carries a shielded output (same base fixture as the ingest tests).
+  // We clone and patch token_data=0 so the token resolves to HTR and the
+  // rewind mock can credit the balance.
+  const SHIELDED_ADDRESS = 'WShieldedAddress1';
+  const TOKEN_ID = '00';
+  const RECOVERED_VALUE = 150n;
+  // commitment / ephemeralPubkey must match what the fixture carries so the
+  // mock keyed by (commitment, ephemeralPubkey) fires correctly.
+  const COMMITMENT = Buffer.from('02'.repeat(33), 'hex');
+  const EPHEM_PUBKEY = Buffer.from('05'.repeat(33), 'hex');
+
+  // Build the ACCEPT event (token_data=0 → HTR, mode=1 AmountShielded).
+  const buildReceiveVertex = () => {
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0].token_data = 0;
+    return fixture;
+  };
+
+  // Build the matching VOID event for the same vertex.
+  const buildVoidEvent = (fixture: typeof eventsFixture.VERTEX_WITH_SHIELDED) => ({
+    stream_id: 'stream-void-shielded',
+    peer_id: 'peer-void',
+    network: 'mainnet',
+    type: 'FULLNODE_EVENT',
+    latest_event_id: 999,
+    event: {
+      id: 998,
+      data: {
+        hash: fixture.event.data.hash,
+        outputs: fixture.event.data.outputs,
+        inputs: fixture.event.data.inputs,
+        tokens: fixture.event.data.tokens,
+        shielded_outputs: fixture.event.data.shielded_outputs,
+        version: fixture.event.data.version,
+        headers: [],
+      },
+    },
+  });
+
+  beforeEach(async () => {
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  afterEach(async () => {
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  it('reverses a recovered shielded receive when the vertex is voided', async () => {
+    expect.hasAssertions();
+
+    const fixture = buildReceiveVertex();
+    const txHash = fixture.event.data.hash;
+    const so = fixture.event.data.shielded_outputs[0];
+
+    // Seed a claimed CTSpend address row so the in-line rewind runs and
+    // the balance is credited on accept.
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [so.decoded.address, Buffer.alloc(32, 0x42)],
+    );
+
+    // Wallet must exist for getAddressWalletInfo's INNER JOIN.
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    resetCtCryptoMock();
+    primeAmountRewind({
+      commitment: COMMITMENT,
+      ephemeralPubkey: EPHEM_PUBKEY,
+      value: RECOVERED_VALUE,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Sanity: shielded balance is credited after accept.
+    const [wbBefore] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received
+         FROM wallet_balance WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', TOKEN_ID],
+    );
+    expect(wbBefore).toHaveLength(1);
+    expect(BigInt(wbBefore[0].unlocked_shielded_balance)).toBe(RECOVERED_VALUE);
+    expect(BigInt(wbBefore[0].total_shielded_received)).toBe(RECOVERED_VALUE);
+
+    // Now void the same vertex.
+    const voidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildVoidEvent(fixture),
+    };
+
+    await handleVoidedTx(voidContext as any);
+
+    // wallet_balance row is deleted by the all-zeros cleanup guard after void
+    // (no transparent balance was ever credited, so every column is zero).
+    const [wbAfter] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received
+         FROM wallet_balance WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', TOKEN_ID],
+    );
+    expect(wbAfter).toHaveLength(0);
+
+    // address_balance row is likewise deleted by the same all-zeros cleanup.
+    const [abAfter] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received
+         FROM address_balance WHERE address = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, TOKEN_ID],
+    );
+    expect(abAfter).toHaveLength(0);
+
+    // address.transactions is decremented back to 0 (involvement reversal).
+    const [addrRows] = await mysql.query<any[]>(
+      `SELECT transactions FROM address WHERE address = ?`,
+      [SHIELDED_ADDRESS],
+    );
+    expect(addrRows).toHaveLength(1);
+    expect(Number(addrRows[0].transactions)).toBe(0);
+
+    // getTxOutput filters voided=FALSE, so the voided row is invisible to it.
+    const txOutput = await getTxOutput(mysql, txHash, 1, false);
+    expect(txOutput).toBeNull();
+    // Confirm voided flag and preserved recovery_state directly via raw query.
+    const [rawRows] = await mysql.query<any[]>(
+      `SELECT voided, recovery_state FROM tx_output WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(rawRows).toHaveLength(1);
+    expect(rawRows[0].voided).toBeTruthy();
+    expect(rawRows[0].recovery_state).toBe('recovered');
+  });
+
+  it('does NOT touch shielded totals when voiding an unowned shielded receive', async () => {
+    expect.hasAssertions();
+
+    // The raw fixture has token_data=1 (non-HTR, no mock primed) → the output
+    // lands as `unowned` and no balance row is ever created.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+
+    resetCtCryptoMock();
+
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Sanity: no wallet_balance row was created (unowned receive → nothing credited).
+    const [wbBefore] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_balance WHERE token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbBefore).toHaveLength(0);
+
+    const voidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildVoidEvent(fixture),
+    };
+
+    await handleVoidedTx(voidContext as any);
+
+    // Still no wallet_balance row after void.
+    const [wbAfter] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_balance WHERE token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbAfter).toHaveLength(0);
+  });
+
+  it('decrements the involvement counter for an unowned shielded receive on void', async () => {
+    expect.hasAssertions();
+
+    // Unowned shielded output: never enters the balance map, but the ingest
+    // path still bumps its address involvement counter via bumpAddressInvolvement.
+    // The void must reverse that bump symmetrically.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    const unownedAddress = fixture.event.data.shielded_outputs[0].decoded.address;
+
+    resetCtCryptoMock();
+
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // After ingest the observation row exists with transactions bumped to 1,
+    // even though no balance row was created.
+    const [addrBefore] = await mysql.query<any[]>(
+      `SELECT transactions FROM address WHERE address = ?`,
+      [unownedAddress],
+    );
+    expect(addrBefore).toHaveLength(1);
+    expect(Number(addrBefore[0].transactions)).toBe(1);
+
+    const voidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildVoidEvent(fixture),
+    };
+    await handleVoidedTx(voidContext as any);
+
+    // Counter reversed back to 0 — the void event carries shielded_outputs, so
+    // the unowned address is in the involvement set decremented on void.
+    const [addrAfter] = await mysql.query<any[]>(
+      `SELECT transactions FROM address WHERE address = ?`,
+      [unownedAddress],
+    );
+    expect(addrAfter).toHaveLength(1);
+    expect(Number(addrAfter[0].transactions)).toBe(0);
+  });
+
+  it('restores shielded balance when voiding a vertex that spent a recovered shielded UTXO', async () => {
+    expect.hasAssertions();
+
+    // Reuse the constants from `handleVertexAccepted with shielded spends`.
+    const PREV_TX_ID = '1'.repeat(64);
+    const PREV_INDEX = 5;
+    const SPEND_TX_ID = '2'.repeat(64);
+    const SEEDED_VALUE = 400n;
+
+    // Wallet must exist for getAddressWalletInfo lookups.
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    // Owned CTSpend address row so findShieldedAddressOwnership recognises it.
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 1)`,
+      ['WShieldedSpendAddr', Buffer.alloc(32, 0x42)],
+    );
+
+    // Seed the previously-recovered shielded UTXO.
+    await mysql.query(
+      `INSERT INTO tx_output
+         (tx_id, \`index\`, mode, address, value, token_id, authorities,
+          timelock, heightlock, locked, voided, spent_by, recovery_state)
+       VALUES (?, ?, 1, 'WShieldedSpendAddr', ?, ?, 0, NULL, NULL, FALSE, FALSE, NULL, 'recovered')`,
+      [PREV_TX_ID, PREV_INDEX, SEEDED_VALUE.toString(), TOKEN_ID],
+    );
+    await mysql.query(
+      `INSERT INTO address_balance
+         (address, token_id,
+          unlocked_balance, locked_balance, total_received,
+          unlocked_shielded_balance, locked_shielded_balance, total_shielded_received,
+          transactions)
+       VALUES ('WShieldedSpendAddr', ?, 0, 0, 0, ?, 0, ?, 1)`,
+      [TOKEN_ID, SEEDED_VALUE.toString(), SEEDED_VALUE.toString()],
+    );
+    await mysql.query(
+      `INSERT INTO wallet_balance
+         (wallet_id, token_id,
+          unlocked_balance, locked_balance, total_received,
+          unlocked_shielded_balance, locked_shielded_balance,
+          total_shielded_received, transactions)
+       VALUES ('wallet_alice', ?, 0, 0, 0, ?, 0, ?, 1)`,
+      [TOKEN_ID, SEEDED_VALUE.toString(), SEEDED_VALUE.toString()],
+    );
+
+    // The spending vertex: AmountShielded input, no outputs.
+    const buildSpendingVertex = () => ({
+      type: 'EVENT',
+      event: {
+        stream_id: 'stream-void-spend',
+        network: 'mainnet',
+        peer_id: 'peer-void-spend',
+        id: 300,
+        timestamp: 1700000100.0,
+        type: 'NEW_VERTEX_ACCEPTED',
+        data: {
+          hash: SPEND_TX_ID,
+          nonce: 12345,
+          timestamp: 1700000000,
+          version: 1,
+          weight: 21.5,
+          signal_bits: 0,
+          inputs: [{
+            tx_id: PREV_TX_ID,
+            index: PREV_INDEX,
+            spent_output: {
+              mode: 1,
+              commitment: '02'.repeat(33),
+              range_proof: '03'.repeat(64),
+              script: '04'.repeat(20),
+              ephemeral_pubkey: '05'.repeat(33),
+              token_data: 0,
+              decoded: {
+                address: 'WShieldedSpendAddr',
+              },
+            },
+          }],
+          outputs: [],
+          shielded_outputs: [],
+          parents: [
+            '16ba3dbe424c443e571b00840ca54b9ff4cff467e10b6a15536e718e2008f952',
+            '33e14cb555a96967841dcbe0f95e9eab5810481d01de8f4f73afb8cce365e869',
+          ],
+          tokens: [],
+          token_name: null,
+          token_symbol: null,
+          metadata: {
+            hash: SPEND_TX_ID,
+            voided_by: [],
+            first_block: null,
+            height: 101,
+          },
+          aux_pow: null,
+        },
+        group_id: null,
+      },
+      latest_event_id: 301,
+    });
+
+    // Accept the spending vertex → shielded balance drops to 0.
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildSpendingVertex(),
+    };
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Sanity: balance zeroed by the spend.
+    const [wbMid] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received
+         FROM wallet_balance WHERE wallet_id = 'wallet_alice' AND token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbMid).toHaveLength(1);
+    expect(BigInt(wbMid[0].unlocked_shielded_balance)).toBe(0n);
+    expect(BigInt(wbMid[0].total_shielded_received)).toBe(SEEDED_VALUE);
+
+    // Void the spending vertex.
+    const voidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: {
+        stream_id: 'stream-void-spend',
+        peer_id: 'peer-void-spend',
+        network: 'mainnet',
+        type: 'FULLNODE_EVENT',
+        latest_event_id: 302,
+        event: {
+          id: 301,
+          data: {
+            hash: SPEND_TX_ID,
+            outputs: [],
+            inputs: buildSpendingVertex().event.data.inputs,
+            tokens: [],
+            version: 1,
+            headers: [],
+          },
+        },
+      },
+    };
+    await handleVoidedTx(voidContext as any);
+
+    // After void: shielded balance restored to SEEDED_VALUE; total_shielded_received
+    // stays at SEEDED_VALUE (spend reversal only restores the running balance,
+    // not the lifetime accumulator which was never decremented by the spend).
+    const [wbAfter] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, locked_shielded_balance, total_shielded_received
+         FROM wallet_balance WHERE wallet_id = 'wallet_alice' AND token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbAfter).toHaveLength(1);
+    expect(BigInt(wbAfter[0].unlocked_shielded_balance)).toBe(SEEDED_VALUE);
+    expect(BigInt(wbAfter[0].locked_shielded_balance)).toBe(0n);
+    expect(BigInt(wbAfter[0].total_shielded_received)).toBe(SEEDED_VALUE);
+
+    // spent_by on the original UTXO is cleared.
+    const prevOutput = await getTxOutput(mysql, PREV_TX_ID, PREV_INDEX, false);
+    expect(prevOutput).not.toBeNull();
+    expect(prevOutput!.spentBy).toBeNull();
+  });
+
+  it('reverses a recovered shielded receive that landed in the locked column', async () => {
+    expect.hasAssertions();
+
+    // Same flow as the recovered-receive void above, but the shielded output
+    // is timelocked, so the credit lands in `locked_shielded_balance`. This is
+    // the only void test that drives the `locked_shielded_balance` subtract
+    // (and its cleanup-guard arm) with a non-zero value.
+    const fixture = buildReceiveVertex();
+    const so = fixture.event.data.shielded_outputs[0];
+    const futureTimelock = Math.floor(Date.now() / 1000) + 3600;
+    so.decoded.timelock = futureTimelock;
+
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [so.decoded.address, Buffer.alloc(32, 0x42)],
+    );
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    resetCtCryptoMock();
+    primeAmountRewind({
+      commitment: COMMITMENT,
+      ephemeralPubkey: EPHEM_PUBKEY,
+      value: RECOVERED_VALUE,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Sanity: the credit is in the LOCKED shielded column after accept.
+    const [wbBefore] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, locked_shielded_balance, total_shielded_received
+         FROM wallet_balance WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', TOKEN_ID],
+    );
+    expect(wbBefore).toHaveLength(1);
+    expect(BigInt(wbBefore[0].unlocked_shielded_balance)).toBe(0n);
+    expect(BigInt(wbBefore[0].locked_shielded_balance)).toBe(RECOVERED_VALUE);
+    expect(BigInt(wbBefore[0].total_shielded_received)).toBe(RECOVERED_VALUE);
+
+    const voidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildVoidEvent(fixture),
+    };
+    await handleVoidedTx(voidContext as any);
+
+    // The locked_shielded_balance subtract drops it back to zero, so the
+    // all-zeros cleanup removes both balance rows. A dropped subtract would
+    // leave locked_shielded_balance non-zero and the rows would survive.
+    const [wbAfter] = await mysql.query<any[]>(
+      `SELECT 1 FROM wallet_balance WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', TOKEN_ID],
+    );
+    expect(wbAfter).toHaveLength(0);
+
+    const [abAfter] = await mysql.query<any[]>(
+      `SELECT 1 FROM address_balance WHERE address = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, TOKEN_ID],
+    );
+    expect(abAfter).toHaveLength(0);
+  });
+
+  it('reverses each row once when one voided tx has multiple shielded outputs to the same address', async () => {
+    expect.hasAssertions();
+
+    // Two recovered shielded outputs land on the SAME owned (address, token)
+    // row in a single tx. The void must reverse BOTH contributions — counting
+    // each tx_output row once despite the ownership lookup deduping the address.
+    const VALUE_A = 150n;
+    const VALUE_B = 250n;
+    const COMMITMENT_B = Buffer.from('0a'.repeat(33), 'hex');
+    const EPHEM_PUBKEY_B = Buffer.from('0b'.repeat(33), 'hex');
+
+    const fixture = buildReceiveVertex();
+    const so = fixture.event.data.shielded_outputs[0];
+    // Second shielded output to the same address, distinct commitment/ephemeral
+    // so the rewind mock keys them apart.
+    const secondOutput = JSON.parse(JSON.stringify(so));
+    secondOutput.commitment = COMMITMENT_B.toString('hex');
+    secondOutput.ephemeral_pubkey = EPHEM_PUBKEY_B.toString('hex');
+    fixture.event.data.shielded_outputs.push(secondOutput);
+
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [so.decoded.address, Buffer.alloc(32, 0x42)],
+    );
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    resetCtCryptoMock();
+    primeAmountRewind({
+      commitment: COMMITMENT,
+      ephemeralPubkey: EPHEM_PUBKEY,
+      value: VALUE_A,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+    primeAmountRewind({
+      commitment: COMMITMENT_B,
+      ephemeralPubkey: EPHEM_PUBKEY_B,
+      value: VALUE_B,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Sanity: both outputs credited the single row → sum of both values.
+    const [abBefore] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received
+         FROM address_balance WHERE address = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, TOKEN_ID],
+    );
+    expect(abBefore).toHaveLength(1);
+    expect(BigInt(abBefore[0].unlocked_shielded_balance)).toBe(VALUE_A + VALUE_B);
+    expect(BigInt(abBefore[0].total_shielded_received)).toBe(VALUE_A + VALUE_B);
+
+    const voidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildVoidEvent(fixture),
+    };
+    await handleVoidedTx(voidContext as any);
+
+    // Exact reversal of both contributions zeroes the row → it is cleaned up.
+    // Under-counting (treating the deduped address as one recovery) would leave
+    // a residual balance and the row would survive.
+    const [abAfter] = await mysql.query<any[]>(
+      `SELECT 1 FROM address_balance WHERE address = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, TOKEN_ID],
+    );
+    expect(abAfter).toHaveLength(0);
+
+    const [wbAfter] = await mysql.query<any[]>(
+      `SELECT 1 FROM wallet_balance WHERE wallet_id = ? AND token_id = ?`,
+      ['wallet_alice', TOKEN_ID],
+    );
+    expect(wbAfter).toHaveLength(0);
+  });
+});
+
+describe('handleUnvoidedTx with shielded', () => {
+  const SHIELDED_ADDRESS = 'WShieldedAddress1';
+  const TOKEN_ID = '00';
+  const RECOVERED_VALUE = 150n;
+  const COMMITMENT = Buffer.from('02'.repeat(33), 'hex');
+  const EPHEM_PUBKEY = Buffer.from('05'.repeat(33), 'hex');
+
+  const buildReceiveVertex = () => {
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0].token_data = 0;
+    return fixture;
+  };
+
+  const buildVoidEvent = (fixture: typeof eventsFixture.VERTEX_WITH_SHIELDED) => ({
+    stream_id: 'stream-unvoid-shielded',
+    peer_id: 'peer-unvoid',
+    network: 'mainnet',
+    type: 'FULLNODE_EVENT',
+    latest_event_id: 999,
+    event: {
+      id: 998,
+      data: {
+        hash: fixture.event.data.hash,
+        outputs: fixture.event.data.outputs,
+        inputs: fixture.event.data.inputs,
+        tokens: fixture.event.data.tokens,
+        shielded_outputs: fixture.event.data.shielded_outputs,
+        version: fixture.event.data.version,
+        headers: [],
+      },
+    },
+  });
+
+  beforeEach(async () => {
+    // Restore any spies left active by earlier tests (e.g. db.voidTransaction spy)
+    // so the real implementations run throughout the void→unvoid cycle.
+    jest.restoreAllMocks();
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  afterEach(async () => {
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  it('round-trip restores shielded balance for a recovered receive', async () => {
+    expect.hasAssertions();
+
+    const fixture = buildReceiveVertex();
+    const txHash = fixture.event.data.hash;
+    const so = fixture.event.data.shielded_outputs[0];
+
+    // Seed a claimed CTSpend address row (bip32_account = 2) so the rewind
+    // mock fires during ingest and the balance is credited.
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [so.decoded.address, Buffer.alloc(32, 0x42)],
+    );
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    // Prime the mock once; do NOT call resetCtCryptoMock between steps so the
+    // re-ingest triggered by unvoid can recover the same value.
+    primeAmountRewind({
+      commitment: COMMITMENT,
+      ephemeralPubkey: EPHEM_PUBKEY,
+      value: RECOVERED_VALUE,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Post-ingest: balance credited.
+    const [wbIngest] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received
+         FROM wallet_balance WHERE wallet_id = 'wallet_alice' AND token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbIngest).toHaveLength(1);
+    expect(BigInt(wbIngest[0].unlocked_shielded_balance)).toBe(RECOVERED_VALUE);
+    expect(BigInt(wbIngest[0].total_shielded_received)).toBe(RECOVERED_VALUE);
+
+    // Void the vertex.
+    const voidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildVoidEvent(fixture),
+    };
+    await handleVoidedTx(voidContext as any);
+
+    // Post-void: the all-zeros cleanup deletes the balance row entirely.
+    const [wbVoided] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_balance WHERE wallet_id = 'wallet_alice' AND token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbVoided).toHaveLength(0);
+
+    // address.transactions decremented back to 0 (involvement reversal).
+    const [addrRowVoided] = await mysql.query<any[]>(
+      `SELECT transactions FROM address WHERE address = ?`,
+      [SHIELDED_ADDRESS],
+    );
+    expect(addrRowVoided).toHaveLength(1);
+    expect(Number(addrRowVoided[0].transactions)).toBe(0);
+
+    // Unvoid step 1: cleanupVoidedTx (DELETE the voided rows).
+    const unvoidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildVoidEvent(fixture),
+    };
+    await handleUnvoidedTx(unvoidContext as any);
+
+    // Unvoid step 2: re-ingest (mirrors what the state machine chains to).
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Post-unvoid: balance restored to the same post-ingest state.
+    const [wbRestored] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received
+         FROM wallet_balance WHERE wallet_id = 'wallet_alice' AND token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbRestored).toHaveLength(1);
+    expect(BigInt(wbRestored[0].unlocked_shielded_balance)).toBe(RECOVERED_VALUE);
+    expect(BigInt(wbRestored[0].total_shielded_received)).toBe(RECOVERED_VALUE);
+
+    const [abRestored] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received
+         FROM address_balance WHERE address = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, TOKEN_ID],
+    );
+    expect(abRestored).toHaveLength(1);
+    expect(BigInt(abRestored[0].unlocked_shielded_balance)).toBe(RECOVERED_VALUE);
+    expect(BigInt(abRestored[0].total_shielded_received)).toBe(RECOVERED_VALUE);
+
+    // address.transactions involvement counter restored to 1.
+    const [addrRows] = await mysql.query<any[]>(
+      `SELECT transactions FROM address WHERE address = ?`,
+      [SHIELDED_ADDRESS],
+    );
+    expect(addrRows).toHaveLength(1);
+    expect(Number(addrRows[0].transactions)).toBe(1);
+
+    // tx_output visible again (voided = FALSE) with recovery_state preserved.
+    const txOutput = await getTxOutput(mysql, txHash, 1, false);
+    expect(txOutput).not.toBeNull();
+    const [rawRows] = await mysql.query<any[]>(
+      `SELECT voided, recovery_state FROM tx_output WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(rawRows).toHaveLength(1);
+    expect(rawRows[0].voided).toBeFalsy();
+    expect(rawRows[0].recovery_state).toBe('recovered');
+  });
+
+  it('no-op on balance for an unowned shielded receive round-trip', async () => {
+    expect.hasAssertions();
+
+    // Raw fixture: token_data = 1 (non-HTR), no claimed address row, no mock
+    // primed → output ingests as `unowned`, no balance row created.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    const txHash = fixture.event.data.hash;
+
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // No balance row after ingest (unowned).
+    const [wbIngest] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_balance WHERE token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbIngest).toHaveLength(0);
+
+    // tx_output written with recovery_state = 'unowned'.
+    const [rawIngest] = await mysql.query<any[]>(
+      `SELECT voided, recovery_state FROM tx_output WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(rawIngest).toHaveLength(1);
+    expect(rawIngest[0].voided).toBeFalsy();
+    expect(rawIngest[0].recovery_state).toBe('unowned');
+
+    // Void the vertex.
+    const voidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildVoidEvent(fixture),
+    };
+    await handleVoidedTx(voidContext as any);
+
+    // tx_output row still exists but is now voided.
+    const [rawVoided] = await mysql.query<any[]>(
+      `SELECT voided, recovery_state FROM tx_output WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(rawVoided).toHaveLength(1);
+    expect(rawVoided[0].voided).toBeTruthy();
+    expect(rawVoided[0].recovery_state).toBe('unowned');
+
+    // Unvoid step 1: cleanup DELETE.
+    const unvoidContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildVoidEvent(fixture),
+    };
+    await handleUnvoidedTx(unvoidContext as any);
+
+    // Unvoid step 2: re-ingest.
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Still no balance row after unvoid (unowned → never credited).
+    const [wbRestored] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_balance WHERE token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbRestored).toHaveLength(0);
+
+    // tx_output visible again (voided = FALSE), recovery_state still 'unowned'.
+    const [rawRestored] = await mysql.query<any[]>(
+      `SELECT voided, recovery_state FROM tx_output WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(rawRestored).toHaveLength(1);
+    expect(rawRestored[0].voided).toBeFalsy();
+    expect(rawRestored[0].recovery_state).toBe('unowned');
+  });
+});
+
+describe('handleVertexRemoved with shielded', () => {
+  // Vertex removal (reorg) is the destructive sibling of void: voidTx reverses
+  // the balances (same unified map), then cleanupVoidedTx DELETEs the rows.
+  // The satellite is cleaned by the FK ON DELETE CASCADE to tx_output.
+  const SHIELDED_ADDRESS = 'WShieldedAddress1';
+  const TOKEN_ID = '00';
+  const RECOVERED_VALUE = 150n;
+  const COMMITMENT = Buffer.from('02'.repeat(33), 'hex');
+  const EPHEM_PUBKEY = Buffer.from('05'.repeat(33), 'hex');
+
+  const buildReceiveVertex = () => {
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0].token_data = 0;
+    return fixture;
+  };
+
+  // VERTEX_REMOVED carries the same data shape voidTx reads; handleVertexRemoved
+  // pulls hash / outputs / inputs / tokens / version / headers off event.data.
+  const buildRemovedEvent = (fixture: typeof eventsFixture.VERTEX_WITH_SHIELDED) => ({
+    stream_id: 'stream-removed-shielded',
+    peer_id: 'peer-removed',
+    network: 'mainnet',
+    type: 'FULLNODE_EVENT',
+    latest_event_id: 999,
+    event: {
+      id: 998,
+      data: {
+        hash: fixture.event.data.hash,
+        outputs: fixture.event.data.outputs,
+        inputs: fixture.event.data.inputs,
+        tokens: fixture.event.data.tokens,
+        shielded_outputs: fixture.event.data.shielded_outputs,
+        version: fixture.event.data.version,
+        headers: [],
+      },
+    },
+  });
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  afterEach(async () => {
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  it('deletes tx_output rows, reverses balances, and cascades the satellite', async () => {
+    expect.hasAssertions();
+
+    const fixture = buildReceiveVertex();
+    const txHash = fixture.event.data.hash;
+    const so = fixture.event.data.shielded_outputs[0];
+
+    // Claimed CTSpend address so the in-line rewind credits the balance on accept.
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [so.decoded.address, Buffer.alloc(32, 0x42)],
+    );
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    resetCtCryptoMock();
+    primeAmountRewind({
+      commitment: COMMITMENT,
+      ephemeralPubkey: EPHEM_PUBKEY,
+      value: RECOVERED_VALUE,
+      tokenUid: Buffer.alloc(32, 0x00),
+    });
+
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Sanity: balance credited and satellite written after accept.
+    const [wbBefore] = await mysql.query<any[]>(
+      `SELECT unlocked_shielded_balance, total_shielded_received
+         FROM wallet_balance WHERE wallet_id = 'wallet_alice' AND token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbBefore).toHaveLength(1);
+    expect(BigInt(wbBefore[0].unlocked_shielded_balance)).toBe(RECOVERED_VALUE);
+    const [satBefore] = await mysql.query<any[]>(
+      `SELECT * FROM shielded_tx_output_data WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(satBefore).toHaveLength(1);
+
+    // Remove the vertex (reorg).
+    const removedContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildRemovedEvent(fixture),
+    };
+    await handleVertexRemoved(removedContext as any, undefined as any);
+
+    // tx_output row is DELETED (not just voided) — removal cleans up the rows.
+    const [txoAfter] = await mysql.query<any[]>(
+      `SELECT * FROM tx_output WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(txoAfter).toHaveLength(0);
+
+    // Satellite is gone via the FK ON DELETE CASCADE to tx_output.
+    const [satAfter] = await mysql.query<any[]>(
+      `SELECT * FROM shielded_tx_output_data WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(satAfter).toHaveLength(0);
+
+    // The transaction row itself is removed.
+    const [txAfter] = await mysql.query<any[]>(
+      `SELECT * FROM \`transaction\` WHERE tx_id = ?`,
+      [txHash],
+    );
+    expect(txAfter).toHaveLength(0);
+
+    // Balances reversed: the all-zeros cleanup deletes both balance rows.
+    const [wbAfter] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_balance WHERE wallet_id = 'wallet_alice' AND token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbAfter).toHaveLength(0);
+    const [abAfter] = await mysql.query<any[]>(
+      `SELECT * FROM address_balance WHERE address = ? AND token_id = ?`,
+      [SHIELDED_ADDRESS, TOKEN_ID],
+    );
+    expect(abAfter).toHaveLength(0);
+
+    // address.transactions involvement counter decremented back to 0.
+    const [addrRows] = await mysql.query<any[]>(
+      `SELECT transactions FROM address WHERE address = ?`,
+      [SHIELDED_ADDRESS],
+    );
+    expect(addrRows).toHaveLength(1);
+    expect(Number(addrRows[0].transactions)).toBe(0);
+  });
+
+  it('does NOT touch balances when removing an unowned shielded receive', async () => {
+    expect.hasAssertions();
+
+    // Raw fixture (token_data = 1, no claimed address, no primed mock) → the
+    // output ingests as `unowned`; no balance row is ever created.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    const txHash = fixture.event.data.hash;
+
+    resetCtCryptoMock();
+
+    const acceptContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+    await handleVertexAccepted(acceptContext as any, undefined as any);
+
+    // Sanity: unowned satellite written, no balance row.
+    const [satBefore] = await mysql.query<any[]>(
+      `SELECT * FROM shielded_tx_output_data WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(satBefore).toHaveLength(1);
+    const [wbBefore] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_balance WHERE token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbBefore).toHaveLength(0);
+
+    const removedContext = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: buildRemovedEvent(fixture),
+    };
+    await handleVertexRemoved(removedContext as any, undefined as any);
+
+    // tx_output + satellite deleted; still no balance row anywhere.
+    const [txoAfter] = await mysql.query<any[]>(
+      `SELECT * FROM tx_output WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(txoAfter).toHaveLength(0);
+    const [satAfter] = await mysql.query<any[]>(
+      `SELECT * FROM shielded_tx_output_data WHERE tx_id = ? AND \`index\` = 1`,
+      [txHash],
+    );
+    expect(satAfter).toHaveLength(0);
+    const [wbAfter] = await mysql.query<any[]>(
+      `SELECT * FROM wallet_balance WHERE token_id = ?`,
+      [TOKEN_ID],
+    );
+    expect(wbAfter).toHaveLength(0);
   });
 });

--- a/packages/daemon/__tests__/services/totalSupply.test.ts
+++ b/packages/daemon/__tests__/services/totalSupply.test.ts
@@ -1,0 +1,746 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Tests for `token.total_supply` tracking in `handleVertexAccepted` and
+ * `handleTokenCreated`.
+ *
+ * Coverage:
+ *  - Token creation sets total_supply to the SUM of non-authority transparent
+ *    outputs in the creation tx (path 1).
+ *  - Block reward increases HTR total_supply on every block (path 2).
+ *  - Mint, melt, and burn-address outputs apply a signed delta via
+ *    `sum(outputs except burn) - sum(inputs)` (path 3).
+ *  - The shielded gate suppresses path 3 when the vertex carries any shielded
+ *    output, leaving total_supply unchanged.
+ */
+
+import * as db from '../../src/db';
+import {
+  handleTokenCreated,
+  handleVertexAccepted,
+  handleVoidedTx,
+  handleUnvoidedTx,
+  handleVertexRemoved,
+} from '../../src/services';
+import { LRU } from '../../src/utils';
+import { cleanDatabase } from '../utils';
+import { Connection } from 'mysql2/promise';
+import hathorLib from '@hathor/wallet-lib';
+
+/**
+ * @jest-environment node
+ */
+
+// Use a single mysql connection across tests.
+let mysql: Connection;
+
+beforeAll(async () => {
+  try {
+    mysql = await db.getDbConnection();
+  } catch (e) {
+    console.error('Failed to establish db connection', e);
+    throw e;
+  }
+});
+
+afterAll(async () => {
+  if (mysql) {
+    await mysql.destroy();
+  }
+});
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+});
+
+const HTR_TOKEN_ID = hathorLib.constants.NATIVE_TOKEN_UID;
+const AUTHORITY_BIT = hathorLib.constants.TOKEN_AUTHORITY_MASK;
+const BURN_ADDRESS = 'HDeadDeadDeadDeadDeadDeadDeagTPgmn';
+
+// Fixed P2PKH script and decoded shape — value/address-only tests don't care
+// about the script bytes. Use a benign placeholder.
+const SCRIPT_B64 = 'dqkU91U6sMdzgT3zxOtdIVGbqobP0FmIrA==';
+
+const seedToken = async (tokenId: string, totalSupply: bigint): Promise<void> => {
+  await mysql.query(
+    `INSERT INTO token (id, name, symbol, total_supply) VALUES (?, ?, ?, ?)`,
+    [tokenId, `name-${tokenId}`, `S${tokenId.slice(0, 3)}`, totalSupply.toString()],
+  );
+};
+
+const selectTotalSupply = async (tokenId: string): Promise<bigint> => {
+  const [rows] = await mysql.query<any[]>(
+    `SELECT total_supply FROM token WHERE id = ?`,
+    [tokenId],
+  );
+  if (rows.length === 0) throw new Error(`Token ${tokenId} not seeded`);
+  return BigInt(rows[0].total_supply);
+};
+
+// Build a NEW_VERTEX_ACCEPTED context. The shape matches what
+// `handleVertexAccepted` reads from `context.event.event.data` plus the
+// scaffolding fields it touches on `context` itself.
+const buildVertexContext = (data: any) => ({
+  socket: undefined,
+  healthcheck: undefined,
+  retryAttempt: 0,
+  initialEventId: null,
+  txCache: new LRU(100),
+  rewardMinBlocks: 300,
+  event: {
+    stream_id: 'stream-id',
+    peer_id: 'peer-id',
+    network: 'mainnet',
+    type: 'FULLNODE_EVENT',
+    latest_event_id: 1,
+    event: {
+      id: 1,
+      timestamp: 1700000000,
+      type: 'NEW_VERTEX_ACCEPTED',
+      data,
+    },
+  },
+});
+
+// Compose a transparent (mode=0) tx_output event entry — value-bearing or
+// authority depending on `tokenData`. The decoded address resolves correctly
+// for both transparent and burn-bound outputs.
+const transparentOutput = (
+  value: number | bigint,
+  tokenData: number,
+  address: string,
+) => ({
+  value,
+  script: SCRIPT_B64,
+  token_data: tokenData,
+  decoded: {
+    type: 'P2PKH',
+    address,
+    timelock: null,
+  },
+});
+
+// Compose a tx_input pointing at a value-bearing spent output. The daemon
+// reads `spent_output.value` and `spent_output.token_data` only.
+const transparentInput = (
+  parentTxId: string,
+  index: number,
+  value: number | bigint,
+  tokenData: number,
+  address: string,
+) => ({
+  tx_id: parentTxId,
+  index,
+  spent_output: {
+    mode: 0,
+    value,
+    script: SCRIPT_B64,
+    token_data: tokenData,
+    decoded: {
+      type: 'P2PKH',
+      address,
+      timelock: null,
+    },
+  },
+});
+
+// Minimal data block matching `TxEventDataSchema`. Fields not asserted by the
+// supply-update path may be defaulted.
+const buildVertexData = (overrides: Partial<{
+  hash: string;
+  outputs: any[];
+  inputs: any[];
+  tokens: string[];
+  shielded_outputs: any[];
+  version: number;
+  height: number | null;
+  first_block: string | null;
+}> = {}) => ({
+  hash: overrides.hash ?? 'a'.repeat(64),
+  nonce: 0,
+  timestamp: 1700000000,
+  version: overrides.version ?? 1,
+  weight: 1,
+  signal_bits: 0,
+  inputs: overrides.inputs ?? [],
+  outputs: overrides.outputs ?? [],
+  shielded_outputs: overrides.shielded_outputs ?? [],
+  parents: [],
+  tokens: overrides.tokens ?? [],
+  token_name: null,
+  token_symbol: null,
+  metadata: {
+    hash: overrides.hash ?? 'a'.repeat(64),
+    voided_by: [],
+    first_block: overrides.first_block ?? null,
+    height: overrides.height ?? 100,
+  },
+  aux_pow: null,
+});
+
+describe('token.total_supply tracking', () => {
+  it('token creation sets total_supply from wire initial_amount', async () => {
+    expect.hasAssertions();
+
+    // Regular CREATE_TOKEN_TX: token_uid === tx_id by convention.
+    const tokenId = 'token-creation-001';
+    const txId = tokenId;
+
+    // The transparent outputs here are not consulted: handleTokenCreated
+    // now reads `initial_amount` from the wire payload directly. Their
+    // sum (1000) intentionally differs from `initial_amount` (12345) to
+    // prove the wire value wins.
+    await db.addOrUpdateTx(mysql, txId, null, 1700000000, 1, 1, null);
+    await mysql.query(
+      `INSERT INTO tx_output (tx_id, \`index\`, token_id, address, value, authorities, locked, voided, mode)
+       VALUES
+         (?, 0, ?, 'addr-mint-a', 600, 0, 0, 0, 0),
+         (?, 1, ?, 'addr-mint-b', 400, 0, 0, 0, 0),
+         (?, 2, ?, 'addr-auth',   0,   1, 0, 0, 0)`,
+      [txId, tokenId, txId, tokenId, txId, tokenId],
+    );
+
+
+    const context = {
+      socket: undefined,
+      healthcheck: undefined,
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      event: {
+        stream_id: 'stream-id',
+        peer_id: 'peer-id',
+        network: 'mainnet',
+        type: 'FULLNODE_EVENT',
+        latest_event_id: 1,
+        event: {
+          id: 1,
+          timestamp: 1700000000,
+          type: 'TOKEN_CREATED',
+          data: {
+            token_uid: tokenId,
+            nc_exec_info: null,
+            token_name: 'CreationToken',
+            token_symbol: 'CRT',
+            token_version: 1,
+            initial_amount: 12345,
+          },
+          group_id: null,
+        },
+      },
+    };
+
+    await handleTokenCreated(context as any);
+
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(12345n);
+  });
+
+  it('token creation falls back to 0 when initial_amount is absent on the wire', async () => {
+    expect.hasAssertions();
+
+    const tokenId = 'token-creation-no-amount';
+    const txId = tokenId;
+
+    // Seed a creation tx with outputs that, under the old SUM-based
+    // logic, would have produced a non-zero supply. Under the new logic
+    // an absent `initial_amount` should produce total_supply = 0.
+    await db.addOrUpdateTx(mysql, txId, null, 1700000000, 1, 1, null);
+    await mysql.query(
+      `INSERT INTO tx_output (tx_id, \`index\`, token_id, address, value, authorities, locked, voided, mode)
+       VALUES (?, 0, ?, 'addr-x', 999, 0, 0, 0, 0)`,
+      [txId, tokenId],
+    );
+
+    const context = {
+      socket: undefined,
+      healthcheck: undefined,
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      event: {
+        stream_id: 'stream-id',
+        peer_id: 'peer-id',
+        network: 'mainnet',
+        type: 'FULLNODE_EVENT',
+        latest_event_id: 1,
+        event: {
+          id: 1,
+          timestamp: 1700000000,
+          type: 'TOKEN_CREATED',
+          data: {
+            token_uid: tokenId,
+            nc_exec_info: null,
+            token_name: 'NoAmount',
+            token_symbol: 'NA',
+            token_version: 1,
+          },
+          group_id: null,
+        },
+      },
+    };
+
+    await handleTokenCreated(context as any);
+
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(0n);
+  });
+
+  it('mint tx increments total_supply by the minted delta', async () => {
+    expect.hasAssertions();
+
+    const tokenId = 'token-mint-001';
+    await seedToken(tokenId, 1000n);
+
+    // Inputs: one melt authority (no value). Outputs: 500 value at tokens[0],
+    // plus a fresh mint authority. Mint delta = 500 - 0 = +500.
+    const data = buildVertexData({
+      hash: 'b'.repeat(64),
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 1n, AUTHORITY_BIT | 1, 'addr-prev-auth')],
+      outputs: [
+        transparentOutput(500, 1, 'addr-recipient'),
+        transparentOutput(1, AUTHORITY_BIT | 1, 'addr-new-auth'),
+      ],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1500n);
+  });
+
+  it('melt tx decreases total_supply by the melted delta', async () => {
+    expect.hasAssertions();
+
+    const tokenId = 'token-melt-001';
+    await seedToken(tokenId, 1000n);
+
+    // Inputs: 800 value-bearing. Outputs: 500 to a recipient (no burn, no
+    // mint). Net delta = 500 - 800 = -300.
+    const data = buildVertexData({
+      hash: 'c'.repeat(64),
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 800n, 1, 'addr-prev-holder')],
+      outputs: [transparentOutput(500, 1, 'addr-recipient')],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(700n);
+  });
+
+  it('transparent output to BURN_ADDRESS decreases total_supply', async () => {
+    expect.hasAssertions();
+
+    const tokenId = 'token-burn-001';
+    await seedToken(tokenId, 1000n);
+
+    // Inputs: 100 value-bearing. Outputs: 60 to a recipient + 40 to burn.
+    // Net delta = 60 (recipient) - 100 (input) = -40 — the burn appears
+    // naturally as the missing-from-outputs leg.
+    const data = buildVertexData({
+      hash: 'd'.repeat(64),
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 100n, 1, 'addr-source')],
+      outputs: [
+        transparentOutput(60, 1, 'addr-recipient'),
+        transparentOutput(40, 1, BURN_ADDRESS),
+      ],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(960n);
+  });
+
+  it('mint+burn in the same tx applies the net delta', async () => {
+    expect.hasAssertions();
+
+    const tokenId = 'token-mix-001';
+    await seedToken(tokenId, 50n);
+
+    // Plan example: inputs = 50, outputs = 70 alice + 30 BURN + 50 bob, mint
+    // authority output present. With burn-exclusion folded into path 3:
+    //   delta = (70 + 50) - 50 = +70.
+    const data = buildVertexData({
+      hash: 'e'.repeat(64),
+      tokens: [tokenId],
+      inputs: [
+        transparentInput('parent-tx', 0, 50n, 1, 'addr-prev-holder'),
+        transparentInput('parent-tx', 1, 1n, AUTHORITY_BIT | 1, 'addr-prev-auth'),
+      ],
+      outputs: [
+        transparentOutput(70, 1, 'addr-alice'),
+        transparentOutput(30, 1, BURN_ADDRESS),
+        transparentOutput(50, 1, 'addr-bob'),
+        transparentOutput(1, AUTHORITY_BIT | 1, 'addr-new-auth'),
+      ],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(120n);
+  });
+
+  it('mint tx with any shielded output leaves total_supply unchanged (gate fires)', async () => {
+    expect.hasAssertions();
+
+    const tokenId = 'token-gate-001';
+    await seedToken(tokenId, 1000n);
+
+    // Same shape as the mint case, but with a shielded output present. The
+    // path-3 gate must suppress the supply update.
+    const data = buildVertexData({
+      hash: 'f'.repeat(64),
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 1n, AUTHORITY_BIT | 1, 'addr-prev-auth')],
+      outputs: [
+        transparentOutput(500, 1, 'addr-recipient'),
+        transparentOutput(1, AUTHORITY_BIT | 1, 'addr-new-auth'),
+      ],
+      shielded_outputs: [{
+        mode: 1,
+        commitment: '02'.repeat(33),
+        range_proof: '03'.repeat(64),
+        script: '04'.repeat(20),
+        ephemeral_pubkey: '05'.repeat(33),
+        token_data: 0,
+        decoded: { address: 'WShieldedAddrGate1' },
+      }],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1000n);
+  });
+
+  it('block accepted adds the block reward to HTR total_supply', async () => {
+    expect.hasAssertions();
+
+    await seedToken(HTR_TOKEN_ID, 1_000_000n);
+
+    // Version 0 is BLOCK_VERSION. The first output's value is the coinbase.
+    const data = buildVertexData({
+      hash: '1'.repeat(64),
+      version: hathorLib.constants.BLOCK_VERSION,
+      tokens: [],
+      inputs: [],
+      outputs: [transparentOutput(6400, 0, 'addr-miner')],
+      height: 100,
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+
+    expect(await selectTotalSupply(HTR_TOKEN_ID)).toStrictEqual(1_006_400n);
+  });
+
+  it('applyTokenSupplyUpdates on CREATE_TOKEN_TX does not write the new token row', async () => {
+    expect.hasAssertions();
+
+    // CREATE_TOKEN_TX vertex: the freshly-minted token row does NOT exist
+    // yet — handleTokenCreated is what inserts it later via a separate
+    // TOKEN_CREATED event. The per-token supply-delta loop in
+    // handleVertexAccepted runs first against the same vertex and would
+    // historically have tried to insert the token row from a positive
+    // delta; with the UPDATE-only contract, that write must no-op.
+    const tokenId = 'token-create-vertex-001';
+    const txId = 'd'.repeat(64);
+
+    const data = buildVertexData({
+      hash: txId,
+      version: hathorLib.constants.CREATE_TOKEN_TX_VERSION,
+      tokens: [tokenId],
+      // No inputs (pretending the deposit was zero for simplicity). The
+      // single output for the new token would produce a per-token delta
+      // of +500, which incrementTokenTotalSupply must not turn into an
+      // INSERT against `token`.
+      inputs: [],
+      outputs: [transparentOutput(500, 1, 'addr-mint-recipient')],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+
+    const [rows] = await mysql.query<any[]>(
+      `SELECT total_supply FROM token WHERE id = ?`,
+      [tokenId],
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('CREATE_TOKEN_TX (version 2) leaves HTR and the created token total_supply untouched', async () => {
+    expect.hasAssertions();
+
+    // CREATE_TOKEN_TX: token_id === tx_id. The created token's supply is owned
+    // by handleTokenCreated (from the wire initial_amount); seed it here as if
+    // that event already landed. The vertex also consumes an HTR deposit
+    // (100 in, 99 change). applyTokenSupplyUpdates must skip version-2 entirely
+    // so neither the created token (would otherwise gain the +500 mint delta)
+    // nor HTR (would otherwise lose the 1 HTR deposit) is altered on ingest.
+    const txId = 'a1'.repeat(32);
+    const tokenId = txId;
+
+    await seedToken(HTR_TOKEN_ID, 1_000_000n);
+    await mysql.query(
+      `INSERT INTO token (id, name, symbol, total_supply) VALUES (?, 'Created', 'CRT', 500)`,
+      [tokenId],
+    );
+
+    const data = buildVertexData({
+      hash: txId,
+      version: hathorLib.constants.CREATE_TOKEN_TX_VERSION,
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 100n, 0, 'addr-depositor')],
+      outputs: [
+        transparentOutput(99, 0, 'addr-change'),
+        transparentOutput(500, 1, 'addr-mint-recipient'),
+      ],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+
+    expect(await selectTotalSupply(HTR_TOKEN_ID)).toStrictEqual(1_000_000n);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(500n);
+  });
+});
+
+describe('token.total_supply reversal on void / unvoid / remove', () => {
+  // The void / remove handlers carry no wire event of their own — they read
+  // the to-be-reversed vertex back out of the DB. Build the context shape they
+  // consume from the same `data` block the accept path used.
+  const buildReverseContext = (data: any) => ({
+    socket: undefined,
+    healthcheck: undefined,
+    retryAttempt: 0,
+    initialEventId: null,
+    txCache: new LRU(100),
+    rewardMinBlocks: 300,
+    event: {
+      stream_id: 'stream-id',
+      peer_id: 'peer-id',
+      network: 'mainnet',
+      type: 'FULLNODE_EVENT',
+      latest_event_id: 2,
+      event: {
+        id: 2,
+        data: {
+          hash: data.hash,
+          outputs: data.outputs,
+          inputs: data.inputs,
+          tokens: data.tokens,
+          version: data.version,
+          headers: [],
+        },
+      },
+    },
+  });
+
+  // The shielded satellite is not part of the shared cleanDatabase table set.
+  beforeEach(async () => {
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+  afterEach(async () => {
+    await mysql.query('DELETE FROM shielded_tx_output_data');
+  });
+
+  it('reverses the block reward when a block vertex is voided', async () => {
+    expect.hasAssertions();
+    await seedToken(HTR_TOKEN_ID, 1_000_000n);
+
+    const data = buildVertexData({
+      hash: '1'.repeat(64),
+      version: hathorLib.constants.BLOCK_VERSION,
+      tokens: [],
+      inputs: [],
+      outputs: [transparentOutput(6400, 0, 'addr-miner')],
+      height: 100,
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+    expect(await selectTotalSupply(HTR_TOKEN_ID)).toStrictEqual(1_006_400n);
+
+    await handleVoidedTx(buildReverseContext(data) as any);
+    expect(await selectTotalSupply(HTR_TOKEN_ID)).toStrictEqual(1_000_000n);
+  });
+
+  it('reverses the mint delta when a mint vertex is voided', async () => {
+    expect.hasAssertions();
+    const tokenId = 'token-mint-void';
+    await seedToken(tokenId, 1000n);
+
+    const data = buildVertexData({
+      hash: 'b'.repeat(64),
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 1n, AUTHORITY_BIT | 1, 'addr-prev-auth')],
+      outputs: [
+        transparentOutput(500, 1, 'addr-recipient'),
+        transparentOutput(1, AUTHORITY_BIT | 1, 'addr-new-auth'),
+      ],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1500n);
+
+    await handleVoidedTx(buildReverseContext(data) as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1000n);
+  });
+
+  it('reverses a burn (re-credits supply) when a burn vertex is voided', async () => {
+    expect.hasAssertions();
+    const tokenId = 'token-burn-void';
+    await seedToken(tokenId, 1000n);
+
+    const data = buildVertexData({
+      hash: 'c'.repeat(64),
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 100n, 1, 'addr-source')],
+      outputs: [
+        transparentOutput(60, 1, 'addr-recipient'),
+        transparentOutput(40, 1, BURN_ADDRESS),
+      ],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(960n);
+
+    await handleVoidedTx(buildReverseContext(data) as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1000n);
+  });
+
+  it('round-trips: ingest -> void -> unvoid restores total_supply', async () => {
+    expect.hasAssertions();
+    const tokenId = 'token-mint-roundtrip';
+    await seedToken(tokenId, 1000n);
+
+    const data = buildVertexData({
+      hash: '9'.repeat(64),
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 1n, AUTHORITY_BIT | 1, 'addr-prev-auth')],
+      outputs: [
+        transparentOutput(500, 1, 'addr-recipient'),
+        transparentOutput(1, AUTHORITY_BIT | 1, 'addr-new-auth'),
+      ],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1500n);
+
+    await handleVoidedTx(buildReverseContext(data) as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1000n);
+
+    // Unvoid = cleanupVoidedTx (delete the voided rows) followed by the state
+    // machine's re-ingest. Mirror that here: the re-ingest re-applies the
+    // forward supply delta, restoring the post-ingest state.
+    await handleUnvoidedTx(buildReverseContext(data) as any);
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1500n);
+  });
+
+  it('leaves total_supply untouched when voiding a vertex with shielded outputs', async () => {
+    expect.hasAssertions();
+    const tokenId = 'token-gate-void';
+    await seedToken(tokenId, 1000n);
+
+    // A mint-shaped vertex that also carries a shielded output: the path-3 gate
+    // suppressed the supply update on ingest, so the void reversal must be
+    // gated identically and leave total_supply at its seeded value.
+    const data = buildVertexData({
+      hash: 'f'.repeat(64),
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 1n, AUTHORITY_BIT | 1, 'addr-prev-auth')],
+      outputs: [
+        transparentOutput(500, 1, 'addr-recipient'),
+        transparentOutput(1, AUTHORITY_BIT | 1, 'addr-new-auth'),
+      ],
+      shielded_outputs: [{
+        mode: 1,
+        commitment: '02'.repeat(33),
+        range_proof: '03'.repeat(64),
+        script: '04'.repeat(20),
+        ephemeral_pubkey: '05'.repeat(33),
+        token_data: 0,
+        decoded: { address: 'WShieldedAddrGateVoid' },
+      }],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1000n);
+
+    await handleVoidedTx(buildReverseContext(data) as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1000n);
+  });
+
+  it('reverses the mint delta when a mint vertex is removed (reorg)', async () => {
+    expect.hasAssertions();
+    const tokenId = 'token-mint-remove';
+    await seedToken(tokenId, 1000n);
+
+    const data = buildVertexData({
+      hash: '7'.repeat(64),
+      tokens: [tokenId],
+      inputs: [transparentInput('parent-tx', 0, 1n, AUTHORITY_BIT | 1, 'addr-prev-auth')],
+      outputs: [
+        transparentOutput(500, 1, 'addr-recipient'),
+        transparentOutput(1, AUTHORITY_BIT | 1, 'addr-new-auth'),
+      ],
+    });
+
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1500n);
+
+    await handleVertexRemoved(buildReverseContext(data) as any, undefined as any);
+    // The token pre-existed this vertex, so it is not deleted — only the mint
+    // delta is reversed.
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(1000n);
+  });
+
+  it('void of a token-creation vertex deletes the token without underflowing total_supply', async () => {
+    expect.hasAssertions();
+
+    // CREATE_TOKEN_TX: token_uid === tx_id by convention. A token CREATED by
+    // the voided vertex is reversed by its row deletion (deleteTokens), never by
+    // a supply delta — applyTokenSupplyUpdates skips version-2 entirely, so the
+    // void reversal does not run for the created token. We seed initial_amount
+    // (300) deliberately LOWER than the token output sum (1000): a signed
+    // reversal against the still-present row would compute 300 - 1000 and
+    // underflow the UNSIGNED total_supply column, erroring out the whole void.
+    // The version-2 skip prevents that.
+    const tokenId = 'a'.repeat(64);
+    const txId = tokenId;
+
+    const data = buildVertexData({
+      hash: txId,
+      version: hathorLib.constants.CREATE_TOKEN_TX_VERSION,
+      tokens: [tokenId],
+      inputs: [],
+      outputs: [transparentOutput(1000, 1, 'addr-mint-recipient')],
+    });
+
+    // Ingest the creation vertex. The token row does not exist yet, so the
+    // forward supply delta no-ops (handleTokenCreated is what inserts it).
+    await handleVertexAccepted(buildVertexContext(data) as any, undefined as any);
+
+    // Simulate the TOKEN_CREATED event: insert the token row + token_creation
+    // record and set total_supply from the (lower) wire initial_amount.
+    // (Insert directly rather than via seedToken — a 64-char token_id would
+    // overflow the token.name column there.)
+    await mysql.query(
+      `INSERT INTO token (id, name, symbol, total_supply) VALUES (?, 'CreateVoid', 'CV', 300)`,
+      [tokenId],
+    );
+    await db.insertTokenCreation(mysql, tokenId, txId);
+    expect(await selectTotalSupply(tokenId)).toStrictEqual(300n);
+
+    // Void the creation vertex. Must not throw (no underflow) and must drop
+    // the token row entirely.
+    await handleVoidedTx(buildReverseContext(data) as any);
+
+    const [rows] = await mysql.query<any[]>(
+      `SELECT total_supply FROM token WHERE id = ?`,
+      [tokenId],
+    );
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/daemon/__tests__/utils.ts
+++ b/packages/daemon/__tests__/utils.ts
@@ -88,7 +88,7 @@ export const createEventTxInput = (
     tx_id: txId,
     index,
     spent_output: {
-      mode: 0 as const,
+      mode: 0,
       value,
       token_data: tokenData,
       script: 'dqkUCEboPJo9txn548FA/NLLaMLsfsSIrA==',

--- a/packages/daemon/__tests__/utils/helpers.test.ts
+++ b/packages/daemon/__tests__/utils/helpers.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { parseNullableBigInt } from '../../src/utils/helpers';
+
+describe('parseNullableBigInt', () => {
+  test('returns null for null', () => {
+    expect(parseNullableBigInt(null)).toBeNull();
+  });
+
+  test('returns null for undefined', () => {
+    expect(parseNullableBigInt(undefined)).toBeNull();
+  });
+
+  test('parses a numeric value into a bigint', () => {
+    expect(parseNullableBigInt(42)).toEqual(42n);
+  });
+
+  test('parses a string value into a bigint', () => {
+    expect(parseNullableBigInt('9007199254740993')).toEqual(9007199254740993n);
+  });
+
+  test('preserves zero (not treated as nullish)', () => {
+    expect(parseNullableBigInt(0)).toEqual(0n);
+    expect(parseNullableBigInt('0')).toEqual(0n);
+  });
+});

--- a/packages/daemon/__tests__/utils/wallet.test.ts
+++ b/packages/daemon/__tests__/utils/wallet.test.ts
@@ -5,8 +5,34 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { EventTxOutput } from '../../src/types';
-import { prepareOutputs } from '../../src/utils';
+import { Connection } from 'mysql2/promise';
+import { constants } from '@hathor/wallet-lib';
+import {
+  EventTxHeader,
+  EventTxInput,
+  EventTxOutput,
+  ShieldedOutput,
+} from '../../src/types';
+import {
+  getInvolvedAddresses,
+  getUnifiedBalanceMap,
+  prepareInputs,
+  prepareOutputs,
+  unlockUtxos,
+} from '../../src/utils';
+import {
+  getDbConnection,
+  getExpiredTimelocksUtxos,
+  insertTxOutput,
+} from '../../src/db';
+import { cleanDatabase } from '../utils';
+import {
+  ShieldedOutputMode,
+  RecoveryState,
+  TokenBalanceMap,
+  TxInput,
+  TxOutputWithIndex,
+} from '@wallet-service/common';
 
 /**
  * @jest-environment node
@@ -44,5 +70,334 @@ describe('prepareOutputs', () => {
 
     expect(preparedOutputs).toHaveLength(2);
     expect(preparedOutputs.find((output) => output.script === nftOutputs[0].script)).toBeUndefined();
+  });
+});
+
+describe('unlockUtxos dispatch', () => {
+  let mysql: Connection;
+
+  beforeAll(async () => {
+    try {
+      mysql = await getDbConnection();
+    } catch (e) {
+      console.error('Failed to establish db connection', e);
+      throw e;
+    }
+  });
+
+  afterAll(() => {
+    mysql.destroy();
+  });
+
+  beforeEach(async () => {
+    await cleanDatabase(mysql);
+  });
+
+  it('flips locked=false for every row and dispatches balance updates by (mode, recovery_state)', async () => {
+    expect.hasAssertions();
+
+    // Seed three locked rows: transparent, shielded recovered, shielded unowned.
+    await insertTxOutput(mysql, {
+      tx_id: 'T_t',
+      index: 0,
+      mode: ShieldedOutputMode.Transparent,
+      address: 'addr_t',
+      value: 100n,
+      token_id: '00',
+      authorities: 0,
+      timelock: 5,
+      heightlock: null,
+      locked: true,
+      voided: false,
+      recovery_state: null,
+    });
+    await insertTxOutput(mysql, {
+      tx_id: 'T_sr',
+      index: 0,
+      mode: ShieldedOutputMode.AmountShielded,
+      address: 'addr_sr',
+      value: 150n,
+      token_id: '00',
+      authorities: 0,
+      timelock: 5,
+      heightlock: null,
+      locked: true,
+      voided: false,
+      recovery_state: RecoveryState.Recovered,
+    });
+    await insertTxOutput(mysql, {
+      tx_id: 'T_su',
+      index: 0,
+      mode: ShieldedOutputMode.AmountShielded,
+      address: 'addr_su',
+      value: null,
+      token_id: '00',
+      authorities: 0,
+      timelock: 5,
+      heightlock: null,
+      locked: true,
+      voided: false,
+      recovery_state: RecoveryState.Unowned,
+    });
+
+    // Wallet that owns both addr_t (transparent) and addr_sr (shielded).
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', 'xpub123', 'xpub456', 'ready', 20, ?, ?)`,
+      [Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)],
+    );
+
+    // addr_legacy -> wallet_alice (Legacy ownership, bip32_account = 0)
+    await mysql.query(
+      `INSERT INTO \`address\` (\`address\`, \`index\`, \`wallet_id\`, \`bip32_account\`, \`transactions\`)
+       VALUES (?, 0, 'wallet_alice', 0, 1)`,
+      ['addr_t'],
+    );
+
+    // addr_ctspend -> wallet_alice (CTSpend ownership, bip32_account = 2)
+    await mysql.query(
+      `INSERT INTO \`address\` (\`address\`, \`index\`, \`wallet_id\`, \`bip32_account\`, \`scan_privkey\`, \`transactions\`)
+       VALUES (?, 0, 'wallet_alice', 2, ?, 1)`,
+      ['addr_sr', Buffer.alloc(32, 0x42)],
+    );
+
+    // Pre-load wallet_balance: 100 transparent locked + 150 shielded locked.
+    // The unified unlock SQL writes both column families in one statement;
+    // each side's locked amount is what its own UTXO will decrement.
+    await mysql.query(
+      `INSERT INTO \`wallet_balance\`
+         (wallet_id, token_id,
+          unlocked_balance, locked_balance,
+          unlocked_shielded_balance, locked_shielded_balance,
+          total_received, total_shielded_received,
+          unlocked_authorities, locked_authorities, transactions)
+       VALUES ('wallet_alice', '00', 0, 100, 0, 150, 100, 150, 0, 0, 1)`,
+    );
+
+    // address_balance for the transparent address: 100 transparent locked.
+    await mysql.query(
+      `INSERT INTO \`address_balance\`
+         (address, token_id, unlocked_balance, locked_balance,
+          unlocked_shielded_balance, locked_shielded_balance,
+          unlocked_authorities, locked_authorities,
+          total_received, total_shielded_received, transactions)
+       VALUES ('addr_t', '00', 0, 100, 0, 0, 0, 0, 100, 0, 1)`,
+    );
+    // address_balance for the shielded address: 150 shielded locked, no
+    // transparent activity (addr_sr has only ever held shielded UTXOs).
+    await mysql.query(
+      `INSERT INTO \`address_balance\`
+         (address, token_id, unlocked_balance, locked_balance,
+          unlocked_shielded_balance, locked_shielded_balance,
+          unlocked_authorities, locked_authorities,
+          total_received, total_shielded_received, transactions)
+       VALUES ('addr_sr', '00', 0, 0, 0, 150, 0, 0, 0, 150, 1)`,
+    );
+
+    // getExpiredTimelocksUtxos now returns rows of every mode (filter reverted).
+    const expired = await getExpiredTimelocksUtxos(mysql, 10);
+    expect(expired).toHaveLength(3);
+
+    await unlockUtxos(mysql, expired, true);
+
+    // Row-level lock flag flipped for all 3 rows, regardless of mode.
+    const [lockedRows] = await mysql.query<any[]>(
+      `SELECT COUNT(*) AS c
+         FROM \`tx_output\`
+        WHERE \`locked\` = TRUE
+          AND \`tx_id\` IN (?, ?, ?)`,
+      ['T_t', 'T_sr', 'T_su'],
+    );
+    expect(Number(lockedRows[0].c)).toBe(0);
+
+    // wallet_balance: the unified unlock writes both column families in one
+    // statement. Transparent UTXO (100) moves locked → unlocked on the
+    // transparent columns; shielded recovered UTXO (150) moves
+    // locked_shielded → unlocked_shielded on the shielded columns. The
+    // unowned shielded UTXO contributes nothing (its value is unknown).
+    const [walletBalanceRows] = await mysql.query<any[]>(
+      `SELECT unlocked_balance, locked_balance,
+              unlocked_shielded_balance, locked_shielded_balance
+         FROM \`wallet_balance\`
+        WHERE \`wallet_id\` = 'wallet_alice'
+          AND \`token_id\` = '00'`,
+    );
+    expect(walletBalanceRows).toHaveLength(1);
+    expect(BigInt(walletBalanceRows[0].unlocked_balance)).toBe(100n);
+    expect(BigInt(walletBalanceRows[0].locked_balance)).toBe(0n);
+    expect(BigInt(walletBalanceRows[0].unlocked_shielded_balance)).toBe(150n);
+    expect(BigInt(walletBalanceRows[0].locked_shielded_balance)).toBe(0n);
+
+    // address_balance: addr_t's transparent columns moved locked → unlocked.
+    // addr_sr's shielded columns moved locked_shielded → unlocked_shielded;
+    // its transparent columns are untouched (no transparent activity ever
+    // happened on this shielded scan-path address in this test).
+    const [addrBalanceRows] = await mysql.query<any[]>(
+      `SELECT address, unlocked_balance, locked_balance,
+              unlocked_shielded_balance, locked_shielded_balance
+         FROM \`address_balance\`
+        WHERE \`address\` IN (?, ?)
+        ORDER BY \`address\``,
+      ['addr_sr', 'addr_t'],
+    );
+    expect(addrBalanceRows).toHaveLength(2);
+    const byAddr = Object.fromEntries(addrBalanceRows.map((r: any) => [r.address, r]));
+    expect(BigInt(byAddr.addr_t.unlocked_balance)).toBe(100n);
+    expect(BigInt(byAddr.addr_t.locked_balance)).toBe(0n);
+    expect(BigInt(byAddr.addr_t.unlocked_shielded_balance)).toBe(0n);
+    expect(BigInt(byAddr.addr_t.locked_shielded_balance)).toBe(0n);
+    expect(BigInt(byAddr.addr_sr.unlocked_balance)).toBe(0n);
+    expect(BigInt(byAddr.addr_sr.locked_balance)).toBe(0n);
+    expect(BigInt(byAddr.addr_sr.unlocked_shielded_balance)).toBe(150n);
+    expect(BigInt(byAddr.addr_sr.locked_shielded_balance)).toBe(0n);
+  });
+});
+
+describe('getInvolvedAddresses', () => {
+  const nanoHeader = (ncAddress: string): EventTxHeader => ({
+    id: '10',
+    nc_seqnum: 0,
+    nc_id: 'nc1',
+    nc_method: 'initialize',
+    nc_address: ncAddress,
+  });
+
+  it('skips inputs that carry no spent_output', () => {
+    const inputs = [{ tx_id: 't', index: 0 }] as unknown as EventTxInput[];
+    expect(getInvolvedAddresses(inputs, [], [], []).size).toBe(0);
+  });
+
+  it('skips inputs and outputs whose decode failed (no address)', () => {
+    const inputs = [{
+      tx_id: 't',
+      index: 0,
+      spent_output: { mode: 0, value: 1n, token_data: 0, script: '', decoded: {} },
+    }] as unknown as EventTxInput[];
+    const outputs = [{
+      value: 1n, token_data: 0, script: '', decoded: null,
+    }] as unknown as EventTxOutput[];
+    expect(getInvolvedAddresses(inputs, outputs, [], []).size).toBe(0);
+  });
+
+  it('skips shielded outputs with no decoded.address', () => {
+    const shielded = [{ mode: 1, decoded: {} }] as unknown as ShieldedOutput[];
+    expect(getInvolvedAddresses([], [], shielded, []).size).toBe(0);
+  });
+
+  it('adds the nano-header nc_address', () => {
+    expect([...getInvolvedAddresses([], [], [], [nanoHeader('Hnano')])]).toEqual(['Hnano']);
+  });
+
+  it('dedupes an address that appears in multiple sources', () => {
+    const addr = 'Hdup';
+    const inputs = [{
+      tx_id: 't',
+      index: 0,
+      spent_output: {
+        mode: 0, value: 1n, token_data: 0, script: '',
+        decoded: { type: 'P2PKH', address: addr, timelock: null },
+      },
+    }] as unknown as EventTxInput[];
+    const outputs = [{
+      value: 1n, token_data: 0, script: '',
+      decoded: { type: 'P2PKH', address: addr, timelock: null },
+    }] as unknown as EventTxOutput[];
+    const shielded = [{ mode: 1, decoded: { address: addr } }] as unknown as ShieldedOutput[];
+
+    expect([...getInvolvedAddresses(inputs, outputs, shielded, [])]).toEqual([addr]);
+  });
+});
+
+describe('prepareInputs', () => {
+  // A valid base64 P2PKH script — the Output model only stores the buffer,
+  // so any base64 works for these filter/decode assertions.
+  const P2PKH_SCRIPT_B64 = 'dqkUCU1EY3YLi8WURhDOEsspok4Y0XiIrA==';
+
+  const transparentInput = (txId: string, tokenData: number, decoded: unknown): EventTxInput => ({
+    tx_id: txId,
+    index: 0,
+    spent_output: {
+      mode: 0,
+      value: 100n,
+      token_data: tokenData,
+      script: P2PKH_SCRIPT_B64,
+      decoded,
+    },
+  }) as unknown as EventTxInput;
+
+  it('drops shielded inputs, keeping only the transparent ones', () => {
+    const inputs = [
+      transparentInput('t0', 0, { type: 'P2PKH', address: 'H1', timelock: null }),
+      { tx_id: 't1', index: 0, spent_output: { mode: 1 } },
+      { tx_id: 't2', index: 0, spent_output: { mode: 2 } },
+    ] as unknown as EventTxInput[];
+
+    const result = prepareInputs(inputs, []);
+    expect(result).toHaveLength(1);
+    expect(result[0].tx_id).toBe('t0');
+  });
+
+  it('resolves the token uid from the tokens array for a custom-token input', () => {
+    const tokens = ['000013f562dc216890f247688028754a49d21dbb2b1f7731f840dc65585b1d57'];
+    const result = prepareInputs(
+      [transparentInput('t0', 1, { type: 'P2PKH', address: 'H1', timelock: null })],
+      tokens,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].token).toBe(tokens[0]);
+  });
+
+  it('sets decoded to null for a transparent input with an invalid decode', () => {
+    const result = prepareInputs([transparentInput('t0', 0, {})], []);
+    expect(result).toHaveLength(1);
+    expect(result[0].decoded).toBeNull();
+  });
+});
+
+describe('getUnifiedBalanceMap (pure portions)', () => {
+  // The shielded-input reversal is the only branch that touches the DB, and it
+  // only runs for shielded `eventInputs`. These tests pass none, so the mysql
+  // handle is never dereferenced.
+  const noopMysql = {} as any;
+
+  it('throws when an output has no decoded script', async () => {
+    const outputs = [{
+      value: 1n, script: '', token: '00', decoded: null,
+      spent_by: null, token_data: 0, index: 0,
+    }] as unknown as TxOutputWithIndex[];
+
+    await expect(getUnifiedBalanceMap(noopMysql, [], outputs, [], [], []))
+      .rejects.toThrow('Output has no decoded script');
+  });
+
+  it('throws when a decoded output has no address', async () => {
+    const outputs = [{
+      value: 1n, script: '', token: '00',
+      decoded: { type: 'P2PKH', timelock: null },
+      spent_by: null, token_data: 0, index: 0,
+    }] as unknown as TxOutputWithIndex[];
+
+    await expect(getUnifiedBalanceMap(noopMysql, [], outputs, [], [], []))
+      .rejects.toThrow('Decoded output data has no address');
+  });
+
+  it('skips transparent inputs with an invalid decode', async () => {
+    const inputs = [{
+      tx_id: 't', index: 0, value: 1n, token_data: 0, script: '', token: '00', decoded: null,
+    }] as unknown as TxInput[];
+
+    const map = await getUnifiedBalanceMap(noopMysql, inputs, [], [], [], []);
+    expect(Object.keys(map)).toHaveLength(0);
+  });
+
+  it('seeds an empty HTR entry for a nano-header address', async () => {
+    const headers = [{
+      id: '10', nc_seqnum: 0, nc_id: 'nc1', nc_method: 'initialize', nc_address: 'Hnano',
+    }] as unknown as EventTxHeader[];
+
+    const map = await getUnifiedBalanceMap(noopMysql, [], [], [], [], headers);
+    expect(Object.keys(map)).toEqual(['Hnano']);
+    expect(map.Hnano).toBeInstanceOf(TokenBalanceMap);
+    expect(map.Hnano.get(constants.NATIVE_TOKEN_UID)).toBeDefined();
   });
 });

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -254,7 +254,7 @@ export interface InsertTxOutputArgs {
   locked: boolean;
   voided: boolean;
   spent_by?: string | null;
-  recovery_state: 'unowned' | 'recovered' | 'recovery_failed' | null;
+  recovery_state: RecoveryState | null;
 }
 
 /**

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -28,7 +28,7 @@ import {
   TxOutputWithIndex,
   Balance,
 } from '@wallet-service/common';
-import { isAuthority, toTokenVersion } from '@wallet-service/common';
+import { isAuthority, toTokenVersion, RecoveryState, Bip32Account } from '@wallet-service/common';
 import { getWalletBalanceMap } from '../utils/wallet';
 import {
   AddressBalanceRow,
@@ -235,13 +235,351 @@ export const addUtxos = async (
 };
 
 /**
- * Remove a tx inputs from the utxo table.
+ * Arguments for inserting a single tx_output row.
+ *
+ * Supports transparent (mode=0), AmountShielded (mode=1) and FullyShielded (mode=2) rows.
+ * `value` and `token_id` are nullable to accommodate unrecovered shielded outputs where
+ * either the amount, the token, or both are not yet known.
+ */
+export interface InsertTxOutputArgs {
+  tx_id: string;
+  index: number;
+  mode: number;
+  address: string;
+  value: bigint | null;
+  token_id: string | null;
+  authorities: number;
+  timelock: number | null;
+  heightlock: number | null;
+  locked: boolean;
+  voided: boolean;
+  spent_by?: string | null;
+  recovery_state: 'unowned' | 'recovered' | 'recovery_failed' | null;
+}
+
+/**
+ * Insert a single row into `tx_output`.
+ *
+ * Idempotent against re-ingest of the same vertex: `ON DUPLICATE KEY UPDATE address = VALUES(address)`
+ * re-writes a no-op same value when the (tx_id, index) primary key already exists.
  *
  * @param mysql - Database connection
- * @param inputs - The transaction inputs
+ * @param args - The row to insert
+ */
+export const insertTxOutput = async (
+  mysql: any,
+  args: InsertTxOutputArgs,
+): Promise<void> => {
+  await mysql.query(
+    `INSERT INTO \`tx_output\`
+       (\`tx_id\`, \`index\`, \`mode\`, \`address\`, \`value\`, \`token_id\`, \`authorities\`,
+        \`timelock\`, \`heightlock\`, \`locked\`, \`voided\`, \`spent_by\`, \`recovery_state\`)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+       address = VALUES(address)`,
+    [
+      args.tx_id,
+      args.index,
+      args.mode,
+      args.address,
+      args.value,
+      args.token_id,
+      args.authorities,
+      args.timelock,
+      args.heightlock,
+      args.locked,
+      args.voided,
+      args.spent_by ?? null,
+      args.recovery_state,
+    ],
+  );
+};
+
+/**
+ * Arguments for inserting a single `shielded_tx_output_data` satellite row.
+ *
+ * The satellite carries the per-output cryptographic payload that accompanies a
+ * shielded `tx_output`. The parent `tx_output(tx_id, index)` row must exist
+ * first — the foreign key is `ON DELETE CASCADE`, so cleanup follows the parent.
+ *
+ * Per-mode field conventions:
+ * - mode=1 (AmountShielded): `token_data` carries the plaintext token index;
+ *   `asset_commitment` and `surjection_proof` are NULL.
+ * - mode=2 (FullyShielded): `asset_commitment` and `surjection_proof` carry the
+ *   per-output asset proofs; `token_data` is NULL.
+ */
+export interface InsertShieldedDataArgs {
+  tx_id: string;
+  index: number;
+  mode: 1 | 2;
+  commitment: Buffer;
+  range_proof: Buffer;
+  script: Buffer;
+  ephemeral_pubkey: Buffer;
+  token_data?: number | null;
+  asset_commitment?: Buffer | null;
+  surjection_proof?: Buffer | null;
+}
+
+/**
+ * Insert a single row into `shielded_tx_output_data`.
+ *
+ * Idempotent against re-ingest of the same vertex via
+ * `ON DUPLICATE KEY UPDATE commitment = VALUES(commitment)` (a no-op rewrite
+ * when the (tx_id, index) primary key already exists).
+ *
+ * The caller is responsible for inserting the parent `tx_output` row first;
+ * this helper assumes the FK target exists.
+ *
+ * @param conn - Database connection
+ * @param args - The satellite row to insert
+ */
+export const insertShieldedTxOutputData = async (
+  conn: any,
+  args: InsertShieldedDataArgs,
+): Promise<void> => {
+  await conn.query(
+    `INSERT INTO \`shielded_tx_output_data\`
+       (\`tx_id\`, \`index\`, \`commitment\`, \`range_proof\`, \`script\`, \`ephemeral_pubkey\`,
+        \`token_data\`, \`asset_commitment\`, \`surjection_proof\`)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+       commitment = VALUES(commitment)`,
+    [
+      args.tx_id,
+      args.index,
+      args.commitment,
+      args.range_proof,
+      args.script,
+      args.ephemeral_pubkey,
+      args.token_data ?? null,
+      args.asset_commitment ?? null,
+      args.surjection_proof ?? null,
+    ],
+  );
+};
+
+/**
+ * Record an observation of a CTSpend-derived address in the unified `address`
+ * table.
+ *
+ * Used at observation time: the daemon has seen a shielded `tx_output` whose
+ * destination address it does not (yet) own. The row is inserted with just
+ * `address` and `transactions = 0`. Ownership and derivation-slot fields
+ * (`wallet_id`, `index`, `bip32_account`, `scan_privkey`, `catchup_state`,
+ * `ct_address`) stay NULL until a wallet registration claims this address
+ * — that's the step that knows the derivation account and writes
+ * `bip32_account = Bip32Account.CTSpend` along with the scan key and
+ * long-form CT address.
+ *
+ * This helper does NOT bump `transactions`. The single canonical
+ * `transactions` bump per `(address, tx)` lives exclusively in
+ * `bumpAddressInvolvement`, which runs once per vertex against the
+ * wire-level involved-addresses set and covers every address regardless of
+ * ownership or recovery state. Using `INSERT IGNORE` makes the observation
+ * a row-existence guarantee with no on-conflict side effect — any
+ * registration data attached to the row by a previous wallet claim is
+ * preserved untouched across repeated observations.
+ *
+ * @param conn - Database connection
+ * @param address - The P2PKH spend address (CTSpend-derived) observed as the
+ *   destination of a shielded `tx_output`
+ */
+export async function upsertShieldedAddressObservation(
+  conn: any,
+  address: string,
+): Promise<void> {
+  await conn.query(
+    `INSERT IGNORE INTO \`address\` (\`address\`, \`transactions\`)
+     VALUES (?, 0)`,
+    [address],
+  );
+}
+
+/**
+ * Ownership info for a CTSpend-derived address that has been claimed by a
+ * wallet.
+ */
+export interface ShieldedAddressOwnership {
+  wallet_id: string;
+  shielded_index: number;
+  scan_privkey: Buffer;
+}
+
+/**
+ * Look up CTSpend ownership info for an address on the unified `address`
+ * table.
+ *
+ * Filters on `bip32_account = Bip32Account.CTSpend` so the CT-derived row
+ * is isolated from any Legacy row that might exist for the same P2PKH
+ * address (both account paths can produce the same on-chain address by
+ * accident, though deterministically unlikely). Returns ownership only when
+ * a wallet has claimed the address (`wallet_id IS NOT NULL`) and the scan
+ * key has been recorded (`scan_privkey IS NOT NULL`).
+ *
+ * Used during recovery to look up the scan key associated with an observed
+ * shielded output.
+ *
+ * @param conn - Database connection
+ * @param address - The shielded P2PKH spend address to look up
+ * @returns Ownership info when the address is owned by a wallet, otherwise null
+ */
+export async function findShieldedAddressOwnership(
+  conn: any,
+  address: string,
+): Promise<ShieldedAddressOwnership | null> {
+  const [rows] = await conn.query(
+    `SELECT wallet_id, \`index\` AS shielded_index, scan_privkey
+       FROM address
+      WHERE address = ?
+        AND bip32_account = ?
+        AND wallet_id IS NOT NULL
+        AND scan_privkey IS NOT NULL`,
+    [address, Bip32Account.CTSpend],
+  );
+  if (!rows || rows.length === 0) return null;
+  return {
+    wallet_id: rows[0].wallet_id,
+    shielded_index: rows[0].shielded_index,
+    scan_privkey: rows[0].scan_privkey,
+  };
+}
+
+/**
+ * Promote a shielded tx_output from 'unowned' to 'recovered' once the
+ * wallet's scan key has successfully rewound the commitment, revealing
+ * the value (and the token id, for AmountShielded outputs).
+ *
+ * The UPDATE is guarded on the current recovery_state being 'unowned'
+ * so a re-ingest of the same vertex is a no-op (returns affectedRows = 0).
+ * Callers can use affectedRows to detect the idempotent case.
+ */
+export async function markTxOutputRecovered(
+  conn: any,
+  txId: string,
+  index: number,
+  recovered: { value: bigint; token_id: string },
+): Promise<{ affectedRows: number }> {
+  const [r] = await conn.query(
+    `UPDATE tx_output
+        SET value = ?, token_id = ?, recovery_state = 'recovered'
+      WHERE tx_id = ? AND \`index\` = ? AND recovery_state = 'unowned'`,
+    [recovered.value.toString(), recovered.token_id, txId, index],
+  );
+  return { affectedRows: r.affectedRows };
+}
+
+/**
+ * Record that the rewind threw for an output we believed we owned.
+ * Terminal state — we don't keep retrying. Same idempotency guard as
+ * markTxOutputRecovered.
+ */
+export async function markTxOutputRecoveryFailed(
+  conn: any,
+  txId: string,
+  index: number,
+): Promise<void> {
+  await conn.query(
+    `UPDATE tx_output
+        SET recovery_state = 'recovery_failed'
+      WHERE tx_id = ? AND \`index\` = ? AND recovery_state = 'unowned'`,
+    [txId, index],
+  );
+}
+
+/**
+ * Set `token.total_supply` to an absolute value.
+ *
+ * Used at token creation time to record the initial mint amount.
+ */
+export async function setTokenTotalSupply(
+  conn: any,
+  tokenId: string,
+  value: bigint,
+): Promise<void> {
+  await conn.execute(
+    'UPDATE token SET total_supply = ? WHERE id = ?',
+    [value.toString(), tokenId],
+  );
+}
+
+/**
+ * Apply a signed delta to `token.total_supply`.
+ *
+ * MySQL handles signed arithmetic against an UNSIGNED column as long as the
+ * result is non-negative. A correctly-tracked supply can never go below zero;
+ * any negative result is a bug worth surfacing (the UPDATE would error).
+ *
+ * Used by mint/melt detection, the burn-address sweep, and block-reward
+ * dispatch in `handleVertexAccepted`. Void/unvoid sign-reversal is wired in
+ * a follow-up phase.
+ *
+ * Invariant: this helper is UPDATE-only. It does NOT insert a `token`
+ * row when one doesn't exist — `applyTokenSupplyUpdates` only ever
+ * mutates existing token rows, and `handleTokenCreated` is the single
+ * inserter (it calls `storeTokenInformation` followed by
+ * `setTokenTotalSupply`). A delta against a not-yet-created token row
+ * naturally no-ops here. The two writers never compete on the same
+ * column.
+ */
+export async function incrementTokenTotalSupply(
+  conn: any,
+  tokenId: string,
+  delta: bigint,
+): Promise<void> {
+  await conn.execute(
+    'UPDATE token SET total_supply = total_supply + ? WHERE id = ?',
+    [delta.toString(), tokenId],
+  );
+}
+
+/**
+ * Bump `address.transactions` by 1 for each address in the involvement set.
+ *
+ * Insert-or-increment using a single batched statement. Mirrors the
+ * existing per-balance bump inside `updateAddressTablesWithTx`, but is
+ * decoupled from the balance map so shielded-credit-only,
+ * shielded-spend-only and unowned-shielded-output vertices still bump the
+ * counter once per involved address. This is the only writer of the
+ * involvement counter for a given (address, tx) pair; the per-token
+ * counter (`address_balance.transactions`) is still owned by the
+ * balance-map-driven path further downstream.
+ *
+ * No-op when the set is empty.
+ */
+export async function bumpAddressInvolvement(
+  mysql: any,
+  addresses: Iterable<string>,
+): Promise<void> {
+  const entries: [string, number][] = [];
+  for (const addr of addresses) {
+    entries.push([addr, 1]);
+  }
+  if (entries.length === 0) return;
+  await mysql.query(
+    `INSERT INTO \`address\`(\`address\`, \`transactions\`)
+          VALUES ?
+              ON DUPLICATE KEY UPDATE transactions = transactions + 1`,
+    [entries],
+  );
+}
+
+/**
+ * Mark spent tx outputs by setting `spent_by` on the matching rows.
+ *
+ * Kind-agnostic: takes any `{tx_id, index}` shape (TxInput, EventTxInput,
+ * or a custom thin type), so it works for transparent and shielded
+ * inputs uniformly. The query only consumes the primary-key columns.
+ *
+ * @param mysql - Database connection
+ * @param inputs - The spent input references (tx_id + index per entry)
  * @param txId - The transaction that spent these utxos
  */
-export const updateTxOutputSpentBy = async (mysql: any, inputs: TxInput[], txId: string): Promise<void> => {
+export const updateTxOutputSpentBy = async (
+  mysql: any,
+  inputs: Array<{ tx_id: string; index: number }>,
+  txId: string,
+): Promise<void> => {
   const entries = inputs.map((input) => [input.tx_id, input.index]);
   // entries might be empty if there are no inputs
   if (entries.length) {
@@ -297,9 +635,9 @@ export const getTxOutputsFromTx = async (
     const utxo: DbTxOutput = {
       txId: result.tx_id as string,
       index: result.index as number,
-      tokenId: result.token_id as string,
+      tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: BigInt(result.value),
+      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,
@@ -307,6 +645,8 @@ export const getTxOutputsFromTx = async (
       txProposalId: result.tx_proposal as string,
       txProposalIndex: result.tx_proposal_index as number,
       spentBy: result.spent_by ? result.spent_by as string : null,
+      mode: result.mode as number,
+      recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
     };
     utxos.push(utxo);
   }
@@ -341,9 +681,9 @@ export const getTxOutputs = async (
     const utxo: DbTxOutput = {
       txId: result.tx_id as string,
       index: result.index as number,
-      tokenId: result.token_id as string,
+      tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: BigInt(result.value),
+      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,
@@ -351,6 +691,8 @@ export const getTxOutputs = async (
       txProposalId: result.tx_proposal as string,
       txProposalIndex: result.tx_proposal_index as number,
       spentBy: result.spent_by ? result.spent_by as string : null,
+      mode: result.mode as number,
+      recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
     };
     utxos.push(utxo);
   }
@@ -424,9 +766,9 @@ export const getTxOutputsAtHeight = async (
     const utxo: DbTxOutput = {
       txId: result.tx_id as string,
       index: result.index as number,
-      tokenId: result.token_id as string,
+      tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: BigInt(result.value),
+      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,
@@ -434,6 +776,8 @@ export const getTxOutputsAtHeight = async (
       spentBy: result.spent_by as string,
       txProposalId: result.tx_proposal as string,
       txProposalIndex: result.tx_proposal_index as number,
+      mode: result.mode as number,
+      recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
     };
     utxos.push(utxo);
   }
@@ -740,28 +1084,24 @@ export const updateAddressTablesWithTx = async (
     // No need to do anything here
     return;
   }
-  /*
-   * update address table
-   *
-   * If an address is not yet present, add entry with index = null, walletId = null and transactions = 1.
-   * Later, when the corresponding wallet is started, index and walletId will be updated.
-   *
-   * If address is already present, just increment the transactions counter.
-   */
-  const addressEntries = Object.keys(addressBalanceMap).map((address) => [address, 1]);
-  if (addressEntries.length > 0) {
-    await mysql.query(
-      `INSERT INTO \`address\`(\`address\`, \`transactions\`)
-            VALUES ?
-                ON DUPLICATE KEY UPDATE transactions = transactions + 1`,
-      [addressEntries],
-    );
-  }
+  // The per-address `address.transactions` bump is handled by the central
+  // `bumpAddressInvolvement` helper earlier in the vertex pipeline, which
+  // is driven by the wire-level involvement set so it covers
+  // shielded-credit-only, shielded-spend-only, and unowned shielded
+  // vertices alongside the transparent ones. This function is now only
+  // responsible for the per-(address, token) row writes.
 
   const entries = [];
   for (const [address, tokenMap] of Object.entries(addressBalanceMap)) {
     for (const [token, tokenBalance] of tokenMap.iterator()) {
       // update address_balance table or update balance and transactions if there's an entry already
+      // Shielded balance columns are clamped to 0 on the insert branch
+      // because MySQL's STRICT_TRANS_TABLES (8.0 default) validates the
+      // VALUES(...) literal against the UNSIGNED column type before
+      // selecting the UPDATE branch. The real signed delta is applied in
+      // the ON DUPLICATE KEY UPDATE branch via the positional bind args
+      // below. totalShieldedReceived is already non-negative by the
+      // fromShielded() factory contract (lifetime accumulator).
       const entry = {
         address,
         token_id: token,
@@ -775,6 +1115,9 @@ export const updateAddressTablesWithTx = async (
         unlocked_authorities: tokenBalance.unlockedAuthorities.toUnsignedInteger(),
         locked_authorities: tokenBalance.lockedAuthorities.toUnsignedInteger(),
         timelock_expires: tokenBalance.lockExpires,
+        unlocked_shielded_balance: (tokenBalance.unlockedShieldedAmount < 0n ? 0n : tokenBalance.unlockedShieldedAmount),
+        locked_shielded_balance: (tokenBalance.lockedShieldedAmount < 0n ? 0n : tokenBalance.lockedShieldedAmount),
+        total_shielded_received: tokenBalance.totalShieldedReceived,
         transactions: 1,
       };
       // save the smaller value of timelock_expires, when not null
@@ -785,6 +1128,9 @@ export const updateAddressTablesWithTx = async (
                             UPDATE total_received = total_received + ?,
                                    unlocked_balance = unlocked_balance + ?,
                                    locked_balance = locked_balance + ?,
+                                   unlocked_shielded_balance = unlocked_shielded_balance + ?,
+                                   locked_shielded_balance = locked_shielded_balance + ?,
+                                   total_shielded_received = total_shielded_received + ?,
                                    transactions = transactions + 1,
                                    timelock_expires = CASE
                                                         WHEN timelock_expires IS NULL THEN VALUES(timelock_expires)
@@ -793,7 +1139,17 @@ export const updateAddressTablesWithTx = async (
                                                       END,
                                    unlocked_authorities = (unlocked_authorities | VALUES(unlocked_authorities)),
                                    locked_authorities = locked_authorities | VALUES(locked_authorities)`,
-        [entry, tokenBalance.totalAmountSent, tokenBalance.unlockedAmount, tokenBalance.lockedAmount, address, token],
+        [
+          entry,
+          tokenBalance.totalAmountSent,
+          tokenBalance.unlockedAmount,
+          tokenBalance.lockedAmount,
+          tokenBalance.unlockedShieldedAmount,
+          tokenBalance.lockedShieldedAmount,
+          tokenBalance.totalShieldedReceived,
+          address,
+          token,
+        ],
       );
 
       // if we're removing any of the authorities, we need to refresh the authority columns. Unlike the values,
@@ -821,18 +1177,30 @@ export const updateAddressTablesWithTx = async (
       // unlocked before it can be spent. In case we're just adding new locked authorities, this will be taken
       // care by the first sql query.
 
-      // update address_tx_history with one entry for each pair (address, token)
-      entries.push([address, txId, token, tokenBalance.total(), timestamp]);
+      // update address_tx_history with one entry for each pair (address, token).
+      // `balance` is the transparent delta (signed unlocked + locked) and
+      // `shielded_balance_delta` is the shielded delta (signed
+      // unlockedShielded + lockedShielded); the two columns live on the
+      // same row keyed by (address, tx_id, token_id).
+      const transparentDelta = tokenBalance.unlockedAmount + tokenBalance.lockedAmount;
+      const shieldedDelta = tokenBalance.unlockedShieldedAmount + tokenBalance.lockedShieldedAmount;
+      entries.push([address, txId, token, transparentDelta, shieldedDelta, timestamp]);
     }
   }
 
-  await mysql.query(
-    `INSERT INTO \`address_tx_history\`(\`address\`, \`tx_id\`,
-                                        \`token_id\`, \`balance\`,
-                                        \`timestamp\`)
-     VALUES ?`,
-    [entries],
-  );
+  if (entries.length > 0) {
+    await mysql.query(
+      `INSERT INTO \`address_tx_history\`(\`address\`, \`tx_id\`,
+                                          \`token_id\`, \`balance\`,
+                                          \`shielded_balance_delta\`,
+                                          \`timestamp\`)
+       VALUES ?
+       ON DUPLICATE KEY UPDATE \`balance\` = VALUES(\`balance\`),
+                               \`shielded_balance_delta\` = VALUES(\`shielded_balance_delta\`),
+                               \`timestamp\` = VALUES(\`timestamp\`)`,
+      [entries],
+    );
+  }
 };
 
 /**
@@ -897,13 +1265,15 @@ export const getUtxosLockedAtHeight = async (
       const utxo: DbTxOutput = {
         txId: result.tx_id as string,
         index: result.index as number,
-        tokenId: result.token_id as string,
+        tokenId: result.token_id as string | null,
         address: result.address as string,
-        value: BigInt(result.value),
+        value: result.value === null || result.value === undefined ? null : BigInt(result.value),
         authorities: result.authorities as number,
         timelock: result.timelock as number,
         heightlock: result.heightlock as number,
         locked: Number(result.locked) > 0,
+        mode: result.mode as number,
+        recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
       };
       utxos.push(utxo);
     }
@@ -936,9 +1306,18 @@ export const unlockUtxos = async (mysql: MysqlConnection, utxos: TxInput[]): Pro
  * The balance of an address might change as a locked amount becomes unlocked. This function updates
  * the address_balance table, subtracting from the locked column and adding to the unlocked column.
  *
+ * The SQL writes both transparent (`unlocked_balance` / `locked_balance`) and shielded
+ * (`unlocked_shielded_balance` / `locked_shielded_balance`) column families in one statement.
+ * Each `TokenBalance` carries both `unlockedAmount` (transparent delta) and `unlockedShieldedAmount`
+ * (shielded delta); for a transparent-only unlock the shielded deltas are 0, and vice versa.
+ *
+ * `timelock_expires` is refreshed whenever an unlock landed on this address — transparent or
+ * shielded. The column tracks the earliest expiry across ALL locked UTXOs (mode 0, 1, or 2)
+ * for the address; the refresh `SELECT MIN(timelock)` is intentionally kind-agnostic.
+ *
  * @param mysql - Database connection
  * @param addressBalanceMap - A map of addresses and the unlocked balances
- * @param updateTimelock - If this update is triggered by a timelock expiring, update the next expire timestamp
+ * @param updateTimelocks - If this update is triggered by a timelock expiring, update the next expire timestamp
  */
 export const updateAddressLockedBalance = async (
   mysql: MysqlConnection,
@@ -951,11 +1330,15 @@ export const updateAddressLockedBalance = async (
         `UPDATE \`address_balance\`
             SET \`unlocked_balance\` = \`unlocked_balance\` + ?,
                 \`locked_balance\` = \`locked_balance\` - ?,
+                \`unlocked_shielded_balance\` = \`unlocked_shielded_balance\` + ?,
+                \`locked_shielded_balance\` = \`locked_shielded_balance\` - ?,
                 \`unlocked_authorities\` = (unlocked_authorities | ?)
           WHERE \`address\` = ?
             AND \`token_id\` = ?`, [
         tokenBalance.unlockedAmount,
         tokenBalance.unlockedAmount,
+        tokenBalance.unlockedShieldedAmount,
+        tokenBalance.unlockedShieldedAmount,
         tokenBalance.unlockedAuthorities.toInteger(),
         address,
         token,
@@ -963,6 +1346,7 @@ export const updateAddressLockedBalance = async (
       );
 
       // if any authority has been unlocked, we have to refresh the locked authorities
+      // (shielded outputs cannot carry authority, so this only fires for transparent unlocks)
       if (tokenBalance.unlockedAuthorities.toInteger() > 0) {
         await mysql.execute(
           `UPDATE \`address_balance\`
@@ -980,7 +1364,10 @@ export const updateAddressLockedBalance = async (
         );
       }
 
-      // if this is being unlocked due to a timelock, also update the timelock_expires column
+      // Refresh timelock_expires whenever this update is triggered by a timelock expiry.
+      // The SELECT MIN is kind-agnostic: shielded outputs can also carry timelocks, and the
+      // column's contract is "earliest locked UTXO's expiry" across all kinds. Mode 1/2
+      // unowned rows have NULL timelock and naturally fall out of the MIN.
       if (updateTimelocks) {
         await mysql.execute(`
           UPDATE \`address_balance\`
@@ -1051,6 +1438,17 @@ export const getAddressWalletInfo = async (mysql: MysqlConnection, addresses: st
  * The balance of a wallet might change as a locked amount becomes unlocked. This function updates
  * the wallet_balance table, subtracting from the locked column and adding to the unlocked column.
  *
+ * The SQL writes both transparent (`unlocked_balance` / `locked_balance`) and shielded
+ * (`unlocked_shielded_balance` / `locked_shielded_balance`) column families in one statement.
+ * Each `TokenBalance` carries both `unlockedAmount` (transparent delta) and `unlockedShieldedAmount`
+ * (shielded delta); for a transparent-only unlock the shielded deltas are 0, and vice versa.
+ * Authority bits only ever move on the transparent path (shielded outputs cannot carry authority).
+ *
+ * `timelock_expires` is refreshed whenever `updateTimelocks` is true. The aggregating SELECT
+ * pulls `MIN(timelock_expires)` from every `address_balance` row owned by the wallet — those
+ * rows themselves already track the per-address earliest expiry across kinds (see
+ * {@link updateAddressLockedBalance}), so the wallet aggregation is kind-agnostic by construction.
+ *
  * @param mysql - Database connection
  * @param walletBalanceMap - A map of walletId and the unlocked balances
  * @param updateTimelocks - If this update is triggered by a timelock expiring, update the next lock expiration
@@ -1066,14 +1464,24 @@ export const updateWalletLockedBalance = async (
         `UPDATE \`wallet_balance\`
             SET \`unlocked_balance\` = \`unlocked_balance\` + ?,
                 \`locked_balance\` = \`locked_balance\` - ?,
+                \`unlocked_shielded_balance\` = \`unlocked_shielded_balance\` + ?,
+                \`locked_shielded_balance\` = \`locked_shielded_balance\` - ?,
                 \`unlocked_authorities\` = (\`unlocked_authorities\` | ?)
           WHERE \`wallet_id\` = ?
             AND \`token_id\` = ?`,
-        [tokenBalance.unlockedAmount, tokenBalance.unlockedAmount,
-        tokenBalance.unlockedAuthorities.toInteger(), walletId, token],
+        [
+          tokenBalance.unlockedAmount,
+          tokenBalance.unlockedAmount,
+          tokenBalance.unlockedShieldedAmount,
+          tokenBalance.unlockedShieldedAmount,
+          tokenBalance.unlockedAuthorities.toInteger(),
+          walletId,
+          token,
+        ],
       );
 
       // if any authority has been unlocked, we have to refresh the locked authorities
+      // (shielded outputs cannot carry authority, so this only fires for transparent unlocks)
       if (tokenBalance.unlockedAuthorities.toInteger() > 0) {
         await mysql.execute(
           `UPDATE \`wallet_balance\`
@@ -1091,7 +1499,10 @@ export const updateWalletLockedBalance = async (
         );
       }
 
-      // if this is being unlocked due to a timelock, also update the timelock_expires column
+      // Refresh timelock_expires whenever this update is triggered by a timelock expiry.
+      // The aggregation pulls MIN(timelock_expires) from every address_balance row owned by
+      // the wallet; those per-address rows are already kind-agnostic (transparent and shielded
+      // earliest expiries fold into the same column), so this aggregation is kind-agnostic too.
       if (updateTimelocks) {
         await mysql.execute(
           `UPDATE \`wallet_balance\`
@@ -1193,9 +1604,9 @@ export const getExpiredTimelocksUtxos = async (
 export const mapDbResultToDbTxOutput = (result: TxOutputRow): DbTxOutput => ({
   txId: result.tx_id as string,
   index: result.index as number,
-  tokenId: result.token_id as string,
+  tokenId: result.token_id as string | null,
   address: result.address as string,
-  value: BigInt(result.value),
+  value: result.value === null || result.value === undefined ? null : BigInt(result.value),
   authorities: result.authorities as number,
   timelock: result.timelock as number,
   heightlock: result.heightlock as number,
@@ -1203,6 +1614,8 @@ export const mapDbResultToDbTxOutput = (result: TxOutputRow): DbTxOutput => ({
   txProposalId: result.tx_proposal as string,
   txProposalIndex: result.tx_proposal_index as number,
   spentBy: result.spent_by as string,
+  mode: result.mode as number,
+  recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
 });
 
 /**
@@ -1355,13 +1768,15 @@ export const getLockedUtxoFromInputs = async (mysql: MysqlConnection, inputs: Ev
     return results.map((utxo) => ({
       txId: utxo.tx_id as string,
       index: utxo.index as number,
-      tokenId: utxo.token_id as string,
+      tokenId: utxo.token_id as string | null,
       address: utxo.address as string,
-      value: BigInt(utxo.value),
+      value: utxo.value === null || utxo.value === undefined ? null : BigInt(utxo.value),
       authorities: utxo.authorities as number,
       timelock: utxo.timelock as number,
       heightlock: utxo.heightlock as number,
       locked: utxo.locked ? Boolean(utxo.locked) : false,
+      mode: utxo.mode as number,
+      recoveryState: (utxo.recovery_state ?? null) as RecoveryState | null,
     }));
   }
 
@@ -1451,6 +1866,10 @@ export const updateWalletTablesWithTx = async (
       // as (tokenBalance < 0 ? 0 : tokenBalance). In case the wallet's balance in this tx is negative,
       // there must necessarily be an entry already and we'll fall on the ON DUPLICATE KEY case, so the
       // entry value won't be used. We'll just update balance = balance + tokenBalance
+      // Shielded balance columns are clamped to 0 on insert (see
+      // updateAddressTablesWithTx for the strict-mode rationale). The
+      // signed delta is applied in the ON DUPLICATE KEY UPDATE branch via
+      // positional bind args.
       const entry = {
         wallet_id: walletId,
         token_id: token,
@@ -1462,6 +1881,9 @@ export const updateWalletTablesWithTx = async (
         unlocked_authorities: tokenBalance.unlockedAuthorities.toUnsignedInteger(),
         locked_authorities: tokenBalance.lockedAuthorities.toUnsignedInteger(),
         timelock_expires: tokenBalance.lockExpires,
+        unlocked_shielded_balance: (tokenBalance.unlockedShieldedAmount < 0n ? 0n : tokenBalance.unlockedShieldedAmount),
+        locked_shielded_balance: (tokenBalance.lockedShieldedAmount < 0n ? 0n : tokenBalance.lockedShieldedAmount),
+        total_shielded_received: tokenBalance.totalShieldedReceived,
         transactions: 1,
       };
 
@@ -1473,6 +1895,9 @@ export const updateWalletTablesWithTx = async (
          UPDATE total_received = total_received + ?,
                 unlocked_balance = unlocked_balance + ?,
                 locked_balance = locked_balance + ?,
+                unlocked_shielded_balance = unlocked_shielded_balance + ?,
+                locked_shielded_balance = locked_shielded_balance + ?,
+                total_shielded_received = total_shielded_received + ?,
                 transactions = transactions + 1,
                 timelock_expires = CASE WHEN timelock_expires IS NULL THEN VALUES(timelock_expires)
                                         WHEN VALUES(timelock_expires) IS NULL THEN timelock_expires
@@ -1480,7 +1905,17 @@ export const updateWalletTablesWithTx = async (
                                    END,
                 unlocked_authorities = (unlocked_authorities | VALUES(unlocked_authorities)),
                 locked_authorities = locked_authorities | VALUES(locked_authorities)`,
-        [entry, tokenBalance.totalAmountSent, tokenBalance.unlockedAmount, tokenBalance.lockedAmount, walletId, token],
+        [
+          entry,
+          tokenBalance.totalAmountSent,
+          tokenBalance.unlockedAmount,
+          tokenBalance.lockedAmount,
+          tokenBalance.unlockedShieldedAmount,
+          tokenBalance.lockedShieldedAmount,
+          tokenBalance.totalShieldedReceived,
+          walletId,
+          token,
+        ],
       );
 
       // same logic here as in the updateAddressTablesWithTx function
@@ -1505,7 +1940,12 @@ export const updateWalletTablesWithTx = async (
         );
       }
 
-      entries.push([walletId, token, txId, tokenBalance.total(), timestamp]);
+      // `balance` is the transparent delta; `shielded_balance_delta` is
+      // the signed shielded delta (positive on credit, negative on the
+      // reversal of a previously-recovered shielded UTXO being spent).
+      const transparentDelta = tokenBalance.unlockedAmount + tokenBalance.lockedAmount;
+      const shieldedDelta = tokenBalance.unlockedShieldedAmount + tokenBalance.lockedShieldedAmount;
+      entries.push([walletId, token, txId, transparentDelta, shieldedDelta, timestamp]);
     }
   }
 
@@ -1513,8 +1953,11 @@ export const updateWalletTablesWithTx = async (
     await mysql.query(
       `INSERT INTO \`wallet_tx_history\` (\`wallet_id\`, \`token_id\`,
                                           \`tx_id\`, \`balance\`,
+                                          \`shielded_balance_delta\`,
                                           \`timestamp\`)
-            VALUES ?`,
+            VALUES ?
+       ON DUPLICATE KEY UPDATE \`balance\` = VALUES(\`balance\`),
+                               \`shielded_balance_delta\` = VALUES(\`shielded_balance_delta\`)`,
       [entries],
     );
   }
@@ -1568,9 +2011,9 @@ export const getTxOutputsBySpent = async (
     const utxo: DbTxOutput = {
       txId: result.tx_id as string,
       index: result.index as number,
-      tokenId: result.token_id as string,
+      tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: BigInt(result.value),
+      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,
@@ -1578,6 +2021,8 @@ export const getTxOutputsBySpent = async (
       txProposalId: result.tx_proposal as string,
       txProposalIndex: result.tx_proposal_index as number,
       spentBy: result.spent_by ? result.spent_by as string : null,
+      mode: result.mode as number,
+      recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
     };
 
     utxos.push(utxo);
@@ -1784,9 +2229,9 @@ export const getTxOutputsHeightUnlockedAtHeight = async (
     const utxo: DbTxOutput = {
       txId: result.tx_id as string,
       index: result.index as number,
-      tokenId: result.token_id as string,
+      tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: BigInt(result.value),
+      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,
@@ -1794,6 +2239,8 @@ export const getTxOutputsHeightUnlockedAtHeight = async (
       txProposalId: result.tx_proposal as string,
       txProposalIndex: result.tx_proposal_index as number,
       spentBy: result.spent_by ? result.spent_by as string : null,
+      mode: result.mode as number,
+      recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
     };
     utxos.push(utxo);
   }

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -409,6 +409,43 @@ export interface ShieldedAddressOwnership {
 }
 
 /**
+ * Batch variant of `findShieldedAddressOwnership`.
+ *
+ * Takes a list of addresses and returns a `Map<address, ShieldedAddressOwnership>`
+ * for every address that is owned (bip32_account = CTSpend, wallet_id and
+ * scan_privkey populated). Addresses without a matching row are absent from
+ * the map. Issues a single query regardless of list size; the result Map
+ * naturally deduplicates by address — passing the same address twice returns
+ * one entry.
+ *
+ * Returns an empty map when `addresses` is empty.
+ */
+export async function findShieldedAddressOwnershipBatch(
+  conn: any,
+  addresses: string[],
+): Promise<Map<string, ShieldedAddressOwnership>> {
+  if (addresses.length === 0) return new Map();
+  const [rows] = await conn.query(
+    `SELECT address, wallet_id, \`index\` AS shielded_index, scan_privkey
+       FROM address
+      WHERE address IN (?)
+        AND bip32_account = ?
+        AND wallet_id IS NOT NULL
+        AND scan_privkey IS NOT NULL`,
+    [addresses, Bip32Account.CTSpend],
+  );
+  const result = new Map<string, ShieldedAddressOwnership>();
+  for (const row of rows as any[]) {
+    result.set(row.address, {
+      wallet_id: row.wallet_id,
+      shielded_index: row.shielded_index,
+      scan_privkey: row.scan_privkey,
+    });
+  }
+  return result;
+}
+
+/**
  * Look up CTSpend ownership info for an address on the unified `address`
  * table.
  *
@@ -562,6 +599,36 @@ export async function bumpAddressInvolvement(
     `INSERT INTO \`address\`(\`address\`, \`transactions\`)
           VALUES ?
               ON DUPLICATE KEY UPDATE transactions = transactions + 1`,
+    [entries],
+  );
+}
+
+/**
+ * Decrement `address.transactions` by 1 for each address in the involvement set.
+ *
+ * The void/remove mirror of `bumpAddressInvolvement`: it must be fed the SAME
+ * wire-level involvement set the ingest path bumped (`getInvolvedAddresses`),
+ * not just the balance-map keys — otherwise involvement-only addresses
+ * (unowned shielded outputs, nano `nc_address`es) that carry no balance delta
+ * would be bumped on ingest but never decremented, drifting the counter
+ * upward. Inserts a 0-valued row for an address that somehow doesn't exist yet
+ * (a no-op decrement) so the statement stays a single batched upsert.
+ *
+ * No-op when the set is empty.
+ */
+export async function decrementAddressInvolvement(
+  mysql: any,
+  addresses: Iterable<string>,
+): Promise<void> {
+  const entries: [string, number][] = [];
+  for (const addr of addresses) {
+    entries.push([addr, 0]);
+  }
+  if (entries.length === 0) return;
+  await mysql.query(
+    `INSERT INTO \`address\`(\`address\`, \`transactions\`)
+          VALUES ?
+              ON DUPLICATE KEY UPDATE transactions = transactions - 1`,
     [entries],
   );
 }
@@ -798,9 +865,8 @@ export const getTxOutputsAtHeight = async (
  * @returns {Promise<void>} - A promise that resolves when the address-related data has been updated
  *
  * This function performs the following steps:
- * 1. Inserts addresses with a transaction count of 0 into the `address` table or subtracts 1 from the transaction count if they already exist
- * 2. Iterates over the addressBalanceMap to update the `address_balance` table with the received token balances.
- * 3. Deletes the transaction entry from the `address_tx_history` table.
+ * 1. Iterates over the addressBalanceMap to update the `address_balance` table with the received token balances.
+ * 2. Deletes the transaction entry from the `address_tx_history` table.
  *
  * The function ensures that the authorities are correctly updated and the smallest timelock expiration value is preserved.
  */
@@ -810,17 +876,6 @@ export const voidAddressTransaction = async (
   addressBalanceMap: StringMap<TokenBalanceMap>,
   _version: number,
 ): Promise<void> => {
-  const addressEntries = Object.keys(addressBalanceMap).map((address) => [address, 0]);
-
-  if (addressEntries.length > 0) {
-    await mysql.query(
-      `INSERT INTO \`address\`(\`address\`, \`transactions\`)
-            VALUES ?
-                ON DUPLICATE KEY UPDATE transactions = transactions - 1`,
-      [addressEntries],
-    );
-  }
-
   // Collect all (address, token) pairs and their balances
   const pairs: { address: string; token: string; balance: Balance }[] = [];
   for (const [address, tokenMap] of Object.entries(addressBalanceMap)) {
@@ -859,6 +914,9 @@ export const voidAddressTransaction = async (
       { column: '`unlocked_authorities`', op: 'bitor', getValue: (p) => p.balance.unlockedAuthorities.toUnsignedInteger() },
       // locked_authorities: OR only, no recalculation needed — locked authorities can't be spent before unlocking
       { column: '`locked_authorities`', op: 'bitor', getValue: (p) => p.balance.lockedAuthorities.toUnsignedInteger() },
+      { column: '`unlocked_shielded_balance`', op: 'subtract', getValue: (p) => p.balance.unlockedShieldedAmount },
+      { column: '`locked_shielded_balance`', op: 'subtract', getValue: (p) => p.balance.lockedShieldedAmount },
+      { column: '`total_shielded_received`', op: 'subtract', getValue: (p) => p.balance.totalShieldedReceived },
       // Decrement transactions by 1 for each voided (address, token) pair.
       { column: '`transactions`', op: 'subtract', getValue: () => 1 },
     ],
@@ -905,7 +963,10 @@ export const voidAddressTransaction = async (
     );
   }
 
-  // Clean up fully-zeroed address_balance rows
+  // Clean up fully-zeroed address_balance rows.
+  // Both transparent and shielded column families must be zero before
+  // a row is safe to delete; omitting the shielded guards would
+  // incorrectly drop rows that still hold shielded balance.
   const addressTokenPairs = pairs.map(getAddrKeys);
   await mysql.query(
     `DELETE FROM \`address_balance\`
@@ -915,6 +976,9 @@ export const voidAddressTransaction = async (
         AND \`locked_balance\` = 0
         AND \`unlocked_authorities\` = 0
         AND \`locked_authorities\` = 0
+        AND \`unlocked_shielded_balance\` = 0
+        AND \`locked_shielded_balance\` = 0
+        AND \`total_shielded_received\` = 0
         AND \`transactions\` = 0`,
     [addressTokenPairs],
   );
@@ -1015,6 +1079,9 @@ export const voidWalletTransaction = async (
         { column: '`unlocked_authorities`', op: 'bitor', getValue: (p) => p.balance.unlockedAuthorities.toUnsignedInteger() },
         // locked_authorities: OR only, no recalculation needed — locked authorities can't be spent before unlocking
         { column: '`locked_authorities`', op: 'bitor', getValue: (p) => p.balance.lockedAuthorities.toUnsignedInteger() },
+        { column: '`unlocked_shielded_balance`', op: 'subtract', getValue: (p) => p.balance.unlockedShieldedAmount },
+        { column: '`locked_shielded_balance`', op: 'subtract', getValue: (p) => p.balance.lockedShieldedAmount },
+        { column: '`total_shielded_received`', op: 'subtract', getValue: (p) => p.balance.totalShieldedReceived },
         // Decrement transactions by 1 for each voided (wallet, token) pair.
         { column: '`transactions`', op: 'subtract', getValue: () => 1 },
       ],
@@ -1041,7 +1108,10 @@ export const voidWalletTransaction = async (
       );
     }
 
-    // Clean up fully-zeroed wallet_balance rows
+    // Clean up fully-zeroed wallet_balance rows.
+    // Both transparent and shielded column families must be zero before
+    // a row is safe to delete; omitting the shielded guards would
+    // incorrectly drop rows that still hold shielded balance.
     const walletTokenPairs = pairs.map(getWalletKeys);
     await mysql.query(
       `DELETE FROM \`wallet_balance\`
@@ -1051,6 +1121,9 @@ export const voidWalletTransaction = async (
           AND \`locked_balance\` = 0
           AND \`unlocked_authorities\` = 0
           AND \`locked_authorities\` = 0
+          AND \`unlocked_shielded_balance\` = 0
+          AND \`locked_shielded_balance\` = 0
+          AND \`total_shielded_received\` = 0
           AND \`transactions\` = 0`,
       [walletTokenPairs],
     );

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -30,6 +30,7 @@ import {
 } from '@wallet-service/common';
 import { isAuthority, toTokenVersion, RecoveryState, Bip32Account } from '@wallet-service/common';
 import { getWalletBalanceMap } from '../utils/wallet';
+import { parseNullableBigInt } from '../utils/helpers';
 import {
   AddressBalanceRow,
   AddressTxHistorySumRow,
@@ -638,7 +639,7 @@ export const getTxOutputsFromTx = async (
       index: result.index as number,
       tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
+      value: parseNullableBigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,
@@ -684,7 +685,7 @@ export const getTxOutputs = async (
       index: result.index as number,
       tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
+      value: parseNullableBigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,
@@ -769,7 +770,7 @@ export const getTxOutputsAtHeight = async (
       index: result.index as number,
       tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
+      value: parseNullableBigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,
@@ -1195,10 +1196,7 @@ export const updateAddressTablesWithTx = async (
                                           \`token_id\`, \`balance\`,
                                           \`shielded_balance_delta\`,
                                           \`timestamp\`)
-       VALUES ?
-       ON DUPLICATE KEY UPDATE \`balance\` = VALUES(\`balance\`),
-                               \`shielded_balance_delta\` = VALUES(\`shielded_balance_delta\`),
-                               \`timestamp\` = VALUES(\`timestamp\`)`,
+       VALUES ?`,
       [entries],
     );
   }
@@ -1268,7 +1266,7 @@ export const getUtxosLockedAtHeight = async (
         index: result.index as number,
         tokenId: result.token_id as string | null,
         address: result.address as string,
-        value: result.value === null || result.value === undefined ? null : BigInt(result.value),
+        value: parseNullableBigInt(result.value),
         authorities: result.authorities as number,
         timelock: result.timelock as number,
         heightlock: result.heightlock as number,
@@ -1607,7 +1605,7 @@ export const mapDbResultToDbTxOutput = (result: TxOutputRow): DbTxOutput => ({
   index: result.index as number,
   tokenId: result.token_id as string | null,
   address: result.address as string,
-  value: result.value === null || result.value === undefined ? null : BigInt(result.value),
+  value: parseNullableBigInt(result.value),
   authorities: result.authorities as number,
   timelock: result.timelock as number,
   heightlock: result.heightlock as number,
@@ -1771,7 +1769,7 @@ export const getLockedUtxoFromInputs = async (mysql: MysqlConnection, inputs: Ev
       index: utxo.index as number,
       tokenId: utxo.token_id as string | null,
       address: utxo.address as string,
-      value: utxo.value === null || utxo.value === undefined ? null : BigInt(utxo.value),
+      value: parseNullableBigInt(utxo.value),
       authorities: utxo.authorities as number,
       timelock: utxo.timelock as number,
       heightlock: utxo.heightlock as number,
@@ -1956,9 +1954,7 @@ export const updateWalletTablesWithTx = async (
                                           \`tx_id\`, \`balance\`,
                                           \`shielded_balance_delta\`,
                                           \`timestamp\`)
-            VALUES ?
-       ON DUPLICATE KEY UPDATE \`balance\` = VALUES(\`balance\`),
-                               \`shielded_balance_delta\` = VALUES(\`shielded_balance_delta\`)`,
+            VALUES ?`,
       [entries],
     );
   }
@@ -2014,7 +2010,7 @@ export const getTxOutputsBySpent = async (
       index: result.index as number,
       tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
+      value: parseNullableBigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,
@@ -2232,7 +2228,7 @@ export const getTxOutputsHeightUnlockedAtHeight = async (
       index: result.index as number,
       tokenId: result.token_id as string | null,
       address: result.address as string,
-      value: result.value === null || result.value === undefined ? null : BigInt(result.value),
+      value: parseNullableBigInt(result.value),
       authorities: result.authorities as number,
       timelock: result.timelock as number,
       heightlock: result.heightlock as number,

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -376,10 +376,10 @@ export const insertShieldedTxOutputData = async (
  * `transactions` bump per `(address, tx)` lives exclusively in
  * `bumpAddressInvolvement`, which runs once per vertex against the
  * wire-level involved-addresses set and covers every address regardless of
- * ownership or recovery state. Using `INSERT IGNORE` makes the observation
- * a row-existence guarantee with no on-conflict side effect — any
- * registration data attached to the row by a previous wallet claim is
- * preserved untouched across repeated observations.
+ * ownership or recovery state. The `ON DUPLICATE KEY UPDATE address = address`
+ * no-op makes the observation a row-existence guarantee with no on-conflict
+ * side effect — any registration data attached to the row by a previous wallet
+ * claim is preserved untouched across repeated observations.
  *
  * @param conn - Database connection
  * @param address - The P2PKH spend address (CTSpend-derived) observed as the
@@ -390,8 +390,9 @@ export async function upsertShieldedAddressObservation(
   address: string,
 ): Promise<void> {
   await conn.query(
-    `INSERT IGNORE INTO \`address\` (\`address\`, \`transactions\`)
-     VALUES (?, 0)`,
+    `INSERT INTO \`address\` (\`address\`, \`transactions\`)
+     VALUES (?, 0)
+     ON DUPLICATE KEY UPDATE \`address\` = \`address\``,
     [address],
   );
 }

--- a/packages/daemon/src/scripts/bench-void-tx.ts
+++ b/packages/daemon/src/scripts/bench-void-tx.ts
@@ -362,7 +362,7 @@ async function main() {
       collectedSpans.length = 0;
 
       const t0 = process.hrtime.bigint();
-      await voidTx(conn, fx.targetHash, fx.inputs, fx.outputs, fx.tokens, [], 1);
+      await voidTx(conn, fx.targetHash, fx.inputs, fx.outputs, [], fx.tokens, [], 1);
       const t1 = process.hrtime.bigint();
       const totalMs = Number(t1 - t0) / 1e6;
 

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -10,7 +10,7 @@ import hathorLib from '@hathor/wallet-lib';
 import { Connection as MysqlConnection, PoolConnection } from 'mysql2/promise';
 import axios from 'axios';
 import { get } from 'lodash';
-import { NftUtils } from '@wallet-service/common';
+import { NftUtils, ShieldedOutputMode, RecoveryState, isShieldedMode } from '@wallet-service/common';
 import {
   StringMap,
   Wallet,
@@ -22,6 +22,7 @@ import {
   Context,
   EventTxInput,
   EventTxOutput,
+  ShieldedOutput,
   WalletStatus,
   FullNodeEventTypes,
   StandardFullNodeEvent,
@@ -34,10 +35,13 @@ import {
   TokenBalanceMap,
   TxOutputWithIndex,
   isDecodedValid,
+  isAuthority,
 } from '@wallet-service/common';
 import {
   prepareOutputs,
-  getAddressBalanceMap,
+  getInvolvedAddresses,
+  getUnifiedBalanceMap,
+  ShieldedRecoveryResult,
   getUnixTimestamp,
   unlockUtxos,
   unlockTimelockedUtxos,
@@ -85,7 +89,19 @@ import {
   voidWalletTransaction,
   getTxOutputs,
   clearTxProposalForVoidedTx,
+  insertTxOutput,
+  insertShieldedTxOutputData,
+  upsertShieldedAddressObservation,
+  findShieldedAddressOwnership,
+  findShieldedAddressOwnershipBatch,
+  markTxOutputRecovered,
+  markTxOutputRecoveryFailed,
+  bumpAddressInvolvement,
+  decrementAddressInvolvement,
+  setTokenTotalSupply,
+  incrementTokenTotalSupply,
 } from '../db';
+import { rewindAmount, rewindFully } from '../crypto/ctRewind';
 import getConfig, { VALIDATE_ADDRESS_BALANCES } from '../config';
 import logger from '../logger';
 import { invokeOnTxPushNotificationRequestedLambda, getDaemonUptime, retryWithBackoff } from '../utils';
@@ -247,6 +263,103 @@ export const isBlock = (version: number): boolean => version === hathorLib.const
   || version === hathorLib.constants.MERGED_MINED_BLOCK_VERSION
   || version === hathorLib.constants.POA_BLOCK_VERSION;
 
+// Sentinel burn address. Outputs sent here are non-spendable and reduce supply
+// when accounted in `applyTokenSupplyUpdates`. Duplicated locally — the
+// wallet-service has its own copy; the constant has not been promoted to
+// `@wallet-service/common` to keep this change minimal.
+const BURN_ADDRESS = 'HDeadDeadDeadDeadDeadDeadDeagTPgmn';
+
+/**
+ * Apply mint/melt/burn/block-reward deltas to `token.total_supply` for a
+ * single accepted vertex.
+ *
+ * Two independent code paths:
+ *  - Block reward: every block with value-bearing outputs increases HTR
+ *    supply by the sum of those outputs. Blocks never carry shielded outputs
+ *    in v1, so this path is not gated on `shieldedOutputCount`.
+ *  - Supply delta: gated on the vertex having NO shielded outputs. Computes
+ *    `sum(outputs) - sum(inputs)` per token, with outputs to BURN_ADDRESS
+ *    EXCLUDED from the outputs sum and authority rows excluded from both
+ *    sums. Applies the signed delta — positive for mint, negative for melt,
+ *    and negative for any burn-address loss (since the burned value
+ *    contributes to the inputs side but not the outputs side, naturally
+ *    appearing as a supply decrease).
+ *
+ * Reads from the prepared (transparent) `TxInput[]` / `TxOutputWithIndex[]`,
+ * which already carry resolved `token` UIDs.
+ *
+ * `sign` flips the direction of every delta: `+1` on ingest (the default),
+ * `-1` when reversing a voided / removed vertex. The shielded gate and the
+ * block short-circuit apply symmetrically to both directions.
+ */
+export async function applyTokenSupplyUpdates(
+  mysql: any,
+  version: number,
+  txOutputs: TxOutputWithIndex[],
+  txInputs: TxInput[],
+  shieldedOutputCount: number,
+  sign: 1 | -1 = 1,
+): Promise<void> {
+  const HTR = hathorLib.constants.NATIVE_TOKEN_UID;
+
+  // Block reward (not gated on shielded).
+  // The coinbase mints HTR; typically a single output but sum them for safety.
+  // Blocks have no real inputs to balance against the coinbase, so the
+  // generic supply-delta loop below would double-count if it ran for blocks —
+  // short out here once the block reward is recorded.
+  if (isBlock(version) && txOutputs.length > 0) {
+    let blockReward = 0n;
+    for (const o of txOutputs) {
+      blockReward += BigInt(o.value);
+    }
+    if (blockReward > 0n) {
+      await incrementTokenTotalSupply(mysql, HTR, BigInt(sign) * blockReward);
+    }
+    return;
+  }
+
+  // Token-creation vertices are skipped entirely: handleTokenCreated is the
+  // single authority for the created token's supply (set from the wire
+  // initial_amount on the TOKEN_CREATED event), and the HTR deposit a creation
+  // tx consumes is not a supply change. Applying the per-token delta here would
+  // double-count the created token and wrongly shrink HTR. Skipping is
+  // sign-agnostic, so the void/remove reversal stays symmetric with ingest.
+  if (version === hathorLib.constants.CREATE_TOKEN_TX_VERSION) return;
+
+  // Per-token supply delta. Gated on absence of shielded outputs.
+  if (shieldedOutputCount !== 0) return;
+
+  const outSumByToken = new Map<string, bigint>();
+  for (const o of txOutputs) {
+    // `prepareOutputs` does NOT zero authority values; the authority flag is
+    // still encoded in `token_data`. Exclude authority rows from the sum so
+    // their bit-pattern values don't pollute mint/melt accounting.
+    if (isAuthority(o.token_data)) continue;
+    // Outputs to the burn sentinel address are excluded from the outputs sum;
+    // their value naturally drops out of `total_supply` because the inputs
+    // funding them remain in the inputs sum.
+    if (o.decoded?.address === BURN_ADDRESS) continue;
+    outSumByToken.set(o.token, (outSumByToken.get(o.token) ?? 0n) + BigInt(o.value));
+  }
+
+  const inSumByToken = new Map<string, bigint>();
+  for (const i of txInputs) {
+    if (isAuthority(i.token_data)) continue;
+    inSumByToken.set(i.token, (inSumByToken.get(i.token) ?? 0n) + BigInt(i.value));
+  }
+
+  const touchedTokens = new Set<string>([
+    ...outSumByToken.keys(),
+    ...inSumByToken.keys(),
+  ]);
+  for (const tokenId of touchedTokens) {
+    const delta = BigInt(sign) * ((outSumByToken.get(tokenId) ?? 0n) - (inSumByToken.get(tokenId) ?? 0n));
+    if (delta !== 0n) {
+      await incrementTokenTotalSupply(mysql, tokenId, delta);
+    }
+  }
+}
+
 export function isNanoContract(headers: EventTxHeader[]) {
   for (const header of headers) {
     if (isNanoHeader(header)) {
@@ -336,8 +449,6 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
 
       span.setAttribute('tx.hash', hash);
       span.setAttribute('tx.version', version);
-
-      const isNano = isNanoContract(headers);
 
       // Duplicate check is a read-only lookup and runs outside the transaction
       // so an early return cannot leave a BEGIN open on a pooled connection.
@@ -432,18 +543,183 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
         // Add utxos
         await withSpan('addUtxos', () => addUtxos(mysql, hash, txOutputs, heightlock));
 
-        // Mark tx utxos as spent
-        await withSpan('updateTxOutputSpentBy', () => updateTxOutputSpentBy(mysql, txInputs, hash));
+        // Resolve a shielded output's token_data to the matching token UID.
+        // Mirrors the transparent-path logic in `prepareOutputs`: a token_data
+        // of 0 selects the native token; otherwise it indexes into `vertex.tokens[]`.
+        const shieldedOutputs = fullNodeEvent.event.data.shielded_outputs ?? [];
+        const transparentCount = outputs.length;
+        const resolveShieldedTokenId = (tokenData: number): string | null => {
+          const idx = hathorLib.tokensUtils.getTokenIndexFromData(tokenData) - 1;
+          if (idx < 0) {
+            return hathorLib.constants.NATIVE_TOKEN_UID;
+          }
+          return tokens[idx] ?? null;
+        };
 
-        // Genesis tx has no inputs and outputs, so nothing to be updated, avoid it
-        // Nano contracts are a special case since they can have an address to update even without inputs/outputs
-        if (inputs.length > 0 || outputs.length > 0 || isNano) {
+        // Per-shielded-output rewind outcomes collected by the loop below
+        // and consumed by the unified balance-map builder. Only owned,
+        // successful recoveries land here; unowned outputs and rewind
+        // failures contribute nothing to the balance map (involvement is
+        // already covered by bumpAddressInvolvement).
+        const shieldedRecoveryResults: ShieldedRecoveryResult[] = [];
+
+        // Walk shielded_outputs[] with concatenated index = transparentCount + i.
+        // Each shielded output produces three rows: the unified `tx_output`, the
+        // `shielded_tx_output_data` satellite carrying the per-output crypto payload,
+        // and an `address` observation row (with bip32_account = Bip32Account.CTSpend).
+        // Every row lands in `recovery_state = 'unowned'` and is then promoted in-line
+        // below when a wallet has claimed the spend address.
+        for (let i = 0; i < shieldedOutputs.length; i++) {
+          const so = shieldedOutputs[i];
+          const idx = transparentCount + i;
+          const isAmount = so.mode === ShieldedOutputMode.AmountShielded;
+
+          // Shielded outputs don't carry a wire-level `locked` flag, so the
+          // daemon derives it locally from `decoded.timelock` (if present) and
+          // the vertex's `heightlock`. Mirrors the transparent path
+          // (`markLockedOutputs` in utils/wallet): locked iff any heightlock
+          // is in effect, or the explicit timelock is still in the future.
+          const shieldedTimelock = so.decoded.timelock ?? null;
+          const shieldedLocked = heightlock !== null
+            || (shieldedTimelock !== null && shieldedTimelock > now);
+
+          await insertTxOutput(mysql, {
+            tx_id: hash,
+            index: idx,
+            mode: so.mode,
+            address: so.decoded.address,
+            value: null,
+            token_id: isAmount ? resolveShieldedTokenId(so.token_data) : null,
+            authorities: 0,
+            timelock: shieldedTimelock,
+            heightlock,
+            locked: shieldedLocked,
+            voided: false,
+            recovery_state: RecoveryState.Unowned,
+          });
+
+          await insertShieldedTxOutputData(mysql, {
+            tx_id: hash,
+            index: idx,
+            mode: so.mode,
+            commitment: Buffer.from(so.commitment, 'hex'),
+            range_proof: Buffer.from(so.range_proof, 'hex'),
+            script: Buffer.from(so.script, 'hex'),
+            ephemeral_pubkey: Buffer.from(so.ephemeral_pubkey, 'hex'),
+            token_data: isAmount ? so.token_data : null,
+            asset_commitment: !isAmount ? Buffer.from(so.asset_commitment, 'hex') : null,
+            surjection_proof: !isAmount ? Buffer.from(so.surjection_proof, 'hex') : null,
+          });
+
+          await upsertShieldedAddressObservation(mysql, so.decoded.address);
+
+          // If a wallet has claimed this shielded address, attempt the rewind
+          // in line. Success → mark the output recovered with the revealed
+          // value/token; failure → mark it recovery_failed and emit an alert.
+          const owned = await findShieldedAddressOwnership(mysql, so.decoded.address);
+          if (owned) {
+            try {
+              const ephem = Buffer.from(so.ephemeral_pubkey, 'hex');
+              const commit = Buffer.from(so.commitment, 'hex');
+              const range = Buffer.from(so.range_proof, 'hex');
+
+              if (isAmount) {
+                const tokenIdHex = resolveShieldedTokenId(so.token_data);
+                if (tokenIdHex === null) {
+                  throw new Error('AmountShielded token_data does not resolve to a known token');
+                }
+                const tokenUid = Buffer.from(tokenIdHex, 'hex');
+                const r = rewindAmount({
+                  scanPrivkey: owned.scan_privkey,
+                  ephemeralPubkey: ephem,
+                  commitment: commit,
+                  rangeProof: range,
+                  tokenUid,
+                });
+                await markTxOutputRecovered(mysql, hash, idx, {
+                  value: r.value,
+                  token_id: tokenIdHex,
+                });
+                shieldedRecoveryResults.push({
+                  address: so.decoded.address,
+                  tokenId: tokenIdHex,
+                  value: r.value,
+                  locked: shieldedLocked,
+                });
+              } else {
+                const assetCommit = Buffer.from(so.asset_commitment, 'hex');
+                const r = rewindFully({
+                  scanPrivkey: owned.scan_privkey,
+                  ephemeralPubkey: ephem,
+                  commitment: commit,
+                  rangeProof: range,
+                  assetCommitment: assetCommit,
+                });
+                const tokenIdHexFull = r.tokenUid;
+                await markTxOutputRecovered(mysql, hash, idx, {
+                  value: r.value,
+                  token_id: tokenIdHexFull,
+                });
+                shieldedRecoveryResults.push({
+                  address: so.decoded.address,
+                  tokenId: tokenIdHexFull,
+                  value: r.value,
+                  locked: shieldedLocked,
+                });
+              }
+            } catch (e) {
+              await markTxOutputRecoveryFailed(mysql, hash, idx);
+              await addAlert(
+                'Shielded recovery failed',
+                `Failed to rewind shielded output ${hash}:${idx} for owned address`,
+                Severity.MAJOR,
+                { tx_id: hash, index: idx, error: String(e) },
+                logger,
+              );
+            }
+          }
+        }
+
+        // Bump address.transactions once per involved address using the
+        // pure wire-data set (transparent in/out + every shielded out +
+        // shielded in spent_output.decoded.address + nano-header addresses).
+        // This is now the single canonical writer of the involvement
+        // counter — updateAddressTablesWithTx no longer touches the
+        // address row directly; it only writes per-token rows.
+        const involvedAddresses = getInvolvedAddresses(inputs, outputs, shieldedOutputs, headers);
+        await withSpan('bumpAddressInvolvement', () => bumpAddressInvolvement(mysql, involvedAddresses));
+
+        // Mark tx utxos as spent. Kind-agnostic: only uses tx_id+index, so
+        // we pass the raw event inputs — both transparent and shielded —
+        // even though prepareInputs only emits transparent TxInput rows.
+        await withSpan('updateTxOutputSpentBy', () => updateTxOutputSpentBy(mysql, inputs, hash));
+
+        // Genesis tx has no inputs and outputs, so nothing to be updated.
+        // Nano contracts contribute an address even without inputs/outputs
+        // — covered by involvedAddresses through the header walk.
+        // Shielded-credit-only and shielded-spend-only vertices also flow
+        // through here because the involvement set always includes any
+        // shielded output / input address.
+        if (involvedAddresses.size > 0) {
           const tokenList: string[] = getTokenListFromInputsAndOutputs(txInputs, txOutputs);
 
           // Update transaction count with the new tx
           await incrementTokensTxCount(mysql, tokenList);
 
-          const addressBalanceMap: StringMap<TokenBalanceMap> = getAddressBalanceMap(txInputs, txOutputs, headers);
+          // Unified per-(address, token) balance map. Includes:
+          //   - transparent inputs/outputs from prepared lists,
+          //   - shielded receives from the in-line rewind results above,
+          //   - shielded spend reversals sourced from local tx_output rows
+          //     (only for `recovery_state = 'recovered'` rows owned by us),
+          //   - header-only addresses seeded with an empty HTR entry.
+          const addressBalanceMap: StringMap<TokenBalanceMap> = await getUnifiedBalanceMap(
+            mysql,
+            txInputs,
+            txOutputs,
+            shieldedRecoveryResults,
+            inputs,
+            headers,
+          );
 
           // update address tables (address, address_balance, address_tx_history)
           await withSpan('updateAddressTablesWithTx', () => updateAddressTablesWithTx(mysql, hash, timestamp, addressBalanceMap));
@@ -530,6 +806,20 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
             token_name,
             token_symbol,
             signal_bits: 0, // TODO: we should actually receive this and store in the database
+            // Additive realtime fields: a lightweight shielded-output projection
+            // (no crypto blobs) and the full involved-address set (reusing the
+            // same set bumpAddressInvolvement consumed). Clients intersect
+            // `addresses` with their own and refetch.
+            shielded_outputs: shieldedOutputs.map((so) => {
+              // `decoded` is schema-guaranteed present (the socket safeParse rejects
+              // any shielded output without it), matching the unguarded ingest path.
+              const decoded = { address: so.decoded.address };
+              // token_data only exists on AmountShielded; FullyShielded hides it.
+              return so.mode === ShieldedOutputMode.AmountShielded
+                ? { mode: so.mode, token_data: so.token_data, decoded }
+                : { mode: so.mode, decoded };
+            }),
+            addresses: Array.from(involvedAddresses),
           };
 
           try {
@@ -546,7 +836,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
 
           try {
             if (PUSH_NOTIFICATION_ENABLED) {
-              const walletBalanceMap = await getWalletBalancesForTx(mysql, txData);
+              const walletBalanceMap = await getWalletBalancesForTx(mysql, txData, addressBalanceMap);
               const { length: hasAffectWallets } = Object.keys(walletBalanceMap);
               if (hasAffectWallets) {
                 invokeOnTxPushNotificationRequestedLambda(walletBalanceMap)
@@ -558,13 +848,21 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
             logger.error(e);
           }
 
-          const network = new hathorLib.Network(NETWORK);
+          // NFT detection on transactions that touch shielded data is deferred —
+          // shielded NFT detection is technical debt, so skip the handler when the
+          // vertex carries any shielded outputs OR spends any shielded input.
+          const hasShieldedInputs = inputs.some(
+            (input) => input?.spent_output && isShieldedMode(input.spent_output.mode),
+          );
+          if (shieldedOutputs.length === 0 && !hasShieldedInputs) {
+            const network = new hathorLib.Network(NETWORK);
 
-          // Call to process the data for NFT handling (if applicable)
-          // This process is not critical, so we run it in a fire-and-forget manner, not waiting for the promise.
-          // @ts-ignore — SpentOutput union introduced in PR3; processNftEvent signature updated in follow-up
-          NftUtils.processNftEvent(fullNodeData, STAGE, SERVERLESS_DEPLOY_PREFIX, network, logger)
-            .catch((err: unknown) => logger.error('[ALERT] Error processing NFT event', err));
+            // Call to process the data for NFT handling (if applicable)
+            // This process is not critical, so we run it in a fire-and-forget manner, not waiting for the promise.
+            // @ts-ignore - wallet-lib's FullNodeTransaction will be updated to know about the new spent_output union in the next release
+            NftUtils.processNftEvent(fullNodeData, STAGE, SERVERLESS_DEPLOY_PREFIX, network, logger)
+              .catch((err: unknown) => logger.error('[ALERT] Error processing NFT event', err));
+          }
         }
 
         // Need to check if there is a nano header and update the nc_address's seqnum if needed
@@ -578,6 +876,17 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
             }
           }
         }
+
+        // Apply token.total_supply deltas: block reward (HTR, every block) and
+        // the per-token sum(outputs except burn) - sum(inputs) (gated on no
+        // shielded outputs).
+        await applyTokenSupplyUpdates(
+          mysql,
+          version,
+          txOutputs,
+          txInputs,
+          shieldedOutputs.length,
+        );
 
         await dbUpdateLastSyncedEvent(mysql, fullNodeEvent.event.id);
 
@@ -625,6 +934,7 @@ export const handleVertexRemoved = async (context: Context, _event: Event) => {
           hash,
           outputs,
           inputs,
+          shielded_outputs: shieldedOutputs = [],
           tokens,
           headers = [],
           version,
@@ -645,6 +955,7 @@ export const handleVertexRemoved = async (context: Context, _event: Event) => {
           hash,
           inputs,
           outputs,
+          shieldedOutputs,
           tokens,
           headers,
           version,
@@ -721,6 +1032,7 @@ export const voidTx = async (
   hash: string,
   inputs: EventTxInput[],
   outputs: EventTxOutput[],
+  shieldedOutputs: ShieldedOutput[],
   tokens: string[],
   headers: EventTxHeader[],
   version: number,
@@ -742,14 +1054,50 @@ export const voidTx = async (
     };
   });
 
-  const addressBalanceMap: StringMap<TokenBalanceMap> = getAddressBalanceMap(txInputs, txOutputsWithLocked, headers);
+  // Build shielded output contributions from local tx_output rows.
+  // A shielded receive is only credited when it was recovered against an
+  // owned address; those same rows must be reversed when the vertex is voided.
+  // We read them from the DB now — before markUtxosAsVoided — so the rows
+  // are still present and still carry value / token_id.
+  //
+  // Ownership is resolved in one batch query to avoid N round-trips.
+  const candidateRows = dbTxOutputs.filter(
+    (r) => r.mode !== 0 && r.recoveryState === RecoveryState.Recovered && r.value !== null && r.tokenId !== null,
+  );
+  const ownershipMap = await findShieldedAddressOwnershipBatch(
+    mysql,
+    candidateRows.map((r) => r.address),
+  );
+  const shieldedRecoveryResults: ShieldedRecoveryResult[] = candidateRows
+    .filter((r) => ownershipMap.has(r.address))
+    .map((r) => ({
+      address: r.address,
+      tokenId: r.tokenId!,
+      value: r.value!,
+      locked: r.locked,
+    }));
+
+  const addressBalanceMap: StringMap<TokenBalanceMap> = await getUnifiedBalanceMap(
+    mysql,
+    txInputs,
+    txOutputsWithLocked,
+    shieldedRecoveryResults,
+    inputs,
+    headers,
+  );
 
   await withSpan('voidTransaction', () => voidTransaction(mysql, hash));
+
   // CRITICAL: markUtxosAsVoided must be called before voidAddressTransaction
   // and voidWalletTransaction as those methods recalculate balances based on
   // the UTXOs table.
   await withSpan('markUtxosAsVoided', () => markUtxosAsVoided(mysql, dbTxOutputs));
   await withSpan('voidAddressTransaction', () => voidAddressTransaction(mysql, hash, addressBalanceMap, version));
+
+  // Reverse the address-grain involvement counter for the SAME set the ingest
+  // path bumped via bumpAddressInvolvement.
+  const involvedAddresses = getInvolvedAddresses(inputs, outputs, shieldedOutputs, headers);
+  await withSpan('decrementAddressInvolvement', () => decrementAddressInvolvement(mysql, involvedAddresses));
 
   // CRITICAL: Unspend the inputs when voiding a transaction
   // The inputs of the voided transaction need to be marked as unspent
@@ -806,6 +1154,25 @@ export const voidTx = async (
     await deleteTokens(mysql, tokensCreated);
   }
 
+  // Reverse the token.total_supply deltas this vertex applied on ingest
+  // (block reward, mint/melt, burn) by replaying the same computation with the
+  // sign flipped. shieldedOutputCount comes from the local tx_output rows so
+  // the shielded gate fires identically to ingest. This runs AFTER deleteTokens
+  // on purpose: a token CREATED by this vertex (path 1) is reversed by its row
+  // deletion, so its row is already gone here and the UPDATE-only reversal
+  // no-ops for it — mirroring ingest, where applyTokenSupplyUpdates(+1) also
+  // no-ops because handleTokenCreated hasn't inserted the row yet. Only
+  // pre-existing tokens (paths 2-4) remain to be reversed.
+  const shieldedOutputCount = dbTxOutputs.filter((r) => r.mode !== 0).length;
+  await withSpan('reverseTokenSupplyUpdates', () => applyTokenSupplyUpdates(
+    mysql,
+    version,
+    txOutputs,
+    txInputs,
+    shieldedOutputCount,
+    -1,
+  ));
+
   if (VALIDATE_ADDRESS_BALANCES) {
     const addresses = Object.keys(addressBalanceMap);
     await validateAddressBalances(mysql, addresses);
@@ -826,6 +1193,7 @@ export const handleVoidedTx = async (context: Context) => {
           hash,
           outputs,
           inputs,
+          shielded_outputs: shieldedOutputs = [],
           tokens,
           headers = [],
           version,
@@ -838,6 +1206,7 @@ export const handleVoidedTx = async (context: Context) => {
           hash,
           inputs,
           outputs,
+          shieldedOutputs,
           tokens,
           headers,
           version,
@@ -1187,6 +1556,7 @@ export const handleTokenCreated = async (context: Context) => {
           token_symbol,
           token_version,
           nc_exec_info,
+          initial_amount,
         } = fullNodeEvent.event.data;
 
         span.setAttribute('token.uid', token_uid);
@@ -1219,7 +1589,20 @@ export const handleTokenCreated = async (context: Context) => {
           // Insert the new token
           await storeTokenInformation(mysql, token_uid, token_name, token_symbol, token_version);
           await insertTokenCreation(mysql, token_uid, txId, firstBlock);
-          logger.debug(`Inserted new token ${token_uid} with first_block=${firstBlock}, version=${token_version}`);
+
+          // Record the initial mint amount as the token's starting
+          // total_supply. The wire payload carries `initial_amount`
+          // directly, so we use it instead of reconstructing the sum
+          // from tx_output rows. handleTokenCreated is the single writer
+          // of token-creation supply; applyTokenSupplyUpdates (in
+          // handleVertexAccepted) only mutates existing token rows for
+          // mint/melt/burn deltas, so the two paths never compete on the
+          // same column. The `?? 0n` fallback covers events that omit
+          // the field defensively.
+          const initialSupply = BigInt(initial_amount ?? 0);
+          await setTokenTotalSupply(mysql, token_uid, initialSupply);
+
+          logger.debug(`Inserted new token ${token_uid} with first_block=${firstBlock}, version=${token_version}, initial_supply=${initialSupply}`);
         } else {
           logger.debug(`Token ${token_uid} already exists, skipping insertion`);
         }

--- a/packages/daemon/src/types/db.ts
+++ b/packages/daemon/src/types/db.ts
@@ -10,9 +10,9 @@ import { RowDataPacket } from 'mysql2/promise';
 export interface TxOutputRow extends RowDataPacket {
   tx_id: string;
   index: number;
-  token_id: string;
+  token_id: string | null;
   address: string;
-  value: number;
+  value: number | null;
   authorities: number;
   timelock: number;
   heightlock: number;
@@ -20,6 +20,8 @@ export interface TxOutputRow extends RowDataPacket {
   tx_proposal?: string;
   tx_proposal_index?: number;
   spent_by?: string;
+  mode: number;
+  recovery_state: string | null;
 }
 
 export interface LastSyncedEventRow extends RowDataPacket {

--- a/packages/daemon/src/types/transaction.ts
+++ b/packages/daemon/src/types/transaction.ts
@@ -5,12 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { RecoveryState } from '@wallet-service/common';
+
 export interface DbTxOutput {
   txId: string;
   index: number;
-  tokenId: string;
+  tokenId: string | null;
   address: string;
-  value: bigint;
+  value: bigint | null;
   authorities: number;
   timelock: number | null;
   heightlock: number | null;
@@ -19,6 +21,8 @@ export interface DbTxOutput {
   txProposalId?: string | null;
   txProposalIndex?: number | null;
   voided?: boolean | null;
+  mode: number;
+  recoveryState: RecoveryState | null;
 }
 
 export interface DbTransaction {

--- a/packages/daemon/src/types/wallet.ts
+++ b/packages/daemon/src/types/wallet.ts
@@ -34,6 +34,10 @@ export type TokenBalanceValue = {
   unlockedAuthorities: Record<string, unknown>;
   lockExpires: number | null;
   total: bigint;
+  // Net shielded balance change for this tx (unlocked + locked shielded),
+  // positive on a recovered shielded receive. `total` stays transparent-only;
+  // the push builder combines the two for the displayed amount.
+  shieldedAmount: bigint;
 }
 
 export interface WalletBalanceValue {

--- a/packages/daemon/src/utils/helpers.ts
+++ b/packages/daemon/src/utils/helpers.ts
@@ -12,6 +12,17 @@ export function stringMapIterator<T>(stringMap: StringMap<T>): [string, T][] {
   return Object.entries(stringMap);
 }
 
+/**
+ * Parse a nullable numeric database column into a bigint.
+ *
+ * MySQL returns BIGINT columns as either a `number` or a `string` depending on
+ * the driver/column, and `NULL` as `null`. This normalizes that to `bigint`,
+ * preserving `null`/`undefined` as `null`.
+ */
+export function parseNullableBigInt(value: number | string | null | undefined): bigint | null {
+  return value === null || value === undefined ? null : BigInt(value);
+}
+
 export const getFullnodeHttpUrl = () => {
   const { USE_SSL, FULLNODE_HOST } = getConfig();
   const protocol = USE_SSL ? 'https://' : 'http://';

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -191,6 +191,7 @@ export const getAddressBalanceMap = (
 export const unlockUtxos = async (mysql: MysqlConnection, utxos: DbTxOutput[], updateTimelocks: boolean): Promise<void> => {
   if (utxos.length === 0) return;
 
+  // @ts-ignore — value/tokenId are nullable on shielded rows; unlockUtxos is rewritten in follow-up
   const outputs: TxOutput[] = utxos.map((utxo) => {
     const decoded: DecodedOutput = {
       type: 'P2PKH',
@@ -215,9 +216,11 @@ export const unlockUtxos = async (mysql: MysqlConnection, utxos: DbTxOutput[], u
   await dbUnlockUtxos(mysql, utxos.map((utxo: DbTxOutput): TxInput => ({
     tx_id: utxo.txId,
     index: utxo.index,
+    // @ts-ignore — nullable on shielded rows; rewritten in follow-up
     value: utxo.value,
     token_data: 0,
     script: '',
+    // @ts-ignore
     token: utxo.tokenId,
     decoded: null,
   })));

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -16,6 +16,7 @@ import {
   EventTxInput,
   EventTxOutput,
   isNanoHeader,
+  ShieldedOutput,
   StringMap,
   TokenBalanceValue,
   Wallet,
@@ -23,7 +24,6 @@ import {
   WalletBalanceValue,
 } from '../types';
 import {
-  DecodedOutput,
   Transaction,
   TxOutputWithIndex,
   TxInput,
@@ -34,13 +34,16 @@ import {
 import {
   fetchAddressBalance,
   fetchAddressTxHistorySum,
+  findShieldedAddressOwnership,
   getAddressWalletInfo,
   getExpiredTimelocksUtxos,
   getTokenSymbols,
+  getTxOutput,
   unlockUtxos as dbUnlockUtxos,
   updateAddressLockedBalance,
   updateWalletLockedBalance,
 } from '../db';
+import { ShieldedOutputMode, RecoveryState, isShieldedMode } from '@wallet-service/common';
 import logger from '../logger';
 import { stringMapIterator } from './helpers';
 
@@ -182,7 +185,187 @@ export const getAddressBalanceMap = (
 };
 
 /**
+ * Compute the set of addresses involved in a vertex.
+ *
+ * The involvement set drives the `address.transactions` counter — every
+ * address that appears anywhere on the vertex is bumped once regardless
+ * of whether the daemon can resolve a token/value for it. Sources:
+ *
+ *  - Transparent inputs: `spent_output.decoded.address` (when decode succeeded).
+ *  - Transparent outputs: `decoded.address` (when decode succeeded).
+ *  - Shielded outputs: every shielded `decoded.address`, regardless of
+ *    ownership or recovery state. Unowned shielded outputs still mark
+ *    their address as involved so an observer can see something happened.
+ *  - Shielded inputs: `spent_output.decoded.address` — present on all
+ *    shielded spent_output variants.
+ *  - Nano-contract headers: `nc_address`.
+ *
+ * Pure function over wire data; no DB lookups. The caller is responsible
+ * for using the returned set to drive `address.transactions` separately
+ * from the per-(address, token) balance map.
+ */
+export const getInvolvedAddresses = (
+  inputs: EventTxInput[],
+  outputs: EventTxOutput[],
+  shieldedOutputs: ShieldedOutput[],
+  headers: EventTxHeader[],
+): Set<string> => {
+  const involved = new Set<string>();
+
+  for (const input of inputs) {
+    const spent = input?.spent_output;
+    if (!spent) continue;
+    // `spent_output.decoded` is present on every variant of the union
+    // (transparent + both shielded). Address may still be absent if the
+    // decode failed upstream; skip empty/unknown values.
+    const decoded = (spent as { decoded?: { address?: string } | null }).decoded;
+    const address = decoded && (decoded as { address?: string }).address;
+    if (address) involved.add(address);
+  }
+
+  for (const output of outputs) {
+    if (!isDecodedValid(output.decoded, ['address'])) continue;
+    const address = (output.decoded as { address?: string }).address;
+    if (address) involved.add(address);
+  }
+
+  for (const so of shieldedOutputs) {
+    const address = so.decoded?.address;
+    if (address) involved.add(address);
+  }
+
+  for (const header of headers) {
+    if (!isNanoHeader(header)) continue;
+    if (header.nc_address) involved.add(header.nc_address);
+  }
+
+  return involved;
+};
+
+/**
+ * Per-shielded-output rewind outcome captured during the
+ * handleVertexAccepted shielded loop. Only successful recoveries against an
+ * owned address contribute; unowned outputs and rewind failures are not
+ * included because no balance was credited.
+ */
+export interface ShieldedRecoveryResult {
+  address: string;
+  tokenId: string;
+  value: bigint;
+  locked: boolean;
+}
+
+/**
+ * Build the unified per-(address, token) balance map for a vertex.
+ *
+ * Combines four contribution sources into a single map so the address /
+ * wallet writers can issue one statement per (address, token) row that
+ * carries both transparent and shielded deltas:
+ *
+ *  - Transparent outputs: read from prepared outputs; standard
+ *    TokenBalanceMap.fromTxOutput semantics (positive delta, locked vs
+ *    unlocked column routed by `output.locked`).
+ *  - Transparent inputs: read from prepared inputs; standard
+ *    TokenBalanceMap.fromTxInput semantics (negative delta plus any
+ *    authority bookkeeping).
+ *  - Shielded outputs that recovered against an owned address: the rewind
+ *    revealed (value, token) — contribute a positive shielded delta
+ *    routed to the locked or unlocked shielded column by `locked`.
+ *  - Shielded inputs whose original `tx_output` row is in recovery_state =
+ *    'recovered' AND owned by us: look up the local row to learn the
+ *    value and contribute a negative shielded delta. Unowned or
+ *    recovery_failed shielded inputs contribute nothing — the bump in
+ *    `address.transactions` from the involvement helper already accounts
+ *    for them.
+ *
+ * Shielded-input contributions are sourced from local state rather than
+ * the wire because the shielded `spent_output` payload doesn't carry the
+ * recovered value, and for FullyShielded inputs it doesn't carry the
+ * token either.
+ *
+ * Headers (currently only nano-contract `nc_address`) seed an empty HTR
+ * entry, matching the legacy `getAddressBalanceMap` behaviour so the
+ * downstream wallet lookup can still attach to the address. This is the
+ * only zero-delta seed produced by the unified builder.
+ *
+ * `txInputs` is expected to be the transparent-only slice produced by
+ * `prepareInputs` (shielded inputs are dropped there). `eventInputs` is
+ * the raw wire-level input array, used here only to drive the shielded
+ * spend reversal lookup.
+ */
+export const getUnifiedBalanceMap = async (
+  mysql: MysqlConnection,
+  txInputs: TxInput[],
+  txOutputs: TxOutputWithIndex[],
+  shieldedRecoveryResults: ShieldedRecoveryResult[],
+  eventInputs: EventTxInput[],
+  headers: EventTxHeader[],
+): Promise<StringMap<TokenBalanceMap>> => {
+  const map: StringMap<TokenBalanceMap> = {};
+
+  for (const input of txInputs) {
+    if (!isDecodedValid(input.decoded)) continue;
+    const address = input.decoded?.address!;
+    const tokenMap = TokenBalanceMap.fromTxInput(input);
+    map[address] = TokenBalanceMap.merge(map[address], tokenMap);
+  }
+
+  for (const output of txOutputs) {
+    if (!isDecodedValid(output.decoded)) {
+      throw new Error('Output has no decoded script');
+    }
+    if (!output.decoded.address) {
+      throw new Error('Decoded output data has no address');
+    }
+    const address = output.decoded.address;
+    const tokenMap = TokenBalanceMap.fromTxOutput(output);
+    map[address] = TokenBalanceMap.merge(map[address], tokenMap);
+  }
+
+  for (const r of shieldedRecoveryResults) {
+    const tokenMap = TokenBalanceMap.fromShielded(r.tokenId, r.value, r.locked);
+    map[r.address] = TokenBalanceMap.merge(map[r.address], tokenMap);
+  }
+
+  // Shielded input reversals: look up the local tx_output row for each
+  // shielded input. Only owned, recovered rows contributed a balance
+  // originally; unowned and recovery_failed are skipped.
+  for (const ei of eventInputs) {
+    if (!ei?.spent_output || !isShieldedMode(ei.spent_output.mode)) continue;
+    const row = await getTxOutput(mysql, ei.tx_id, ei.index, false);
+    if (!row) continue;
+    if (row.recoveryState !== RecoveryState.Recovered) continue;
+    if (row.value === null || row.tokenId === null) continue;
+    const owned = await findShieldedAddressOwnership(mysql, row.address);
+    if (!owned) continue;
+    const tokenMap = TokenBalanceMap.fromShielded(row.tokenId, -row.value, row.locked);
+    map[row.address] = TokenBalanceMap.merge(map[row.address], tokenMap);
+  }
+
+  // Header-only addresses (nano-contract callers without an input/output)
+  // get an empty HTR seed so the downstream wallet lookup can attach.
+  for (const header of headers) {
+    if (!isNanoHeader(header)) continue;
+    const address = header.nc_address;
+    if (map[address]) continue;
+    const emptyHTR = new TokenBalanceMap();
+    emptyHTR.set(constants.NATIVE_TOKEN_UID, emptyHTR.get(constants.NATIVE_TOKEN_UID));
+    map[address] = emptyHTR;
+  }
+
+  return map;
+};
+
+/**
  * Update the unlocked/locked balances for addresses and wallets connected to the given UTXOs.
+ *
+ * Row-level `locked = FALSE` is flipped for every UTXO, regardless of mode or recovery state.
+ * Balance accounting then dispatches by `(mode, recovery_state)`:
+ * - transparent rows update transparent balance columns;
+ * - shielded rows in `recovered` state update shielded balance columns;
+ * - shielded rows in `unowned` / `recovery_failed` contribute no balance (the value is unknown
+ *   to this node), so they are skipped from balance updates while still getting their lock flag
+ *   flipped.
  *
  * @param mysql - Database connection
  * @param utxos - List of UTXOs that are unlocked by height
@@ -191,49 +374,69 @@ export const getAddressBalanceMap = (
 export const unlockUtxos = async (mysql: MysqlConnection, utxos: DbTxOutput[], updateTimelocks: boolean): Promise<void> => {
   if (utxos.length === 0) return;
 
-  // @ts-ignore — value/tokenId are nullable on shielded rows; unlockUtxos is rewritten in follow-up
-  const outputs: TxOutput[] = utxos.map((utxo) => {
-    const decoded: DecodedOutput = {
-      type: 'P2PKH',
-      address: utxo.address,
-      timelock: utxo.timelock,
-    };
-
-    return {
-      value: utxo.authorities > 0 ? BigInt(utxo.authorities) : utxo.value,
-      token: utxo.tokenId,
-      decoded,
-      locked: false,
-      // set authority bit if necessary
-      token_data: utxo.authorities > 0 ? constants.TOKEN_AUTHORITY_MASK : 0,
-      // we don't care about spent_by and script
-      spent_by: null,
-      script: '',
-    };
-  });
-
-  // mark as unlocked in database (this just changes the 'locked' flag)
+  // Row-level lock flip applies to every row regardless of mode. `dbUnlockUtxos` only reads
+  // `tx_id` and `index` to issue the UPDATE, so populating the other fields with placeholders
+  // (including the null `value` of unowned shielded rows) is safe.
   await dbUnlockUtxos(mysql, utxos.map((utxo: DbTxOutput): TxInput => ({
     tx_id: utxo.txId,
     index: utxo.index,
-    // @ts-ignore — nullable on shielded rows; rewritten in follow-up
-    value: utxo.value,
+    value: utxo.value ?? 0n,
     token_data: 0,
     script: '',
-    // @ts-ignore
-    token: utxo.tokenId,
+    token: utxo.tokenId ?? '',
     decoded: null,
   })));
 
-  const addressBalanceMap: StringMap<TokenBalanceMap> = getAddressBalanceMap([], outputs, []);
-  // update address_balance table
+  // Build a unified per-(address, token) balance map via getUnifiedBalanceMap by classifying
+  // each UTXO: transparent rows feed the `txOutputs` slot (which populates the transparent
+  // `unlockedAmount` field via `fromTxOutput`); recovered shielded rows feed
+  // `shieldedRecoveryResults` (which populates the `unlockedShieldedAmount` field via
+  // `fromShielded`). Unowned / recovery_failed shielded rows are skipped — they never
+  // contributed to balance, so unlocking them touches no column. `locked: false` on both
+  // sides routes the value to the unlocked column families.
+  const synthOutputs: TxOutputWithIndex[] = [];
+  const synthRecoveryResults: ShieldedRecoveryResult[] = [];
+  for (const utxo of utxos) {
+    if (utxo.mode === ShieldedOutputMode.Transparent) {
+      synthOutputs.push({
+        value: utxo.authorities > 0 ? BigInt(utxo.authorities) : utxo.value!,
+        token: utxo.tokenId!,
+        decoded: {
+          type: 'P2PKH',
+          address: utxo.address,
+          timelock: utxo.timelock,
+        },
+        locked: false,
+        token_data: utxo.authorities > 0 ? constants.TOKEN_AUTHORITY_MASK : 0,
+        spent_by: null,
+        script: '',
+        index: utxo.index,
+      });
+    } else if (utxo.recoveryState === RecoveryState.Recovered) {
+      synthRecoveryResults.push({
+        address: utxo.address,
+        tokenId: utxo.tokenId!,
+        value: utxo.value!,
+        locked: false,
+      });
+    }
+  }
+
+  const addressBalanceMap = await getUnifiedBalanceMap(
+    mysql,
+    [],
+    synthOutputs,
+    synthRecoveryResults,
+    [],
+    [],
+  );
+
   await updateAddressLockedBalance(mysql, addressBalanceMap, updateTimelocks);
 
-  // check if addresses belong to any started wallet
-  const addressWalletMap: StringMap<Wallet> = await getAddressWalletInfo(mysql, Object.keys(addressBalanceMap));
-
-  // update wallet_balance table
-  const walletBalanceMap: StringMap<TokenBalanceMap> = getWalletBalanceMap(addressWalletMap, addressBalanceMap);
+  // The address table is unified — getAddressWalletInfo returns wallet info for
+  // rows of any Bip32Account slot, so the lookup is account-agnostic.
+  const addressWalletMap = await getAddressWalletInfo(mysql, Object.keys(addressBalanceMap));
+  const walletBalanceMap = getWalletBalanceMap(addressWalletMap, addressBalanceMap);
   await updateWalletLockedBalance(mysql, walletBalanceMap, updateTimelocks);
 };
 
@@ -290,22 +493,35 @@ export const unlockTimelockedUtxos = async (mysql: MysqlConnection, now: number)
 /**
  * Prepares transaction input data for processing or display.
  *
- * This function takes an array of EventTxInput objects and an array of token identifiers
- * to prepare an array of TxInput objects. Each input is processed to include additional information
- * such as the token involved and the decoded output data.
+ * Only transparent inputs (`spent_output.mode === 0`) flow into the
+ * returned array. Shielded inputs are dropped here because the wire
+ * payload does not carry the recovered value (for both shielded modes)
+ * or the token uid (for FullyShielded), so they cannot contribute a
+ * full TxInput. The shielded balance contribution is handled by
+ * `getUnifiedBalanceMap` via a local tx_output lookup, and the
+ * spent-by marking is handled by `updateTxOutputSpentBy` which takes a
+ * thin `{tx_id, index}` shape and is called with the raw event inputs
+ * (covering both kinds).
  *
  * @param inputs - An array of transaction inputs, each containing data like
  *                                  transaction hash, index, and spent output information.
  * @param tokens - An array of token identifiers corresponding to different tokens involved
  *                            in the transaction.
- * @returns - An array of prepared inputs, each enriched with additional data.
+ * @returns - An array of prepared transparent inputs, each enriched with additional data.
  */
 export const prepareInputs = (inputs: EventTxInput[], tokens: string[]): TxInput[] => {
   const preparedInputs: TxInput[] = inputs.reduce((newInputs: TxInput[], _input: EventTxInput): TxInput[] => {
     const output = _input.spent_output;
-    // @ts-ignore — SpentOutput union introduced in PR3; prepareInputs filters to transparent in follow-up
+
+    if (output.mode !== 0) {
+      // Drop shielded inputs from the prepared list; see function docstring.
+      return newInputs;
+    }
+
+    // Transparent input — TS narrows `output` to the mode=0 variant, so
+    // `output.value`, `output.token_data`, `output.script`, `output.decoded`
+    // are accessible without further guards.
     const utxo: Output = new Output(output.value, Buffer.from(output.script, 'base64'), {
-      // @ts-ignore
       tokenData: output.token_data,
     });
     let token = hathorLib.constants.NATIVE_TOKEN_UID;
@@ -430,8 +646,14 @@ export const validateAddressBalances = async (mysql: MysqlConnection, addresses:
  * @param tx - The transaction to get related wallets and their token balances
  * @returns
  */
-export const getWalletBalancesForTx = async (mysql: MysqlConnection, tx: Transaction): Promise<StringMap<WalletBalanceValue>> => {
-  const addressBalanceMap: StringMap<TokenBalanceMap> = getAddressBalanceMap(tx.inputs, tx.outputs, tx.headers ?? []);
+export const getWalletBalancesForTx = async (
+  mysql: MysqlConnection,
+  tx: Transaction,
+  addressBalanceMap: StringMap<TokenBalanceMap>,
+): Promise<StringMap<WalletBalanceValue>> => {
+  // The caller passes the unified balance map (transparent + shielded) computed
+  // for the vertex, so the push summary reflects recovered shielded receives —
+  // not just the transparent inputs/outputs on `tx`.
   // return only wallets that were started
   const addressWalletMap: StringMap<Wallet> = await getAddressWalletInfo(mysql, Object.keys(addressBalanceMap));
 
@@ -493,16 +715,24 @@ export class FromTokenBalanceMapToBalanceValueList {
       unlockedAuthorities: balance.unlockedAuthorities.toJSON(),
       totalAmountSent: balance.totalAmountSent,
       total: balance.total(),
+      // Gross shielded received this tx (the lifetime accumulator, suppressed
+      // to 0 on spends), so the receive-oriented push amount is never negative.
+      shieldedAmount: balance.totalShieldedReceived,
     } as TokenBalanceValue));
     return balances;
   }
 }
 
 export const sortBalanceValueByAbsTotal = (balanceA: TokenBalanceValue, balanceB: TokenBalanceValue): number => {
-  function abs(num: bigint) {
-    return num >= 0n ? num : -num;
-  }
-  if (abs(balanceA.total) - abs(balanceB.total) >= 0n) return -1;
+  const abs = (num: bigint): bigint => (num >= 0n ? num : -num);
+  // Rank by the combined magnitude of transparent and shielded movement so a
+  // shielded receive (transparent total 0) isn't pushed behind transparent
+  // tokens — which would otherwise mis-gate it out of the [0]-based push check
+  // or hide it past the top-N display.
+  const magnitudeA = abs(balanceA.total) + abs(balanceA.shieldedAmount);
+  const magnitudeB = abs(balanceB.total) + abs(balanceB.shieldedAmount);
+  if (magnitudeA > magnitudeB) return -1;
+  if (magnitudeA < magnitudeB) return 1;
   return 0;
 };
 

--- a/packages/wallet-service/src/api/txPushNotificationRequested.ts
+++ b/packages/wallet-service/src/api/txPushNotificationRequested.ts
@@ -56,6 +56,8 @@ class TxPushNotificationRequestValidator {
       unlockedAuthorities: TxPushNotificationRequestValidator.authoritiesSchema,
       lockExpires: Joi.number().integer().min(0).allow(null),
       total: Joi.number().required(),
+      // Optional + defaulted so payloads from daemons predating the field still validate.
+      shieldedAmount: Joi.number().default(0),
     }),
   ).required();
 
@@ -122,8 +124,12 @@ export const handleRequest: Handler<StringMap<WalletBalanceValue>, { success: bo
     // filter wallets in which the token balance > 0
     .filter((eachSettings) => {
       const wallet = body[eachSettings.walletId];
-      // verify by the first token balance
-      return wallet.walletBalanceForTx[0].total > 0;
+      // verify by the first token balance — count the shielded amount too so a
+      // pure shielded receive (transparent total 0) still notifies.
+      const firstBalance = wallet.walletBalanceForTx[0];
+      // Joi validates these as numbers, so compare as numbers (the declared
+      // bigint types don't reflect the runtime values arriving over JSON).
+      return Number(firstBalance.total) > 0 || Number(firstBalance.shieldedAmount ?? 0) > 0;
     });
 
   const genericMessages = devicesEnabledToPush
@@ -174,7 +180,9 @@ const _assembleSpecificMessage = (deviceId: string, txId: string, tokenBalanceLi
 
   const tokens = [];
   for (const eachBalance of tokenBalanceList.slice(0, upperLimit)) {
-    const amount = eachBalance.total;
+    // Combine the transparent and shielded amounts for the displayed value.
+    // Joi validates these as numbers; add as numbers to avoid a bigint/number mix.
+    const amount = Number(eachBalance.total) + Number(eachBalance.shieldedAmount ?? 0);
     const tokenSymbol = eachBalance.tokenSymbol;
     tokens.push(`${amount} ${tokenSymbol}`);
   }

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -2207,6 +2207,16 @@ export const markWalletTxHistoryAsVoided = async (
 };
 
 /**
+ * Coerce a DB integer column (returned as a string under `supportBigNumbers`)
+ * to `bigint`, so lifetime-total arithmetic keeps full precision above
+ * Number.MAX_SAFE_INTEGER. The `?? 0` fallback handles a possibly-null read
+ * defensively; in practice these columns are NOT NULL and the SUM(... ELSE 0)
+ * is never null for an existing group, so the fallback arm is unreachable.
+ */
+/* istanbul ignore next */
+const dbIntToBigInt = (value: unknown): bigint => BigInt((value ?? 0) as string | number);
+
+/**
  * Rebuilds the address_balance table for the given addresses from
  * the tx_output table
 
@@ -2226,32 +2236,45 @@ export const rebuildAddressBalancesFromUtxos = async (
   }
   // first we need to store the transactions count before deleting
   const oldAddressTokenTransactions: DbSelectResult = await mysql.query(
-    `SELECT \`address\`, \`token_id\` AS tokenId, \`transactions\`, \`total_received\` as \`totalReceived\`
+    `SELECT \`address\`, \`token_id\` AS tokenId, \`transactions\`,
+            \`total_received\` as \`totalReceived\`,
+            \`total_shielded_received\` as \`totalShieldedReceived\`
        FROM \`address_balance\`
       WHERE \`address\` IN (?)`,
     [addresses],
   );
 
-  // delete affected address_balances
+  // zero the balance columns we are about to recompute from the live UTXOs.
+  // Both transparent and shielded column families are reset so the SUM
+  // re-aggregations below are authoritative for every kind on the row.
   await mysql.query(
     `UPDATE \`address_balance\`
         SET \`unlocked_balance\` = 0,
             \`locked_balance\` = 0,
             \`locked_authorities\` = 0,
             \`unlocked_authorities\` = 0,
+            \`unlocked_shielded_balance\` = 0,
+            \`locked_shielded_balance\` = 0,
             \`timelock_expires\` = NULL,
             \`transactions\` = 0
       WHERE \`address\` IN (?)`,
     [addresses],
   );
 
-  // update address balances with unlocked utxos
+  // update address balances with unlocked utxos.
+  // The SUMs are partitioned by `mode` so a single aggregation produces both
+  // column families on the unified (address, token_id) row: transparent value
+  // (mode = 0) feeds `unlocked_balance`, recovered shielded value (mode IN (1,2)
+  // with recovery_state = 'recovered') feeds `unlocked_shielded_balance`.
+  // Authorities are transparent-only — shielded outputs never carry them.
   await mysql.query(`
     INSERT INTO address_balance (
       \`address\`,
       \`token_id\`,
       \`unlocked_balance\`,
       \`locked_balance\`,
+      \`unlocked_shielded_balance\`,
+      \`locked_shielded_balance\`,
       \`unlocked_authorities\`,
       \`locked_authorities\`,
       \`timelock_expires\`,
@@ -2259,9 +2282,11 @@ export const rebuildAddressBalancesFromUtxos = async (
     )
         SELECT address,
                 token_id,
-                SUM(\`value\`), -- unlocked_balance
+                SUM(CASE WHEN mode = 0 THEN \`value\` ELSE 0 END), -- unlocked_balance
                 0,
-                BIT_OR(\`authorities\`), -- unlocked_authorities
+                SUM(CASE WHEN mode IN (1, 2) AND recovery_state = 'recovered' THEN \`value\` ELSE 0 END), -- unlocked_shielded_balance
+                0, -- locked_shielded_balance
+                BIT_OR(CASE WHEN mode = 0 THEN \`authorities\` ELSE 0 END), -- unlocked_authorities
                 0, -- locked_authorities
                 NULL, -- timelock_expires
                 0 -- transactions
@@ -2273,16 +2298,19 @@ export const rebuildAddressBalancesFromUtxos = async (
       GROUP BY address, token_id
    ON DUPLICATE KEY UPDATE
     unlocked_balance = VALUES(unlocked_balance),
+    unlocked_shielded_balance = VALUES(unlocked_shielded_balance),
     unlocked_authorities = VALUES(unlocked_authorities)
   `, [addresses]);
 
-  // update address balances with locked utxos
+  // update address balances with locked utxos (same per-mode partitioning).
   await mysql.query(`
     INSERT INTO \`address_balance\` (
       \`address\`,
       \`token_id\`,
       \`unlocked_balance\`,
       \`locked_balance\`,
+      \`unlocked_shielded_balance\`,
+      \`locked_shielded_balance\`,
       \`locked_authorities\`,
       \`timelock_expires\`,
       \`transactions\`
@@ -2290,8 +2318,10 @@ export const rebuildAddressBalancesFromUtxos = async (
        SELECT address,
               token_id,
               0 AS unlocked_balance,
-              SUM(\`value\`) AS locked_balance,
-              BIT_OR(\`authorities\`) AS locked_authorities,
+              SUM(CASE WHEN mode = 0 THEN \`value\` ELSE 0 END) AS locked_balance,
+              0 AS unlocked_shielded_balance,
+              SUM(CASE WHEN mode IN (1, 2) AND recovery_state = 'recovered' THEN \`value\` ELSE 0 END) AS locked_shielded_balance,
+              BIT_OR(CASE WHEN mode = 0 THEN \`authorities\` ELSE 0 END) AS locked_authorities,
               MIN(\`timelock\`) AS timelock_expires,
               0 -- transactions
          FROM \`tx_output\`
@@ -2302,19 +2332,31 @@ export const rebuildAddressBalancesFromUtxos = async (
      GROUP BY \`address\`, \`token_id\`
    ON DUPLICATE KEY UPDATE
     locked_balance = VALUES(locked_balance),
+    locked_shielded_balance = VALUES(locked_shielded_balance),
     locked_authorities = VALUES(locked_authorities),
     timelock_expires = VALUES(timelock_expires)
    `, [addresses]);
 
   const addressTransactionCount: StringMap<number> = await getAffectedAddressTxCountFromTxList(mysql, txList);
-  const addressTotalReceived: StringMap<number> = await getAffectedAddressTotalReceivedFromTxList(mysql, txList);
+  const addressTotalReceived = await getAffectedAddressTotalReceivedFromTxList(mysql, txList);
   const tokenTransactionCount: StringMap<number> = await getAffectedTokenTxCountFromTxList(mysql, txList);
 
-  const finalValues = oldAddressTokenTransactions.map(({ address, tokenId, transactions, totalReceived }) => {
+  const finalValues = oldAddressTokenTransactions.map(({
+    address, tokenId, transactions, totalReceived, totalShieldedReceived,
+  }) => {
     const diffTransactions = addressTransactionCount[`${address}_${tokenId}`] || 0;
-    const diffTotalReceived = addressTotalReceived[`${address}_${tokenId}`] || 0;
+    const diff = addressTotalReceived[`${address}_${tokenId}`] || { totalReceived: 0n, totalShieldedReceived: 0n };
 
-    return [transactions as number - diffTransactions, totalReceived as number - diffTotalReceived, address, tokenId];
+    return [
+      transactions as number - diffTransactions,
+      // total_received / total_shielded_received are 64-bit DB integers; keep the
+      // arithmetic in bigint and stringify for MySQL so amounts above
+      // Number.MAX_SAFE_INTEGER don't lose precision during the rebuild.
+      (dbIntToBigInt(totalReceived) - diff.totalReceived).toString(),
+      (dbIntToBigInt(totalShieldedReceived) - diff.totalShieldedReceived).toString(),
+      address,
+      tokenId,
+    ];
   });
 
   // update address balances with the correct amount of transactions
@@ -2324,7 +2366,8 @@ export const rebuildAddressBalancesFromUtxos = async (
     await mysql.query(`
       UPDATE \`address_balance\`
         SET \`transactions\` = ?,
-            \`total_received\` = ?
+            \`total_received\` = ?,
+            \`total_shielded_received\` = ?
        WHERE \`address\` = ?
          AND \`token_id\` = ?
     `, item);
@@ -2608,24 +2651,25 @@ export const getMinersList = async (
 };
 
 /**
- * Get the total sum of a token's utxos, excluding the burned and voided ones
+ * Get a token's total supply.
+ *
+ * Reads the value tracked by the daemon's mint/melt/burn/block-reward dispatch
+ * directly from `token.total_supply`. The previous implementation summed
+ * `tx_output.value` per-call; that approach is structurally wrong once
+ * shielded outputs are in play (their `value` may be NULL on the shielded
+ * row) and is also slower as the table grows.
  *
  * @param mysql - Database connection
-
- * @returns The calculated sum
+ * @returns The token's total supply
  */
 export const getTotalSupply = async (
   mysql: ServerlessMysql,
   tokenId: string,
 ): Promise<bigint> => {
-  const results: DbSelectResult = await mysql.query(`
-    SELECT SUM(value) as value
-      FROM tx_output
-     WHERE spent_by IS NULL
-       AND token_id = ?
-       AND voided = FALSE
-       AND address != '${BURN_ADDRESS}'
-  `, [tokenId]);
+  const results: DbSelectResult = await mysql.query(
+    `SELECT total_supply AS value FROM token WHERE id = ?`,
+    [tokenId],
+  );
 
   if (!results.length) {
     // This should never happen.
@@ -2728,6 +2772,7 @@ export const getAvailableAuthorities = async (
      AND voided = FALSE
      AND locked = FALSE
      AND spent_by IS NULL
+     AND mode = 0
   `, [tokenId]);
 
   const utxos = results.map(mapDbResultToDbTxOutput);
@@ -2808,14 +2853,19 @@ export const getAffectedTokenTxCountFromTxList = async (
  * @param mysql - Database connection
  * @param txList - A list of affected transactions
 
- * @returns {Promise<StringMap<number>>} A Map with address_tokenId as key and the affected total_received as values
+ * @returns {Promise<StringMap<bigint>>} A Map with address_tokenId as key and the affected total_received as values
  */
 export const getAffectedAddressTotalReceivedFromTxList = async (
   mysql: ServerlessMysql,
   txList: string[],
-): Promise<StringMap<number>> => {
+): Promise<StringMap<{ totalReceived: bigint, totalShieldedReceived: bigint }>> => {
+  // Partition the voided-output sum by `mode` so the lifetime accumulators are
+  // adjusted per-kind: transparent (mode = 0) decrements `total_received`,
+  // recovered shielded (mode IN (1, 2)) decrements `total_shielded_received`.
   const results: DbSelectResult = await mysql.query(`
-    SELECT address, token_id as tokenId, SUM(value) as total
+    SELECT address, token_id as tokenId,
+           SUM(CASE WHEN mode = 0 THEN value ELSE 0 END) as total,
+           SUM(CASE WHEN mode IN (1, 2) AND recovery_state = 'recovered' THEN value ELSE 0 END) as totalShielded
       FROM tx_output
      WHERE tx_id IN (?)
        AND voided = TRUE
@@ -2824,15 +2874,17 @@ export const getAffectedAddressTotalReceivedFromTxList = async (
 
   const addressTotalReceivedMap = results.reduce((acc, result) => {
     const address = result.address as string;
-    const total = result.total as number;
     const tokenId = result.tokenId as string;
 
-    acc[`${address}_${tokenId}`] = total;
+    acc[`${address}_${tokenId}`] = {
+      totalReceived: dbIntToBigInt(result.total),
+      totalShieldedReceived: dbIntToBigInt(result.totalShielded),
+    };
 
     return acc;
   }, {});
 
-  return addressTotalReceivedMap as StringMap<number>;
+  return addressTotalReceivedMap as StringMap<{ totalReceived: bigint, totalShieldedReceived: bigint }>;
 };
 
 /**

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -425,6 +425,9 @@ export type TokenBalanceValue = {
   unlockedAuthorities: Record<string, unknown>;
   lockExpires: number | null;
   total: bigint;
+  // Net shielded balance change for this tx (transparent `total` excludes it).
+  // Optional for backwards-compatibility with daemons that predate the field.
+  shieldedAmount?: bigint;
 }
 
 export class WalletTokenBalance {

--- a/packages/wallet-service/src/ws/txNotify.ts
+++ b/packages/wallet-service/src/ws/txNotify.ts
@@ -31,6 +31,10 @@ const newTxbodySchema = Joi.object({
     .items(Joi.string())
     .min(1)
     .required(),
+  // `tx` is intentionally an unconstrained object: the daemon forwards the full
+  // Transaction shape, including the additive `shielded_outputs` and `addresses`
+  // fields that ride inside `data` on the realtime `new-tx` frame. Keep it
+  // keyless (or allow unknown) so those pass through untouched to the client.
   tx: Joi.object().required(),
 });
 

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -150,8 +150,8 @@ test('GET /addresses', async () => {
   }]);
 
   const addresses = [
-    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, seqnum: 1 },
-    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, seqnum: 2 },
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, seqnum: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, seqnum: 2, bip32_account: 0 },
   ];
 
   await addToAddressTable(mysql, addresses);
@@ -239,10 +239,10 @@ test('GET /addresses/check_mine', async () => {
   }]);
 
   await addToAddressTable(mysql, [
-    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[2], index: 3, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[3], index: 4, walletId: 'my-wallet', transactions: 0 },
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[2], index: 3, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[3], index: 4, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
   ]);
 
   // missing wallet
@@ -332,17 +332,17 @@ test('GET /addresses/new', async () => {
     readyAt: 10001,
   }]);
   await addToAddressTable(mysql, [
-    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[2], index: 2, walletId: 'my-wallet', transactions: 2 },
-    { address: ADDRESSES[3], index: 3, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[4], index: 4, walletId: 'my-wallet', transactions: 3 },
-    { address: ADDRESSES[5], index: 5, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[6], index: 6, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[7], index: 7, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[8], index: 8, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[9], index: 0, walletId: null, transactions: 0 },
-    { address: ADDRESSES[10], index: 0, walletId: 'test', transactions: 0 },
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[2], index: 2, walletId: 'my-wallet', transactions: 2, bip32_account: 0 },
+    { address: ADDRESSES[3], index: 3, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[4], index: 4, walletId: 'my-wallet', transactions: 3, bip32_account: 0 },
+    { address: ADDRESSES[5], index: 5, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[6], index: 6, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[7], index: 7, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[8], index: 8, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[9], index: 0, walletId: null, transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[10], index: 0, walletId: 'test', transactions: 0, bip32_account: 0 },
   ]);
 
   // missing wallet
@@ -380,17 +380,17 @@ test('GET /addresses/new with no transactions', async () => {
   }]);
 
   await addToAddressTable(mysql, [
-    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[2], index: 2, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[3], index: 3, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[4], index: 4, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[5], index: 5, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[6], index: 6, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[7], index: 7, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[8], index: 8, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[9], index: 0, walletId: null, transactions: 0 },
-    { address: ADDRESSES[10], index: 0, walletId: 'test', transactions: 0 },
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[2], index: 2, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[3], index: 3, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[4], index: 4, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[5], index: 5, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[6], index: 6, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[7], index: 7, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[8], index: 8, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[9], index: 0, walletId: null, transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[10], index: 0, walletId: 'test', transactions: 0, bip32_account: 0 },
   ]);
 
   // missing wallet
@@ -527,6 +527,7 @@ test('GET /balances', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
   await addToAddressBalanceTable(mysql, [[ADDRESSES[0], 'token3', 5, 1, lockExpires2, 2, 0, 0, 10]]);
   await addToWalletBalanceTable(mysql, [{
@@ -2235,8 +2236,8 @@ test('GET /addresses (query string index parameter)', async () => {
   }]);
 
   const addresses = [
-    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, seqnum: 1 },
-    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, seqnum: 2 },
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, seqnum: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, seqnum: 2, bip32_account: 0 },
   ];
 
   await addToAddressTable(mysql, addresses);
@@ -2320,8 +2321,8 @@ test('GET /address/info', async () => {
   }]);
 
   const addresses = [
-    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, seqnum: 1 },
-    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, seqnum: 2 },
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, seqnum: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, seqnum: 2, bip32_account: 0 },
   ];
 
   await addToAddressTable(mysql, addresses);

--- a/packages/wallet-service/tests/commons.test.ts
+++ b/packages/wallet-service/tests/commons.test.ts
@@ -301,6 +301,7 @@ test('unlockUtxos', async () => {
     index: 0,
     walletId,
     transactions: 1,
+    bip32_account: 0,
   }]);
 
   await addToAddressBalanceTable(mysql, [
@@ -447,6 +448,7 @@ test('unlockTimelockedUtxos', async () => {
     index: 0,
     walletId,
     transactions: 3,
+    bip32_account: 0,
   }]);
 
   await addToAddressBalanceTable(mysql, [
@@ -715,7 +717,7 @@ describe('getWalletBalancesForTx', () => {
     // register an andress to started wallet
     const addr1 = 'addr1';
     await addToAddressTable(mysql, [
-      { address: addr1, index: 0, walletId: wallet1.id, transactions: 0 },
+      { address: addr1, index: 0, walletId: wallet1.id, transactions: 0, bip32_account: 0 },
     ]);
     // address without started wallet
     const addr2 = 'addr2';
@@ -844,7 +846,7 @@ describe('getWalletBalancesForTx', () => {
       // register an andress to started wallet
       const addr1 = 'addr1';
       await addToAddressTable(mysql, [
-        { address: addr1, index: 0, walletId: wallet1.id, transactions: 0 },
+        { address: addr1, index: 0, walletId: wallet1.id, transactions: 0, bip32_account: 0 },
       ]);
       // address without started wallet
       const addr2 = 'addr2';
@@ -1016,7 +1018,7 @@ describe('getWalletBalancesForTx', () => {
       // address without started wallet
       const addr2 = 'addr2';
       await addToAddressTable(mysql, [
-        { address: addr2, index: 0, walletId: wallet1.id, transactions: 0 },
+        { address: addr2, index: 0, walletId: wallet1.id, transactions: 0, bip32_account: 0 },
       ]);
 
       // add a transaction

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -184,6 +184,7 @@ test('generateAddresses', async () => {
     index: 0,
     walletId: null,
     transactions: 0,
+    bip32_account: 0,
   }]);
   addressesInfo = await generateAddresses(mysql, XPUBKEY, maxGap);
   expect(addressesInfo.addresses).toHaveLength(maxGap);
@@ -215,6 +216,7 @@ test('generateAddresses', async () => {
     index: usedIndex,
     walletId: null,
     transactions: 1,
+    bip32_account: 0,
   }]);
   addressesInfo = await generateAddresses(mysql, XPUBKEY, maxGap);
   expect(addressesInfo.addresses).toHaveLength(maxGap + usedIndex + 1);
@@ -232,6 +234,7 @@ test('generateAddresses', async () => {
     index: usedIndex,
     walletId: null,
     transactions: 1,
+    bip32_account: 0,
   }]);
   addressesInfo = await generateAddresses(mysql, XPUBKEY, maxGap);
   expect(addressesInfo.addresses).toHaveLength(maxGap + usedIndex + 1);
@@ -258,13 +261,16 @@ test('getAddressWalletInfo', async () => {
   };
 
   // populate address table
+  let index = 0;
   for (const [address, wallet] of Object.entries(finalMap)) {
     await addToAddressTable(mysql, [{
       address,
-      index: 0,
+      index,
       walletId: wallet.walletId,
       transactions: 0,
+      bip32_account: 0,
     }]);
+    index++;
   }
   // add address that won't be requested on walletAddressMap
   await addToAddressTable(mysql, [{
@@ -272,6 +278,7 @@ test('getAddressWalletInfo', async () => {
     index: 0,
     walletId: 'wallet3',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // populate wallet table
@@ -513,10 +520,10 @@ test('updateWalletTablesWithTx', async () => {
   const ts3 = 30;
 
   await addToAddressTable(mysql, [
-    { address: 'addr1', index: 0, walletId, transactions: 1 },
-    { address: 'addr2', index: 1, walletId, transactions: 1 },
-    { address: 'addr3', index: 2, walletId, transactions: 1 },
-    { address: 'addr4', index: 0, walletId: walletId2, transactions: 1 },
+    { address: 'addr1', index: 0, walletId, transactions: 1, bip32_account: 0 },
+    { address: 'addr2', index: 1, walletId, transactions: 1, bip32_account: 0 },
+    { address: 'addr3', index: 2, walletId, transactions: 1, bip32_account: 0 },
+    { address: 'addr4', index: 0, walletId: walletId2, transactions: 1, bip32_account: 0 },
   ]);
 
   // add tx1
@@ -552,9 +559,10 @@ test('updateWalletTablesWithTx', async () => {
   // Let's pretend there's another utxo with some authorities as well
   await addToAddressTable(mysql, [{
     address: 'address1',
-    index: 0,
+    index: 4,
     walletId,
     transactions: 1,
+    bip32_account: 0,
   }]);
   await addToAddressBalanceTable(mysql, [['address1', token1, 0, 0, null, 1, 0b10, 0, 0]]);
 
@@ -747,7 +755,7 @@ test('updateAddressTablesWithTx', async () => {
   const token3 = 'token3';
   // we'll add address1 to the address table already, as if it had already received another transaction
   await addToAddressTable(mysql, [
-    { address: address1, index: null, walletId: null, transactions: 1 },
+    { address: address1, index: null, walletId: null, transactions: 1, bip32_account: 0 },
   ]);
 
   const txId1 = 'txId1';
@@ -864,6 +872,7 @@ test('getWalletAddresses', async () => {
     entries.push({
       address: ADDRESSES[i],
       index: i,
+      bip32_account: 0,
       walletId,
       transactions: 0,
     });
@@ -872,6 +881,7 @@ test('getWalletAddresses', async () => {
   entries.unshift({
     address: ADDRESSES[lastIndex],
     index: lastIndex,
+    bip32_account: 0,
     walletId,
     transactions: 0,
   });
@@ -908,6 +918,7 @@ test('getWalletAddressDetail', async () => {
       address: ADDRESSES[i],
       index: i,
       walletId,
+      bip32_account: 0,
       transactions: 0,
     });
   }
@@ -937,6 +948,7 @@ test('incrementAddressSeqnum', async () => {
     walletId,
     transactions: 0,
     seqnum: 5,
+    bip32_account: 0,
   }]);
 
   // seqnum should start at 5
@@ -1173,6 +1185,7 @@ test('updateWalletLockedBalance', async () => {
     index: 0,
     walletId: wallet1,
     transactions: 1,
+    bip32_account: 0,
   }]);
   await addToAddressBalanceTable(mysql, [['address1', tokenId, 0, 0, null, 1, 0, 0b01, 0]]);
   const newMap = TokenBalanceMap.fromStringMap({ [tokenId]: { unlocked: 0, locked: 0, unlockedAuthorities: new Authorities(0b10) } });
@@ -1329,11 +1342,13 @@ test('getWalletSortedValueUtxos', async () => {
     index: 0,
     walletId,
     transactions: 1,
+    bip32_account: 0,
   }, {
     address: addr2,
     index: 1,
     walletId,
     transactions: 1,
+    bip32_account: 0,
   }]);
   await addToUtxoTable(mysql, [
     // authority utxos should be ignored
@@ -1446,11 +1461,11 @@ test('getUnusedAddresses', async () => {
   const walletId = 'walletId';
   const walletId2 = 'walletId2';
   await addToAddressTable(mysql, [
-    { address: 'addr2', index: 1, walletId, transactions: 0 },
-    { address: 'addr3', index: 2, walletId, transactions: 2 },
-    { address: 'addr1', index: 0, walletId, transactions: 0 },
-    { address: 'addr4', index: 0, walletId: walletId2, transactions: 1 },
-    { address: 'addr5', index: 1, walletId: walletId2, transactions: 1 },
+    { address: 'addr2', index: 1, walletId, transactions: 0, bip32_account: 0 },
+    { address: 'addr3', index: 2, walletId, transactions: 2, bip32_account: 0 },
+    { address: 'addr1', index: 0, walletId, transactions: 0, bip32_account: 0 },
+    { address: 'addr4', index: 0, walletId: walletId2, transactions: 1, bip32_account: 0 },
+    { address: 'addr5', index: 1, walletId: walletId2, transactions: 1, bip32_account: 0 },
   ]);
 
   let addresses = await getUnusedAddresses(mysql, walletId);
@@ -2107,6 +2122,114 @@ test('rebuildAddressBalancesFromUtxos', async () => {
   }])).resolves.toBe(true);
 });
 
+test('rebuildAddressBalancesFromUtxos partitions transparent and shielded columns by mode', async () => {
+  expect.hasAssertions();
+
+  const addr = 'addrShieldedRebuild';
+  const token = 'token1';
+
+  // A (address, token_id) row carrying BOTH kinds of live UTXO plus a couple
+  // of voided rows that the total recomputation must subtract per-kind.
+  //   mode = 0  → transparent balance / total_received
+  //   mode = 1 + recovery_state = 'recovered' → shielded balance / total_shielded_received
+  //   mode = 1 + recovery_state = 'unowned' (value NULL) → contributes nothing
+  await mysql.query(
+    `INSERT INTO tx_output
+       (tx_id, \`index\`, mode, address, value, token_id, authorities,
+        timelock, heightlock, locked, voided, spent_by, recovery_state)
+     VALUES
+       ('txT',     0, 0, ?, 100,  ?, 0, NULL, NULL, FALSE, FALSE, NULL, NULL),
+       ('txS',     0, 1, ?, 250,  ?, 0, NULL, NULL, FALSE, FALSE, NULL, 'recovered'),
+       ('txSL',    0, 1, ?, 60,   ?, 0, 500,  NULL, TRUE,  FALSE, NULL, 'recovered'),
+       ('txSU',    0, 1, ?, NULL, ?, 0, NULL, NULL, FALSE, FALSE, NULL, 'unowned'),
+       ('txVoidT', 0, 0, ?, 40,   ?, 0, NULL, NULL, FALSE, TRUE,  NULL, NULL),
+       ('txVoidS', 0, 1, ?, 30,   ?, 0, NULL, NULL, FALSE, TRUE,  NULL, 'recovered')`,
+    [addr, token, addr, token, addr, token, addr, token, addr, token, addr, token],
+  );
+
+  // Seed the address_balance row with deliberately wrong live balances (proves
+  // they are recomputed from UTXOs) and lifetime totals that still include the
+  // about-to-be-voided amounts (proves the per-kind subtraction).
+  await mysql.query(
+    `INSERT INTO address_balance
+       (address, token_id,
+        unlocked_balance, locked_balance, total_received,
+        unlocked_shielded_balance, locked_shielded_balance, total_shielded_received,
+        unlocked_authorities, locked_authorities, transactions)
+     VALUES (?, ?, 999, 999, 140, 999, 999, 280, 0, 0, 5)`,
+    [addr, token],
+  );
+
+  await rebuildAddressBalancesFromUtxos(mysql, [addr], ['txVoidT', 'txVoidS']);
+
+  const rows = await mysql.query(
+    `SELECT unlocked_balance, locked_balance, total_received,
+            unlocked_shielded_balance, locked_shielded_balance, total_shielded_received
+       FROM address_balance WHERE address = ? AND token_id = ?`,
+    [addr, token],
+  );
+  expect(rows).toHaveLength(1);
+  const r = rows[0];
+
+  // Transparent columns reflect only mode = 0 UTXOs.
+  expect(BigInt(r.unlocked_balance)).toBe(100n);
+  expect(BigInt(r.locked_balance)).toBe(0n);
+  // total_received: 140 stored − 40 (voided transparent) = 100.
+  expect(BigInt(r.total_received)).toBe(100n);
+
+  // Shielded columns reflect only recovered mode = 1/2 UTXOs.
+  expect(BigInt(r.unlocked_shielded_balance)).toBe(250n);
+  expect(BigInt(r.locked_shielded_balance)).toBe(60n);
+  // total_shielded_received: 280 stored − 30 (voided shielded) = 250.
+  expect(BigInt(r.total_shielded_received)).toBe(250n);
+});
+
+test('rebuildAddressBalancesFromUtxos preserves bigint precision above Number.MAX_SAFE_INTEGER', async () => {
+  expect.hasAssertions();
+
+  const addr = 'addrBigIntRebuild';
+  const token = 'token1';
+
+  // Lifetime totals above 2^53 (9007199254740992). Subtracting the voided
+  // amounts via JS-number arithmetic would round these to the nearest double
+  // and corrupt the result; the rebuild must keep the arithmetic in bigint.
+  const STORED_TOTAL_RECEIVED = 9007199254740993n; // 2^53 + 1
+  const STORED_TOTAL_SHIELDED = 9007199254740995n; // 2^53 + 3
+
+  await mysql.query(
+    `INSERT INTO tx_output
+       (tx_id, \`index\`, mode, address, value, token_id, authorities,
+        timelock, heightlock, locked, voided, spent_by, recovery_state)
+     VALUES
+       ('txBigVoidT', 0, 0, ?, 1, ?, 0, NULL, NULL, FALSE, TRUE, NULL, NULL),
+       ('txBigVoidS', 0, 1, ?, 2, ?, 0, NULL, NULL, FALSE, TRUE, NULL, 'recovered')`,
+    [addr, token, addr, token],
+  );
+
+  await mysql.query(
+    `INSERT INTO address_balance
+       (address, token_id,
+        unlocked_balance, locked_balance, total_received,
+        unlocked_shielded_balance, locked_shielded_balance, total_shielded_received,
+        unlocked_authorities, locked_authorities, transactions)
+     VALUES (?, ?, 0, 0, ?, 0, 0, ?, 0, 0, 2)`,
+    [addr, token, STORED_TOTAL_RECEIVED.toString(), STORED_TOTAL_SHIELDED.toString()],
+  );
+
+  await rebuildAddressBalancesFromUtxos(mysql, [addr], ['txBigVoidT', 'txBigVoidS']);
+
+  const rows = await mysql.query(
+    `SELECT total_received, total_shielded_received
+       FROM address_balance WHERE address = ? AND token_id = ?`,
+    [addr, token],
+  );
+  expect(rows).toHaveLength(1);
+  // Exact bigint differences; a number-based subtraction would yield
+  // 9007199254740991 / 9007199254740994 here.
+  expect(BigInt(rows[0].total_received)).toBe(STORED_TOTAL_RECEIVED - 1n);
+  expect(BigInt(rows[0].total_shielded_received)).toBe(STORED_TOTAL_SHIELDED - 2n);
+});
+
 test('markAddressTxHistoryAsVoided', async () => {
   expect.hasAssertions();
 
@@ -2178,11 +2301,13 @@ test('filterTxOutputs', async () => {
     index: 0,
     walletId,
     transactions: 1,
+    bip32_account: 0,
   }, {
     address: addr2,
     index: 1,
     walletId,
     transactions: 1,
+    bip32_account: 0,
   }]);
 
   await addToUtxoTable(mysql, [{
@@ -2494,48 +2619,18 @@ test('getMinersList', async () => {
   ]));
 });
 
-test('getTotalSupply', async () => {
+test('getTotalSupply reads from token.total_supply', async () => {
   expect.hasAssertions();
 
-  const txId = 'txId';
-  const utxos = [
-    { value: 500n, address: 'HDeadDeadDeadDeadDeadDeadDeagTPgmn', tokenId: '00', locked: false },
-    { value: 5n, address: 'address1', tokenId: '00', locked: false },
-    { value: 15n, address: 'address1', tokenId: '00', locked: false },
-    { value: 25n, address: 'address2', tokenId: 'token2', timelock: 500, locked: true },
-    { value: 35n, address: 'address2', tokenId: 'token1', locked: false },
-    // authority utxo
-    { value: 0b11n, address: 'address1', tokenId: 'token1', locked: false, tokenData: 129 },
-  ];
+  await mysql.query(`INSERT INTO token (id, name, symbol, total_supply) VALUES ('00', 'Hathor', 'HTR', 12345)`);
 
-  // add to utxo table
-  const outputs = utxos.map((utxo, index) => createOutput(
-    index,
-    utxo.value,
-    utxo.address,
-    utxo.tokenId,
-    utxo.timelock || null,
-    utxo.locked,
-    utxo.tokenData || 0,
-  ));
+  expect(await getTotalSupply(mysql, '00')).toStrictEqual(12345n);
+});
 
-  await addUtxos(mysql, txId, outputs);
+test('getTotalSupply throws when token does not exist', async () => {
+  expect.hasAssertions();
 
-  expect(await getTotalSupply(mysql, '00')).toStrictEqual(20n);
-  expect(await getTotalSupply(mysql, 'token2')).toStrictEqual(25n);
-  expect(await getTotalSupply(mysql, 'token1')).toStrictEqual(35n);
-
-  const mysqlQuerySpy = jest.spyOn(mysql, 'query');
-  mysqlQuerySpy.mockImplementationOnce(() => Promise.resolve({ length: null }));
-
-  await expect(getTotalSupply(mysql, 'undefined-token')).rejects.toThrow('Total supply query returned no results');
-  expect(mockedAddAlert).toHaveBeenCalledWith(
-    'Total supply query returned no results',
-    '-',
-    Severity.MINOR,
-    { tokenId: 'undefined-token' },
-    logger,
-  );
+  await expect(getTotalSupply(mysql, 'nonexistent')).rejects.toThrow('Total supply query returned no results');
 });
 
 test('getExpiredTimelocksUtxos', async () => {
@@ -3770,6 +3865,7 @@ describe('getAddressByIndex', () => {
       walletId,
       transactions,
       seqnum,
+      bip32_account: 0,
     }]);
 
     await expect(getAddressAtIndex(mysql, walletId, index))
@@ -3919,7 +4015,7 @@ describe('hasTransactionsOnNonFirstAddress', () => {
     const walletId = 'test-wallet';
     await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, 5);
     await addToAddressTable(mysql, [
-      { address: ADDRESSES[0], index: 0, walletId, transactions: 5 },
+      { address: ADDRESSES[0], index: 0, walletId, transactions: 5, bip32_account: 0 },
     ]);
 
     const result = await Db.hasTransactionsOnNonFirstAddress(mysql, walletId);
@@ -3933,9 +4029,9 @@ describe('hasTransactionsOnNonFirstAddress', () => {
     const walletId = 'test-wallet';
     await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, 5);
     await addToAddressTable(mysql, [
-      { address: ADDRESSES[0], index: 0, walletId, transactions: 5 },
-      { address: ADDRESSES[1], index: 1, walletId, transactions: 0 },
-      { address: ADDRESSES[2], index: 2, walletId, transactions: 0 },
+      { address: ADDRESSES[0], index: 0, walletId, transactions: 5, bip32_account: 0 },
+      { address: ADDRESSES[1], index: 1, walletId, transactions: 0, bip32_account: 0 },
+      { address: ADDRESSES[2], index: 2, walletId, transactions: 0, bip32_account: 0 },
     ]);
 
     const result = await Db.hasTransactionsOnNonFirstAddress(mysql, walletId);
@@ -3949,8 +4045,8 @@ describe('hasTransactionsOnNonFirstAddress', () => {
     const walletId = 'test-wallet';
     await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, 5);
     await addToAddressTable(mysql, [
-      { address: ADDRESSES[0], index: 0, walletId, transactions: 5 },
-      { address: ADDRESSES[1], index: 1, walletId, transactions: 3 },
+      { address: ADDRESSES[0], index: 0, walletId, transactions: 5, bip32_account: 0 },
+      { address: ADDRESSES[1], index: 1, walletId, transactions: 3, bip32_account: 0 },
     ]);
 
     const result = await Db.hasTransactionsOnNonFirstAddress(mysql, walletId);
@@ -3967,8 +4063,8 @@ describe('hasTransactionsOnNonFirstAddress', () => {
     await createWallet(mysql, walletId2, XPUBKEY, AUTH_XPUBKEY, 5);
 
     await addToAddressTable(mysql, [
-      { address: ADDRESSES[0], index: 0, walletId: walletId1, transactions: 5 },
-      { address: ADDRESSES[1], index: 1, walletId: walletId2, transactions: 10 },
+      { address: ADDRESSES[0], index: 0, walletId: walletId1, transactions: 5, bip32_account: 0 },
+      { address: ADDRESSES[1], index: 1, walletId: walletId2, transactions: 10, bip32_account: 0 },
     ]);
 
     const result1 = await Db.hasTransactionsOnNonFirstAddress(mysql, walletId1);

--- a/packages/wallet-service/tests/hasTxOutsideFirstAddr.test.ts
+++ b/packages/wallet-service/tests/hasTxOutsideFirstAddr.test.ts
@@ -73,8 +73,8 @@ describe('GET /wallet/addresses/has-transactions-outside-first-address', () => {
       readyAt: 10001,
     }]);
     await addToAddressTable(mysql, [
-      { address: ADDRESSES[0], index: 0, walletId, transactions: 10 },
-      { address: ADDRESSES[1], index: 1, walletId, transactions: 0 },
+      { address: ADDRESSES[0], index: 0, walletId, transactions: 10, bip32_account: 0 },
+      { address: ADDRESSES[1], index: 1, walletId, transactions: 0, bip32_account: 0 },
     ]);
 
     const event = makeGatewayEventWithAuthorizer(walletId, null);
@@ -100,8 +100,8 @@ describe('GET /wallet/addresses/has-transactions-outside-first-address', () => {
       readyAt: 10001,
     }]);
     await addToAddressTable(mysql, [
-      { address: ADDRESSES[0], index: 0, walletId, transactions: 10 },
-      { address: ADDRESSES[1], index: 1, walletId, transactions: 5 },
+      { address: ADDRESSES[0], index: 0, walletId, transactions: 10, bip32_account: 0 },
+      { address: ADDRESSES[1], index: 1, walletId, transactions: 5, bip32_account: 0 },
     ]);
 
     const event = makeGatewayEventWithAuthorizer(walletId, null);

--- a/packages/wallet-service/tests/txOutputs.test.ts
+++ b/packages/wallet-service/tests/txOutputs.test.ts
@@ -42,11 +42,13 @@ test('filter utxos api with invalid parameters', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -172,11 +174,13 @@ test('filter tx_output api with invalid parameters', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -301,11 +305,13 @@ test('get utxos with wallet id', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -407,11 +413,13 @@ test('get tx outputs with wallet id', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -513,11 +521,13 @@ test('get authority utxos', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -642,11 +652,13 @@ test('get a specific utxo', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -746,11 +758,13 @@ test('get utxos from addresses that are not my own should fail with ApiError.ADD
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'other-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -832,11 +846,13 @@ test('get spent tx_output', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -904,17 +920,17 @@ test('filter utxos by addresses and max utxos', async () => {
   }]);
 
   await addToAddressTable(mysql, [
-    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[2], index: 2, walletId: 'my-wallet', transactions: 2 },
-    { address: ADDRESSES[3], index: 3, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[4], index: 4, walletId: 'my-wallet', transactions: 3 },
-    { address: ADDRESSES[5], index: 5, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[6], index: 6, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[7], index: 7, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[8], index: 8, walletId: 'my-wallet', transactions: 0 },
-    { address: ADDRESSES[9], index: 0, walletId: null, transactions: 0 },
-    { address: ADDRESSES[10], index: 0, walletId: 'test', transactions: 0 },
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[2], index: 2, walletId: 'my-wallet', transactions: 2, bip32_account: 0 },
+    { address: ADDRESSES[3], index: 3, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[4], index: 4, walletId: 'my-wallet', transactions: 3, bip32_account: 0 },
+    { address: ADDRESSES[5], index: 5, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[6], index: 6, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[7], index: 7, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[8], index: 8, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[9], index: 0, walletId: null, transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[10], index: 0, walletId: 'test', transactions: 0, bip32_account: 0 },
   ]);
 
   await addToUtxoTable(mysql, [{
@@ -998,11 +1014,13 @@ test('filter tx_outputs with totalAmount', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '00';
@@ -1122,6 +1140,7 @@ test('filter tx_outputs with totalAmount insufficient funds', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '00';
@@ -1184,11 +1203,13 @@ test('filter tx_outputs with maxAmount', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }, {
     address: ADDRESSES[1],
     index: 1,
     walletId: 'my-wallet',
     transactions: 4,
+    bip32_account: 0,
   }]);
 
   const token1 = '00';
@@ -1319,6 +1340,7 @@ test('filter tx_outputs with both totalAmount and maxAmount should fail', async 
     index: 0,
     walletId: 'my-wallet',
     transactions: 1,
+    bip32_account: 0,
   }]);
 
   const event = makeGatewayEventWithAuthorizer('my-wallet', {

--- a/packages/wallet-service/tests/txProposal.test.ts
+++ b/packages/wallet-service/tests/txProposal.test.ts
@@ -99,6 +99,7 @@ test('POST /txproposals with utxos that are already used on another txproposal s
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -165,6 +166,7 @@ test('POST /txproposals with utxos that are already used on another txproposal s
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -242,6 +244,7 @@ test('POST /txproposals with too many outputs should fail with ApiError.TOO_MANY
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -291,6 +294,7 @@ test('POST /txproposals with a wallet that is not ready should fail with ApiErro
     index: 0,
     walletId: 'not-ready-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const utxos = [{
@@ -354,6 +358,7 @@ test('POST /txproposals with a wallet that is not ready should fail with ApiErro
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   const event = makeGatewayEventWithAuthorizer('not-ready-wallet', null, JSON.stringify({ txHex: '0001000102006f1ebedd590bb5db5c71adbdeaa9b15f7f75c6257c26b11781dc1a5b20f83300006a473045022100fd6b496012c0db9f7300f2e399cfd2706e85f294e4a9195583df35174496a27d022007f3ea316c74a4f61719d2eff347dd4a88d7041fe7f7251514a38b66c0de097c2102b31636b7f35a6cbb42a2053554314a4ca808b7c4840dcc306060a5e7a3ae1b2b0000006400001976a91482965a89ed19afbc81ad0fc82861ffea3e6c591b88ac0001863b00001976a9140f101f6734e10ad87d305cf5af679e3362a659f488ac40200000218def4160dcc4660200b584c970b3597d59f3d3b8bf52c4928c6ce25604fe3488467d3f2c0f4dd6e2006f1ebedd590bb5db5c71adbdeaa9b15f7f75c6257c26b11781dc1a5b20f83300000161' }));
@@ -381,6 +386,7 @@ test('PUT /txproposals/{proposalId} with an empty body should fail with ApiError
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -447,6 +453,7 @@ test('PUT /txproposals/{proposalId} with an empty body should fail with ApiError
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -522,6 +529,7 @@ test('PUT /txproposals/{proposalId} on a proposal which status is not OPEN or SE
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -588,6 +596,7 @@ test('PUT /txproposals/{proposalId} on a proposal which status is not OPEN or SE
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -647,6 +656,7 @@ test('PUT /txproposals/{proposalId} on a proposal which is not owned by the user
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -713,6 +723,7 @@ test('PUT /txproposals/{proposalId} on a proposal which is not owned by the user
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -804,6 +815,7 @@ test('PUT /txproposals/{proposalId} with an invalid txHex should fail and update
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -870,6 +882,7 @@ test('PUT /txproposals/{proposalId} with an invalid txHex should fail and update
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -954,6 +967,7 @@ test('PUT /txproposals/{proposalId} should update tx_proposal to SEND_ERROR on f
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -1020,6 +1034,7 @@ test('PUT /txproposals/{proposalId} should update tx_proposal to SEND_ERROR on f
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -1074,6 +1089,7 @@ test('DELETE /txproposals/{proposalId} should delete a tx_proposal and remove th
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -1140,6 +1156,7 @@ test('DELETE /txproposals/{proposalId} should delete a tx_proposal and remove th
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -1244,6 +1261,7 @@ test('POST /txproposals one output and input on txHex', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -1310,6 +1328,7 @@ test('POST /txproposals one output and input on txHex', async () => {
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -1368,12 +1387,14 @@ test('POST /txproposals with denied utxos', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[1],
     index: 0,
     walletId: 'other-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -1458,6 +1479,7 @@ test('POST /txproposals a tx create action on txHex', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const utxos = [{
@@ -1479,6 +1501,7 @@ test('POST /txproposals a tx create action on txHex', async () => {
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // hathor input for deposit
@@ -1598,6 +1621,7 @@ test('PUT /txproposals/{proposalId} with txhex', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -1664,6 +1688,7 @@ test('PUT /txproposals/{proposalId} with txhex', async () => {
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -1746,6 +1771,7 @@ test('PUT /txproposals/{proposalId} with a different txhex than the one sent in 
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -1812,6 +1838,7 @@ test('PUT /txproposals/{proposalId} with a different txhex than the one sent in 
     index: 1,
     walletId: 'my-wallet',
     transactions: 0,
+    bip32_account: 0,
   }]);
 
   // only one output, spending the whole 300 utxo of token1
@@ -1896,6 +1923,7 @@ test('POST /txproposals with empty inputs array should succeed', async () => {
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   // Create a transaction with no inputs and no outputs (e.g., for nano contracts)
@@ -1936,6 +1964,7 @@ test('POST /txproposals should create tx_proposal BEFORE marking UTXOs (transact
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -2008,6 +2037,7 @@ test('DELETE /txproposals should update status and release UTXOs atomically', as
     index: 0,
     walletId: 'my-wallet',
     transactions: 2,
+    bip32_account: 0,
   }]);
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
@@ -2117,6 +2147,7 @@ test('POST /txproposals with nano contract tx should increment caller address se
     walletId: 'my-wallet',
     transactions: 0,
     seqnum: 3,
+    bip32_account: 0,
   }]);
 
   // Verify initial seqnum

--- a/packages/wallet-service/tests/txProposalUtxoUnlock.test.ts
+++ b/packages/wallet-service/tests/txProposalUtxoUnlock.test.ts
@@ -97,6 +97,7 @@ describe('TxProposal UTXO unlocking on send failure', () => {
       index: 0,
       walletId: 'test-wallet',
       transactions: 1,
+      bip32_account: 0,
     }]);
 
     const tokenId = '00';
@@ -230,6 +231,7 @@ describe('TxProposal UTXO unlocking on send failure', () => {
       index: 0,
       walletId: 'test-wallet',
       transactions: 1,
+      bip32_account: 0,
     }]);
 
     const tokenId = '00';

--- a/packages/wallet-service/tests/txPushNotificationRequested.test.ts
+++ b/packages/wallet-service/tests/txPushNotificationRequested.test.ts
@@ -325,6 +325,110 @@ describe('success', () => {
 `);
     });
 
+    it('shielded-only receive (transparent total 0, shieldedAmount > 0) notifies with the combined amount', async () => {
+      expect.hasAssertions();
+
+      // Pure shielded receive: transparent total is 0, the value rides in
+      // shieldedAmount. The notification must still fire (gate counts the
+      // shielded amount) and display the combined amount.
+      const sendEvent = buildEvent(walletId, txId, [
+        {
+          tokenId: 'token2',
+          tokenSymbol: 'T2',
+          lockExpires: null,
+          lockedAmount: 0,
+          lockedAuthorities: { melt: false, mint: false },
+          total: 0,
+          totalAmountSent: 0,
+          unlockedAmount: 0,
+          unlockedAuthorities: { melt: false, mint: false },
+          shieldedAmount: 150,
+        } as any,
+      ]);
+      const sendContext = { awsRequestId: '123' } as Context;
+
+      const result = await handleRequest(sendEvent, sendContext, null) as { success: boolean };
+
+      expect(result.success).toStrictEqual(true);
+      expect(spyOnInvokeSendNotification).toHaveBeenCalledTimes(1);
+      const notificationSentOnSpy = spyOnInvokeSendNotification.mock.calls[0][0];
+      expect(notificationSentOnSpy.metadata.bodyLocArgs).toStrictEqual(JSON.stringify(['150 T2']));
+    });
+
+    it('combines positive transparent and shielded amounts for the same token', async () => {
+      expect.hasAssertions();
+
+      // A single token receiving both transparently (100) and shielded (50): the
+      // displayed amount is the sum (150). Asserting the combined value guards the
+      // `total + shieldedAmount` against regressing to a subtraction, a max, or a
+      // dropped term — every other case is transparent-only or shielded-only.
+      const sendEvent = buildEvent(walletId, txId, [
+        {
+          tokenId: 'token2',
+          tokenSymbol: 'T2',
+          lockExpires: null,
+          lockedAmount: 0,
+          lockedAuthorities: { melt: false, mint: false },
+          total: 100,
+          totalAmountSent: 100,
+          unlockedAmount: 100,
+          unlockedAuthorities: { melt: false, mint: false },
+          shieldedAmount: 50,
+        } as any,
+      ]);
+      const sendContext = { awsRequestId: '123' } as Context;
+
+      const result = await handleRequest(sendEvent, sendContext, null) as { success: boolean };
+
+      expect(result.success).toStrictEqual(true);
+      expect(spyOnInvokeSendNotification).toHaveBeenCalledTimes(1);
+      const notificationSentOnSpy = spyOnInvokeSendNotification.mock.calls[0][0];
+      expect(notificationSentOnSpy.metadata.bodyLocArgs).toStrictEqual(JSON.stringify(['150 T2']));
+    });
+
+    it('shielded receive at [0] alongside transparent activity survives the gate', async () => {
+      expect.hasAssertions();
+
+      // The daemon sorts shielded-first (sortBalanceValueByAbsTotal), and the gate
+      // here trusts walletBalanceForTx[0]. Feed the list as the daemon delivers it
+      // — a transparent-total-0 shielded receive at [0], a smaller transparent
+      // token at [1] — and confirm the gate counts the shielded entry (so it isn't
+      // mis-gated out) and both amounts display.
+      const sendEvent = buildEvent(walletId, txId, [
+        {
+          tokenId: 'token2',
+          tokenSymbol: 'T2',
+          lockExpires: null,
+          lockedAmount: 0,
+          lockedAuthorities: { melt: false, mint: false },
+          total: 0,
+          totalAmountSent: 0,
+          unlockedAmount: 0,
+          unlockedAuthorities: { melt: false, mint: false },
+          shieldedAmount: 150,
+        } as any,
+        {
+          tokenId: 'token1',
+          tokenSymbol: 'T1',
+          lockExpires: null,
+          lockedAmount: 0,
+          lockedAuthorities: { melt: false, mint: false },
+          total: 5,
+          totalAmountSent: 5,
+          unlockedAmount: 5,
+          unlockedAuthorities: { melt: false, mint: false },
+        },
+      ]);
+      const sendContext = { awsRequestId: '123' } as Context;
+
+      const result = await handleRequest(sendEvent, sendContext, null) as { success: boolean };
+
+      expect(result.success).toStrictEqual(true);
+      expect(spyOnInvokeSendNotification).toHaveBeenCalledTimes(1);
+      const notificationSentOnSpy = spyOnInvokeSendNotification.mock.calls[0][0];
+      expect(notificationSentOnSpy.metadata.bodyLocArgs).toStrictEqual(JSON.stringify(['150 T2', '5 T1']));
+    });
+
     it('token balance with 2 token', async () => {
       expect.hasAssertions();
 

--- a/packages/wallet-service/tests/types.ts
+++ b/packages/wallet-service/tests/types.ts
@@ -35,6 +35,17 @@ export interface AddressTableEntry {
   walletId?: string;
   transactions: number;
   seqnum?: number;
+  // Hathor BIP32 account slot. Stored values: 0 = Legacy (m/44'/280'/0'),
+  // 2 = CTSpend (m/44'/280'/2'). Account 1 = CTScan is reserved for the
+  // scan-key derivation and never stored as a row identifier. Required so
+  // tests are explicit about which slot they're seeding; the unique
+  // constraint on (wallet_id, bip32_account, index) enforces strictly.
+  bip32_account: number;
+  // CTSpend-only fields. Set on bip32_account = 2 rows that represent an
+  // owned CTSpend slot; left undefined / NULL on Legacy rows.
+  scan_privkey?: Buffer;
+  catchup_state?: 'pending' | 'running' | 'done';
+  ct_address?: string;
 }
 
 export interface TokenTableEntry {

--- a/packages/wallet-service/tests/utils.ts
+++ b/packages/wallet-service/tests/utils.ts
@@ -691,11 +691,17 @@ export const addToAddressTable = async (
     entry.walletId,
     entry.transactions,
     entry.seqnum ?? 0,
+    entry.bip32_account,
+    entry.scan_privkey ?? null,
+    entry.catchup_state ?? null,
+    entry.ct_address ?? null,
   ]));
 
   await mysql.query(`
     INSERT INTO \`address\`(\`address\`, \`index\`,
-                            \`wallet_id\`, \`transactions\`, \`seqnum\`)
+                            \`wallet_id\`, \`transactions\`, \`seqnum\`,
+                            \`bip32_account\`, \`scan_privkey\`,
+                            \`catchup_state\`, \`ct_address\`)
     VALUES ?`,
   [payload]);
 };


### PR DESCRIPTION
## Motivation

Shielded outputs require new database operations that don't exist in the current schema: storing encrypted output data, tracking CT address observations, and recording the outcome of amount-rewind attempts. Without these helpers, the ingestion layer (PR5) has no way to persist shielded state.

This PR adds the write/query layer over the columns introduced in PR2, keeping it isolated from ingestion so the DB logic can be reviewed independently.

## Summary

**`packages/daemon/src/db/index.ts`** — 5 new helpers:
- `insertShieldedTxOutputData` — inserts a row into `shielded_tx_output_data` for AmountShielded and FullyShielded outputs
- `upsertShieldedAddressObservation` — records that a CT address appeared in a tx; `bip32_account = NULL` marks observation-only (not yet resolved to a wallet key)
- `findShieldedAddressOwnership` — looks up which wallets own a CT address, returning the `bip32_account` index needed for rewind dispatch
- `markTxOutputRecovered` — sets `recovery_state = 'recovered'` and writes the recovered `value` after a successful rewind
- `markTxOutputRecoveryFailed` — sets `recovery_state = 'recovery_failed'` when rewind is impossible or the output belongs to another wallet

**`packages/daemon/src/types/db.ts`** — `DbTxOutput` extended with `mode: number` and `recoveryState: string | null`

**`packages/daemon/src/types/transaction.ts`** — adds `RecoveryState` union type and `ShieldedOutputMode` enum

**`@ts-ignore` annotations** — `unlockUtxos` in `utils/wallet.ts` maps `DbTxOutput` to `TxOutput[]`; `value` and `tokenId` are now nullable on shielded rows, but the function itself is rewritten in PR5. Three `@ts-ignore`s mark the call sites.

**6 new test suites** covering every new helper (insert, upsert, find, mark-recovered, mark-failed, shielded spent-by update). All 19/19 suites pass (253 tests).

## Acceptance Criteria

- [ ] `packages/daemon/src/db/index.ts` exports all 5 new helpers
- [ ] `DbTxOutput` has `mode: number` and `recoveryState: string | null`
- [ ] `RecoveryState` and `ShieldedOutputMode` are exported from `types/transaction.ts`
- [ ] 6 new DB test suites exist, one per helper group
- [ ] Full daemon suite passes: 19/19 suites, 253/253 tests
- [ ] `tsc` compiles clean (no errors beyond the 3 annotated `@ts-ignore`s in `unlockUtxos`)
- [ ] No calls to `@hathor/ct-crypto-node` anywhere in this PR
- [ ] New helpers are not yet called from `services/index.ts` (wired in PR5)

## Stack

1. #439 — foundations
2. #442 — migrations
3. #443 — event schema
4. **#444 — DB helpers**
5. #446 — ingestion
6. #447 — wallet-service read-path

Built clean from the net state of #434 (the reference branch), which stays open as the reference until this stack lands.