### PR TITLE
feat(push-notification): push notification events (8)

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -26,6 +26,23 @@ export enum Severity {
   INFO = 'info',
 }
 
+/**
+ * Lightweight projection of a shielded output for the realtime `new-tx`
+ * payload. Shielded values are encrypted, so clients can't derive balances
+ * from the wire — they intersect `Transaction.addresses` with their own and
+ * refetch. This carries only what's safe and useful for that: the kind,
+ * token slot, and decoded address. The on-chain crypto blobs (commitment,
+ * range_proof, ephemeral_pubkey, …) are intentionally omitted.
+ */
+export interface RealtimeShieldedOutput {
+  mode: number;
+  // Present only for AmountShielded (mode 1); FullyShielded (mode 2) hides the
+  // token, so there is no token slot to report.
+  // eslint-disable-next-line camelcase
+  token_data?: number;
+  decoded: { address: string } | null;
+}
+
 export interface Transaction {
   // eslint-disable-next-line camelcase
   tx_id: string;
@@ -45,6 +62,12 @@ export interface Transaction {
   token_name?: string | null;
   // eslint-disable-next-line camelcase
   token_symbol?: string | null;
+  // Additive shielded-outputs realtime fields (see RealtimeShieldedOutput).
+  // `addresses` is the full involved-address set the daemon computed for the
+  // vertex; the client intersects it with its own addresses and refetches.
+  // eslint-disable-next-line camelcase
+  shielded_outputs?: RealtimeShieldedOutput[];
+  addresses?: string[];
 }
 
 export interface TxInput {

--- a/packages/daemon/__tests__/services/newTxRealtime.test.ts
+++ b/packages/daemon/__tests__/services/newTxRealtime.test.ts
@@ -31,7 +31,7 @@ jest.mock('../../src/utils/aws', () => {
 
 import * as db from '../../src/db';
 import { handleVertexAccepted } from '../../src/services';
-import { LRU, getWalletBalancesForTx } from '../../src/utils';
+import { LRU, getWalletBalancesForTx, sortBalanceValueByAbsTotal } from '../../src/utils';
 import { sendRealtimeTx } from '../../src/utils/aws';
 import { cleanDatabase, XPUBKEY } from '../utils';
 import { TokenBalanceMap } from '@wallet-service/common';
@@ -150,5 +150,50 @@ describe('getWalletBalancesForTx shielded amounts (push payload)', () => {
     // transparent total stays zero; the shielded receive rides in shieldedAmount.
     expect(tokenBalance.total).toBe(0n);
     expect(tokenBalance.shieldedAmount).toBe(150n);
+  });
+
+  it('reports shieldedAmount = 0 for a shielded spend (never negative)', async () => {
+    expect.hasAssertions();
+
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WCTSpend1', 'wallet_alice', 7, 2, 0)`,
+    );
+    await mysql.query(
+      `INSERT INTO token (id, name, symbol, total_supply) VALUES ('00', 'Hathor', 'HTR', 0)`,
+    );
+
+    // A shielded SPEND contributes a negative shielded delta; the gross-received
+    // accumulator (shieldedAmount) must stay 0, not go negative.
+    const addressBalanceMap = {
+      WCTSpend1: TokenBalanceMap.fromShielded('00', -150n, false),
+    };
+    const tx = { tx_id: 'tx-shielded-spend' } as any;
+
+    const result = await getWalletBalancesForTx(mysql, tx, addressBalanceMap);
+
+    const tokenBalance = result.wallet_alice.walletBalanceForTx[0];
+    expect(tokenBalance.total).toBe(0n);
+    expect(tokenBalance.shieldedAmount).toBe(0n);
+  });
+});
+
+describe('sortBalanceValueByAbsTotal shielded-aware ordering', () => {
+  it('ranks a shielded receive ahead of a smaller transparent movement', () => {
+    expect.hasAssertions();
+
+    const transparent = { tokenId: 'T', total: 10n, shieldedAmount: 0n } as any;
+    const shielded = { tokenId: 'S', total: 0n, shieldedAmount: 500n } as any;
+
+    // Pre-shielded-aware sort keyed on abs(total) alone would leave the shielded
+    // entry (total 0) last; the combined-magnitude key must rank it first.
+    expect([transparent, shielded].sort(sortBalanceValueByAbsTotal)[0].tokenId).toBe('S');
+    expect([shielded, transparent].sort(sortBalanceValueByAbsTotal)[0].tokenId).toBe('S');
   });
 });

--- a/packages/daemon/__tests__/services/newTxRealtime.test.ts
+++ b/packages/daemon/__tests__/services/newTxRealtime.test.ts
@@ -115,6 +115,64 @@ describe('handleVertexAccepted realtime new-tx payload', () => {
     expect(tx.shielded_outputs[0]).not.toHaveProperty('range_proof');
     expect(tx.shielded_outputs[0]).not.toHaveProperty('ephemeral_pubkey');
   });
+
+  it('projects a FullyShielded (mode 2) output without token_data and rides its address', async () => {
+    expect.hasAssertions();
+
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WTransparentAddress1', 'wallet_alice', 0, 0, 0)`,
+    );
+
+    // Append a FullyShielded (mode 2) output to the mode-1 fixture. Mode 2 carries
+    // no token_data, so the projection must omit that field for this entry while
+    // still surfacing decoded.address and adding it to the involved-address set.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs.push({
+      mode: 2,
+      commitment: '0a'.repeat(33),
+      range_proof: '0b'.repeat(64),
+      script: '0c'.repeat(20),
+      ephemeral_pubkey: '0d'.repeat(33),
+      asset_commitment: '0e'.repeat(33),
+      surjection_proof: '0f'.repeat(64),
+      decoded: { address: 'WShieldedAddress2' },
+    });
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    expect(sendRealtimeTx).toHaveBeenCalledTimes(1);
+    const [, tx] = (sendRealtimeTx as jest.Mock).mock.calls[0];
+
+    // The mode-2 entry surfaces decoded.address with NO token_data; the mode-1
+    // entry keeps token_data.
+    expect(tx.shielded_outputs).toEqual([
+      { mode: 1, token_data: 1, decoded: { address: 'WShieldedAddress1' } },
+      { mode: 2, decoded: { address: 'WShieldedAddress2' } },
+    ]);
+    expect(tx.shielded_outputs[1]).not.toHaveProperty('token_data');
+
+    // the mode-2 address rides in the involved-address set
+    expect(tx.addresses).toEqual(
+      expect.arrayContaining(['WShieldedAddress2']),
+    );
+  });
 });
 
 describe('getWalletBalancesForTx shielded amounts (push payload)', () => {
@@ -182,6 +240,41 @@ describe('getWalletBalancesForTx shielded amounts (push payload)', () => {
     expect(tokenBalance.total).toBe(0n);
     expect(tokenBalance.shieldedAmount).toBe(0n);
   });
+
+  it('reports gross received (not net) when the same token is both received and spent', async () => {
+    expect.hasAssertions();
+
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WCTSpend1', 'wallet_alice', 7, 2, 0)`,
+    );
+    await mysql.query(
+      `INSERT INTO token (id, name, symbol, total_supply) VALUES ('00', 'Hathor', 'HTR', 0)`,
+    );
+
+    // Same token, same tx: a shielded receive of 100 and a shielded spend of 300.
+    // The net shielded delta is -200, but shieldedAmount tracks GROSS received,
+    // so it must report 100 (not the -200 net, nor 0).
+    const addressBalanceMap = {
+      WCTSpend1: TokenBalanceMap.merge(
+        TokenBalanceMap.fromShielded('00', 100n, false),
+        TokenBalanceMap.fromShielded('00', -300n, false),
+      ),
+    };
+    const tx = { tx_id: 'tx-shielded-mixed' } as any;
+
+    const result = await getWalletBalancesForTx(mysql, tx, addressBalanceMap);
+
+    const tokenBalance = result.wallet_alice.walletBalanceForTx[0];
+    expect(tokenBalance.total).toBe(0n);
+    expect(tokenBalance.shieldedAmount).toBe(100n);
+  });
 });
 
 describe('sortBalanceValueByAbsTotal shielded-aware ordering', () => {
@@ -195,5 +288,19 @@ describe('sortBalanceValueByAbsTotal shielded-aware ordering', () => {
     // entry (total 0) last; the combined-magnitude key must rank it first.
     expect([transparent, shielded].sort(sortBalanceValueByAbsTotal)[0].tokenId).toBe('S');
     expect([shielded, transparent].sort(sortBalanceValueByAbsTotal)[0].tokenId).toBe('S');
+  });
+
+  it('treats equal combined magnitude as a tie (returns 0, preserves order)', () => {
+    expect.hasAssertions();
+
+    // Both have combined magnitude 150: one all-transparent, one transparent +
+    // shielded. Equal magnitude must compare as 0 so the comparator honours the
+    // sort contract (the old `>= 0n` form wrongly returned -1 on ties).
+    const a = { tokenId: 'A', total: 150n, shieldedAmount: 0n } as any;
+    const b = { tokenId: 'B', total: 100n, shieldedAmount: 50n } as any;
+
+    expect(sortBalanceValueByAbsTotal(a, b)).toBe(0);
+    expect([a, b].sort(sortBalanceValueByAbsTotal).map((x) => x.tokenId)).toEqual(['A', 'B']);
+    expect([b, a].sort(sortBalanceValueByAbsTotal).map((x) => x.tokenId)).toEqual(['B', 'A']);
   });
 });

--- a/packages/daemon/__tests__/services/newTxRealtime.test.ts
+++ b/packages/daemon/__tests__/services/newTxRealtime.test.ts
@@ -31,9 +31,10 @@ jest.mock('../../src/utils/aws', () => {
 
 import * as db from '../../src/db';
 import { handleVertexAccepted } from '../../src/services';
-import { LRU } from '../../src/utils';
+import { LRU, getWalletBalancesForTx } from '../../src/utils';
 import { sendRealtimeTx } from '../../src/utils/aws';
 import { cleanDatabase, XPUBKEY } from '../utils';
+import { TokenBalanceMap } from '@wallet-service/common';
 import { Connection } from 'mysql2/promise';
 import eventsFixture from '../__fixtures__/events';
 
@@ -113,5 +114,41 @@ describe('handleVertexAccepted realtime new-tx payload', () => {
     expect(tx.shielded_outputs[0]).not.toHaveProperty('commitment');
     expect(tx.shielded_outputs[0]).not.toHaveProperty('range_proof');
     expect(tx.shielded_outputs[0]).not.toHaveProperty('ephemeral_pubkey');
+  });
+});
+
+describe('getWalletBalancesForTx shielded amounts (push payload)', () => {
+  it('carries the recovered shielded receive amount as shieldedAmount', async () => {
+    expect.hasAssertions();
+
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WCTSpend1', 'wallet_alice', 7, 2, 0)`,
+    );
+    await mysql.query(
+      `INSERT INTO token (id, name, symbol, total_supply) VALUES ('00', 'Hathor', 'HTR', 0)`,
+    );
+
+    // Unified balance map for the vertex: a recovered shielded HTR receive of
+    // 150 for the owned address (transparent columns stay zero).
+    const addressBalanceMap = {
+      WCTSpend1: TokenBalanceMap.fromShielded('00', 150n, false),
+    };
+    const tx = { tx_id: 'tx-shielded-push' } as any;
+
+    const result = await getWalletBalancesForTx(mysql, tx, addressBalanceMap);
+
+    expect(result.wallet_alice).toBeDefined();
+    const tokenBalance = result.wallet_alice.walletBalanceForTx[0];
+    expect(tokenBalance.tokenId).toBe('00');
+    // transparent total stays zero; the shielded receive rides in shieldedAmount.
+    expect(tokenBalance.total).toBe(0n);
+    expect(tokenBalance.shieldedAmount).toBe(150n);
   });
 });

--- a/packages/daemon/__tests__/services/newTxRealtime.test.ts
+++ b/packages/daemon/__tests__/services/newTxRealtime.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Owned-wallet ingest triggers wallet-lib's gap-fill/address-derivation path,
+// which is slow against a real xpubkey; bump the timeout to match the other
+// DB-backed shielded suites.
+jest.setTimeout(30000);
+
+jest.mock('../../src/crypto/ctRewind', () => require('../mocks/ct-crypto-node').mockCtCrypto);
+
+const mockAddAlert = jest.fn();
+jest.mock('@wallet-service/common', () => {
+  const actual = jest.requireActual('@wallet-service/common');
+  return { ...actual, addAlert: mockAddAlert };
+});
+
+// Partial-mock the aws module so the outbound SQS / lambda calls are stubbed
+// while every other util (used heavily by handleVertexAccepted) stays real.
+jest.mock('../../src/utils/aws', () => {
+  const actual = jest.requireActual('../../src/utils/aws');
+  return {
+    ...actual,
+    sendRealtimeTx: jest.fn(),
+    invokeOnTxPushNotificationRequestedLambda: jest.fn(),
+  };
+});
+
+import * as db from '../../src/db';
+import { handleVertexAccepted } from '../../src/services';
+import { LRU } from '../../src/utils';
+import { sendRealtimeTx } from '../../src/utils/aws';
+import { cleanDatabase, XPUBKEY } from '../utils';
+import { Connection } from 'mysql2/promise';
+import eventsFixture from '../__fixtures__/events';
+
+/**
+ * @jest-environment node
+ */
+
+let mysql: Connection;
+
+beforeAll(async () => {
+  mysql = await db.getDbConnection();
+});
+
+afterAll(async () => {
+  if (mysql) await mysql.destroy();
+});
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+  await mysql.query('DELETE FROM shielded_tx_output_data');
+  jest.clearAllMocks();
+});
+
+afterEach(async () => {
+  await mysql.query('DELETE FROM shielded_tx_output_data');
+});
+
+describe('handleVertexAccepted realtime new-tx payload', () => {
+  it('enqueues the involved addresses and a lightweight shielded_outputs projection', async () => {
+    expect.hasAssertions();
+
+    // VERTEX_WITH_SHIELDED carries a transparent output to WTransparentAddress1
+    // and a shielded output to WShieldedAddress1. Own the transparent address
+    // so the wallet is "seen" and sendRealtimeTx fires; the shielded output
+    // stays unowned (no rewind needed) but its address still rides in the
+    // involved-address set.
+    const now = Math.floor(Date.now() / 1000);
+    await mysql.query(
+      `INSERT INTO \`wallet\` (id, xpubkey, auth_xpubkey, status, max_gap, created_at, ready_at)
+       VALUES ('wallet_alice', ?, ?, 'ready', 20, ?, ?)`,
+      [XPUBKEY, XPUBKEY, now, now],
+    );
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, transactions)
+       VALUES ('WTransparentAddress1', 'wallet_alice', 0, 0, 0)`,
+    );
+
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    expect(sendRealtimeTx).toHaveBeenCalledTimes(1);
+    const [wallets, tx] = (sendRealtimeTx as jest.Mock).mock.calls[0];
+
+    expect(wallets).toEqual(['wallet_alice']);
+
+    // addresses: the full involved set (transparent + shielded), as an array.
+    expect(Array.isArray(tx.addresses)).toBe(true);
+    expect(tx.addresses).toEqual(
+      expect.arrayContaining(['WTransparentAddress1', 'WShieldedAddress1']),
+    );
+
+    // shielded_outputs: lightweight projection only — mode, token_data, decoded
+    // address; NO crypto blobs (commitment / range_proof / ephemeral_pubkey).
+    expect(tx.shielded_outputs).toEqual([
+      { mode: 1, token_data: 1, decoded: { address: 'WShieldedAddress1' } },
+    ]);
+    expect(tx.shielded_outputs[0]).not.toHaveProperty('commitment');
+    expect(tx.shielded_outputs[0]).not.toHaveProperty('range_proof');
+    expect(tx.shielded_outputs[0]).not.toHaveProperty('ephemeral_pubkey');
+  });
+});

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -834,7 +834,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
 
           try {
             if (PUSH_NOTIFICATION_ENABLED) {
-              const walletBalanceMap = await getWalletBalancesForTx(mysql, txData);
+              const walletBalanceMap = await getWalletBalancesForTx(mysql, txData, addressBalanceMap);
               const { length: hasAffectWallets } = Object.keys(walletBalanceMap);
               if (hasAffectWallets) {
                 invokeOnTxPushNotificationRequestedLambda(walletBalanceMap)

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -811,7 +811,9 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
             // same set bumpAddressInvolvement consumed). Clients intersect
             // `addresses` with their own and refetch.
             shielded_outputs: shieldedOutputs.map((so) => {
-              const decoded = so.decoded ? { address: so.decoded.address } : null;
+              // `decoded` is schema-guaranteed present (the socket safeParse rejects
+              // any shielded output without it), matching the unguarded ingest path.
+              const decoded = { address: so.decoded.address };
               // token_data only exists on AmountShielded; FullyShielded hides it.
               return so.mode === ShieldedOutputMode.AmountShielded
                 ? { mode: so.mode, token_data: so.token_data, decoded }

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -806,6 +806,18 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
             token_name,
             token_symbol,
             signal_bits: 0, // TODO: we should actually receive this and store in the database
+            // Additive realtime fields: a lightweight shielded-output projection
+            // (no crypto blobs) and the full involved-address set (reusing the
+            // same set bumpAddressInvolvement consumed). Clients intersect
+            // `addresses` with their own and refetch.
+            shielded_outputs: shieldedOutputs.map((so) => {
+              const decoded = so.decoded ? { address: so.decoded.address } : null;
+              // token_data only exists on AmountShielded; FullyShielded hides it.
+              return so.mode === ShieldedOutputMode.AmountShielded
+                ? { mode: so.mode, token_data: so.token_data, decoded }
+                : { mode: so.mode, decoded };
+            }),
+            addresses: Array.from(involvedAddresses),
           };
 
           try {

--- a/packages/daemon/src/types/wallet.ts
+++ b/packages/daemon/src/types/wallet.ts
@@ -34,6 +34,10 @@ export type TokenBalanceValue = {
   unlockedAuthorities: Record<string, unknown>;
   lockExpires: number | null;
   total: bigint;
+  // Net shielded balance change for this tx (unlocked + locked shielded),
+  // positive on a recovered shielded receive. `total` stays transparent-only;
+  // the push builder combines the two for the displayed amount.
+  shieldedAmount: bigint;
 }
 
 export interface WalletBalanceValue {

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -715,17 +715,24 @@ export class FromTokenBalanceMapToBalanceValueList {
       unlockedAuthorities: balance.unlockedAuthorities.toJSON(),
       totalAmountSent: balance.totalAmountSent,
       total: balance.total(),
-      shieldedAmount: balance.unlockedShieldedAmount + balance.lockedShieldedAmount,
+      // Gross shielded received this tx (the lifetime accumulator, suppressed
+      // to 0 on spends), so the receive-oriented push amount is never negative.
+      shieldedAmount: balance.totalShieldedReceived,
     } as TokenBalanceValue));
     return balances;
   }
 }
 
 export const sortBalanceValueByAbsTotal = (balanceA: TokenBalanceValue, balanceB: TokenBalanceValue): number => {
-  function abs(num: bigint) {
-    return num >= 0n ? num : -num;
-  }
-  if (abs(balanceA.total) - abs(balanceB.total) >= 0n) return -1;
+  const abs = (num: bigint): bigint => (num >= 0n ? num : -num);
+  // Rank by the combined magnitude of transparent and shielded movement so a
+  // shielded receive (transparent total 0) isn't pushed behind transparent
+  // tokens — which would otherwise mis-gate it out of the [0]-based push check
+  // or hide it past the top-N display.
+  const magnitudeA = abs(balanceA.total) + abs(balanceA.shieldedAmount);
+  const magnitudeB = abs(balanceB.total) + abs(balanceB.shieldedAmount);
+  if (magnitudeA > magnitudeB) return -1;
+  if (magnitudeA < magnitudeB) return 1;
   return 0;
 };
 

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -646,8 +646,14 @@ export const validateAddressBalances = async (mysql: MysqlConnection, addresses:
  * @param tx - The transaction to get related wallets and their token balances
  * @returns
  */
-export const getWalletBalancesForTx = async (mysql: MysqlConnection, tx: Transaction): Promise<StringMap<WalletBalanceValue>> => {
-  const addressBalanceMap: StringMap<TokenBalanceMap> = getAddressBalanceMap(tx.inputs, tx.outputs, tx.headers ?? []);
+export const getWalletBalancesForTx = async (
+  mysql: MysqlConnection,
+  tx: Transaction,
+  addressBalanceMap: StringMap<TokenBalanceMap>,
+): Promise<StringMap<WalletBalanceValue>> => {
+  // The caller passes the unified balance map (transparent + shielded) computed
+  // for the vertex, so the push summary reflects recovered shielded receives —
+  // not just the transparent inputs/outputs on `tx`.
   // return only wallets that were started
   const addressWalletMap: StringMap<Wallet> = await getAddressWalletInfo(mysql, Object.keys(addressBalanceMap));
 
@@ -709,6 +715,7 @@ export class FromTokenBalanceMapToBalanceValueList {
       unlockedAuthorities: balance.unlockedAuthorities.toJSON(),
       totalAmountSent: balance.totalAmountSent,
       total: balance.total(),
+      shieldedAmount: balance.unlockedShieldedAmount + balance.lockedShieldedAmount,
     } as TokenBalanceValue));
     return balances;
   }

--- a/packages/wallet-service/src/api/txPushNotificationRequested.ts
+++ b/packages/wallet-service/src/api/txPushNotificationRequested.ts
@@ -56,6 +56,8 @@ class TxPushNotificationRequestValidator {
       unlockedAuthorities: TxPushNotificationRequestValidator.authoritiesSchema,
       lockExpires: Joi.number().integer().min(0).allow(null),
       total: Joi.number().required(),
+      // Optional + defaulted so payloads from daemons predating the field still validate.
+      shieldedAmount: Joi.number().default(0),
     }),
   ).required();
 
@@ -122,8 +124,10 @@ export const handleRequest: Handler<StringMap<WalletBalanceValue>, { success: bo
     // filter wallets in which the token balance > 0
     .filter((eachSettings) => {
       const wallet = body[eachSettings.walletId];
-      // verify by the first token balance
-      return wallet.walletBalanceForTx[0].total > 0;
+      // verify by the first token balance — count the shielded amount too so a
+      // pure shielded receive (transparent total 0) still notifies.
+      const firstBalance = wallet.walletBalanceForTx[0];
+      return (firstBalance.total > 0n) || ((firstBalance.shieldedAmount ?? 0n) > 0n);
     });
 
   const genericMessages = devicesEnabledToPush
@@ -174,7 +178,8 @@ const _assembleSpecificMessage = (deviceId: string, txId: string, tokenBalanceLi
 
   const tokens = [];
   for (const eachBalance of tokenBalanceList.slice(0, upperLimit)) {
-    const amount = eachBalance.total;
+    // Combine the transparent and shielded amounts for the displayed value.
+    const amount = eachBalance.total + (eachBalance.shieldedAmount ?? 0n);
     const tokenSymbol = eachBalance.tokenSymbol;
     tokens.push(`${amount} ${tokenSymbol}`);
   }

--- a/packages/wallet-service/src/api/txPushNotificationRequested.ts
+++ b/packages/wallet-service/src/api/txPushNotificationRequested.ts
@@ -127,7 +127,9 @@ export const handleRequest: Handler<StringMap<WalletBalanceValue>, { success: bo
       // verify by the first token balance — count the shielded amount too so a
       // pure shielded receive (transparent total 0) still notifies.
       const firstBalance = wallet.walletBalanceForTx[0];
-      return (firstBalance.total > 0n) || ((firstBalance.shieldedAmount ?? 0n) > 0n);
+      // Joi validates these as numbers, so compare as numbers (the declared
+      // bigint types don't reflect the runtime values arriving over JSON).
+      return Number(firstBalance.total) > 0 || Number(firstBalance.shieldedAmount ?? 0) > 0;
     });
 
   const genericMessages = devicesEnabledToPush
@@ -179,7 +181,8 @@ const _assembleSpecificMessage = (deviceId: string, txId: string, tokenBalanceLi
   const tokens = [];
   for (const eachBalance of tokenBalanceList.slice(0, upperLimit)) {
     // Combine the transparent and shielded amounts for the displayed value.
-    const amount = eachBalance.total + (eachBalance.shieldedAmount ?? 0n);
+    // Joi validates these as numbers; add as numbers to avoid a bigint/number mix.
+    const amount = Number(eachBalance.total) + Number(eachBalance.shieldedAmount ?? 0);
     const tokenSymbol = eachBalance.tokenSymbol;
     tokens.push(`${amount} ${tokenSymbol}`);
   }

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -425,6 +425,9 @@ export type TokenBalanceValue = {
   unlockedAuthorities: Record<string, unknown>;
   lockExpires: number | null;
   total: bigint;
+  // Net shielded balance change for this tx (transparent `total` excludes it).
+  // Optional for backwards-compatibility with daemons that predate the field.
+  shieldedAmount?: bigint;
 }
 
 export class WalletTokenBalance {

--- a/packages/wallet-service/src/ws/txNotify.ts
+++ b/packages/wallet-service/src/ws/txNotify.ts
@@ -31,6 +31,10 @@ const newTxbodySchema = Joi.object({
     .items(Joi.string())
     .min(1)
     .required(),
+  // `tx` is intentionally an unconstrained object: the daemon forwards the full
+  // Transaction shape, including the additive `shielded_outputs` and `addresses`
+  // fields that ride inside `data` on the realtime `new-tx` frame. Keep it
+  // keyless (or allow unknown) so those pass through untouched to the client.
   tx: Joi.object().required(),
 });
 

--- a/packages/wallet-service/tests/txPushNotificationRequested.test.ts
+++ b/packages/wallet-service/tests/txPushNotificationRequested.test.ts
@@ -325,6 +325,36 @@ describe('success', () => {
 `);
     });
 
+    it('shielded-only receive (transparent total 0, shieldedAmount > 0) notifies with the combined amount', async () => {
+      expect.hasAssertions();
+
+      // Pure shielded receive: transparent total is 0, the value rides in
+      // shieldedAmount. The notification must still fire (gate counts the
+      // shielded amount) and display the combined amount.
+      const sendEvent = buildEvent(walletId, txId, [
+        {
+          tokenId: 'token2',
+          tokenSymbol: 'T2',
+          lockExpires: null,
+          lockedAmount: 0,
+          lockedAuthorities: { melt: false, mint: false },
+          total: 0,
+          totalAmountSent: 0,
+          unlockedAmount: 0,
+          unlockedAuthorities: { melt: false, mint: false },
+          shieldedAmount: 150,
+        } as any,
+      ]);
+      const sendContext = { awsRequestId: '123' } as Context;
+
+      const result = await handleRequest(sendEvent, sendContext, null) as { success: boolean };
+
+      expect(result.success).toStrictEqual(true);
+      expect(spyOnInvokeSendNotification).toHaveBeenCalledTimes(1);
+      const notificationSentOnSpy = spyOnInvokeSendNotification.mock.calls[0][0];
+      expect(notificationSentOnSpy.metadata.bodyLocArgs).toStrictEqual(JSON.stringify(['150 T2']));
+    });
+
     it('token balance with 2 token', async () => {
       expect.hasAssertions();
 

--- a/packages/wallet-service/tests/txPushNotificationRequested.test.ts
+++ b/packages/wallet-service/tests/txPushNotificationRequested.test.ts
@@ -355,6 +355,80 @@ describe('success', () => {
       expect(notificationSentOnSpy.metadata.bodyLocArgs).toStrictEqual(JSON.stringify(['150 T2']));
     });
 
+    it('combines positive transparent and shielded amounts for the same token', async () => {
+      expect.hasAssertions();
+
+      // A single token receiving both transparently (100) and shielded (50): the
+      // displayed amount is the sum (150). Asserting the combined value guards the
+      // `total + shieldedAmount` against regressing to a subtraction, a max, or a
+      // dropped term — every other case is transparent-only or shielded-only.
+      const sendEvent = buildEvent(walletId, txId, [
+        {
+          tokenId: 'token2',
+          tokenSymbol: 'T2',
+          lockExpires: null,
+          lockedAmount: 0,
+          lockedAuthorities: { melt: false, mint: false },
+          total: 100,
+          totalAmountSent: 100,
+          unlockedAmount: 100,
+          unlockedAuthorities: { melt: false, mint: false },
+          shieldedAmount: 50,
+        } as any,
+      ]);
+      const sendContext = { awsRequestId: '123' } as Context;
+
+      const result = await handleRequest(sendEvent, sendContext, null) as { success: boolean };
+
+      expect(result.success).toStrictEqual(true);
+      expect(spyOnInvokeSendNotification).toHaveBeenCalledTimes(1);
+      const notificationSentOnSpy = spyOnInvokeSendNotification.mock.calls[0][0];
+      expect(notificationSentOnSpy.metadata.bodyLocArgs).toStrictEqual(JSON.stringify(['150 T2']));
+    });
+
+    it('shielded receive at [0] alongside transparent activity survives the gate', async () => {
+      expect.hasAssertions();
+
+      // The daemon sorts shielded-first (sortBalanceValueByAbsTotal), and the gate
+      // here trusts walletBalanceForTx[0]. Feed the list as the daemon delivers it
+      // — a transparent-total-0 shielded receive at [0], a smaller transparent
+      // token at [1] — and confirm the gate counts the shielded entry (so it isn't
+      // mis-gated out) and both amounts display.
+      const sendEvent = buildEvent(walletId, txId, [
+        {
+          tokenId: 'token2',
+          tokenSymbol: 'T2',
+          lockExpires: null,
+          lockedAmount: 0,
+          lockedAuthorities: { melt: false, mint: false },
+          total: 0,
+          totalAmountSent: 0,
+          unlockedAmount: 0,
+          unlockedAuthorities: { melt: false, mint: false },
+          shieldedAmount: 150,
+        } as any,
+        {
+          tokenId: 'token1',
+          tokenSymbol: 'T1',
+          lockExpires: null,
+          lockedAmount: 0,
+          lockedAuthorities: { melt: false, mint: false },
+          total: 5,
+          totalAmountSent: 5,
+          unlockedAmount: 5,
+          unlockedAuthorities: { melt: false, mint: false },
+        },
+      ]);
+      const sendContext = { awsRequestId: '123' } as Context;
+
+      const result = await handleRequest(sendEvent, sendContext, null) as { success: boolean };
+
+      expect(result.success).toStrictEqual(true);
+      expect(spyOnInvokeSendNotification).toHaveBeenCalledTimes(1);
+      const notificationSentOnSpy = spyOnInvokeSendNotification.mock.calls[0][0];
+      expect(notificationSentOnSpy.metadata.bodyLocArgs).toStrictEqual(JSON.stringify(['150 T2', '5 T1']));
+    });
+
     it('token balance with 2 token', async () => {
       expect.hasAssertions();
 


### PR DESCRIPTION
### Motivation

The realtime `new-tx` message described only transparent outputs, and the push-notification balance summary was computed from transparent inputs/outputs alone, so a recovered shielded receive reached the client through neither channel.

This PR makes the event-delivery paths shielded-aware: the realtime `new-tx` message gains the data a client needs to detect shielded involvement and refetch, and push notifications surface the shielded amount received.

Stacked on `feat/shielded-outputs-daemon-7-void-parity`. No schema migrations.

### Summary

**Realtime `new-tx` (WebSocket)** — additive, backwards-compatible fields inside `data`:
- `shielded_outputs`: a lightweight projection of each shielded output (`mode`, `token_data` for AmountShielded, `decoded.address`) — no on-chain crypto blobs, since the client can't derive encrypted values and only needs to know which addresses were involved.
- `addresses`: the full involved-address set the daemon already computes (the same set used for the involvement counter). The client intersects it with its own addresses and refetches affected balances/history.
- The wallet-service `onNewTx` needs no change — `newTxbodySchema.tx` is a keyless `Joi.object()` that passes the fields through; the contract is documented so it stays that way.

**Push notifications** — surface the shielded amount:
- `getWalletBalancesForTx` (daemon) now takes the unified balance map (transparent + shielded) computed for the vertex instead of recomputing transparent-only, and `TokenBalanceValue` gains a `shieldedAmount` field, sourced from the gross-received accumulator (`totalShieldedReceived`) so it is never negative on spends.
- The wallet-service push handler accepts `shieldedAmount` (Joi, defaulted to 0 for older daemons), notifies when the transparent **or** shielded amount is positive, and combines the two for the displayed amount.
- The per-token sort feeding the notification gate/display is now shielded-aware (ranks by combined transparent + shielded magnitude), so a shielded receive isn't pushed behind transparent tokens and dropped.

### Acceptance Criteria

- [x] The realtime `new-tx` payload carries `shielded_outputs` (projection, no crypto blobs) and `addresses` (involved set incl. shielded output addresses) inside `data`; old clients ignoring them are unaffected.
- [x] A FullyShielded (mode 2) output's address is included in `addresses`; `token_data` is omitted from its projection.
- [x] A recovered shielded receive produces a push entry; `getWalletBalancesForTx` reflects shielded amounts without changing transparent `total`.
- [x] `shieldedAmount` is never negative (0 on a shielded spend); the push notifies and displays the combined transparent + shielded amount.
- [x] A shielded receive accompanied by transparent activity is not mis-gated or hidden — the balance sort ranks by combined magnitude.
- [x] Older daemon payloads without `shieldedAmount` still validate (Joi default 0) and behave as before.
- [x] Full daemon unit suite green (300/300); wallet-service push-handler tests green (13/13); pre-existing transparent tests unchanged.

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged `<!-- stacked PR: base is feat/shielded-outputs-daemon-7-void-parity, not master -->`
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.