### PR TITLE
feat(wallet-service): forward token deposit percentage fraction from /version

### DIFF
--- a/packages/wallet-service/src/nodeConfig.ts
+++ b/packages/wallet-service/src/nodeConfig.ts
@@ -51,6 +51,9 @@ export function convertApiVersionData(data: FullNodeApiVersionResponse): FullNod
     minTxWeightCoefficient: data.min_tx_weight_coefficient,
     minTxWeightK: data.min_tx_weight_k,
     tokenDepositPercentage: data.token_deposit_percentage,
+    // Integer fraction that lets clients do exact integer math; both fields are absent on older fullnodes.
+    tokenDepositPercentageNumerator: data.token_deposit_percentage_numerator,
+    tokenDepositPercentageDenominator: data.token_deposit_percentage_denominator,
     rewardSpendMinBlocks: data.reward_spend_min_blocks,
     maxNumberInputs: data.max_number_inputs,
     maxNumberOutputs: data.max_number_outputs,

--- a/packages/wallet-service/src/schemas.ts
+++ b/packages/wallet-service/src/schemas.ts
@@ -24,7 +24,10 @@ export const FullnodeVersionSchema = Joi.object<FullNodeApiVersionResponse>({
   min_tx_weight: Joi.number().integer().positive().allow(0).required(),
   min_tx_weight_coefficient: Joi.number().positive().allow(0).required(),
   min_tx_weight_k: Joi.number().integer().positive().allow(0).required(),
+  // Deprecated float, always present; superseded by the integer numerator/denominator fraction.
   token_deposit_percentage: Joi.number().positive().required(),
+  token_deposit_percentage_numerator: Joi.number().integer().positive(),
+  token_deposit_percentage_denominator: Joi.number().integer().positive(),
   reward_spend_min_blocks: Joi.number().integer().positive().required(),
   max_number_inputs: Joi.number().integer().positive().required(),
   max_number_outputs: Joi.number().integer().positive().required(),

--- a/packages/wallet-service/src/schemas.ts
+++ b/packages/wallet-service/src/schemas.ts
@@ -24,8 +24,8 @@ export const FullnodeVersionSchema = Joi.object<FullNodeApiVersionResponse>({
   min_tx_weight: Joi.number().integer().positive().allow(0).required(),
   min_tx_weight_coefficient: Joi.number().positive().allow(0).required(),
   min_tx_weight_k: Joi.number().integer().positive().allow(0).required(),
-  // Deprecated float, always present; superseded by the integer numerator/denominator fraction.
-  token_deposit_percentage: Joi.number().positive().required(),
+  // Deprecated float, now optional: fullnodes may drop it in favor of the integer fraction below.
+  token_deposit_percentage: Joi.number().positive(),
   token_deposit_percentage_numerator: Joi.number().integer().positive(),
   token_deposit_percentage_denominator: Joi.number().integer().positive(),
   reward_spend_min_blocks: Joi.number().integer().positive().required(),
@@ -40,7 +40,20 @@ export const FullnodeVersionSchema = Joi.object<FullNodeApiVersionResponse>({
     symbol: Joi.string().min(1).max(5).required(),
     version: Joi.number().integer(),
   }),
-}).unknown(true);
+})
+  .unknown(true)
+  // Reject a response with no deposit-percentage source at all: without the deprecated
+  // float nor the integer fraction, clients would silently fall back to a compiled-in default.
+  .or(
+    'token_deposit_percentage',
+    'token_deposit_percentage_numerator',
+    'token_deposit_percentage_denominator',
+  )
+  // The integer fraction is only usable as a complete pair, so require both halves together.
+  .and(
+    'token_deposit_percentage_numerator',
+    'token_deposit_percentage_denominator',
+  );
 
 export const EnvironmentConfigSchema = Joi.object<EnvironmentConfig>({
   defaultServer: Joi.string().required(),

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -95,7 +95,7 @@ export interface FullNodeVersionData {
   minTxWeightCoefficient: number;
   minTxWeightK: number;
   /** @deprecated Use tokenDepositPercentageNumerator/tokenDepositPercentageDenominator for exact integer math. */
-  tokenDepositPercentage: number;
+  tokenDepositPercentage?: number;
   tokenDepositPercentageNumerator?: number;
   tokenDepositPercentageDenominator?: number;
   rewardSpendMinBlocks: number;
@@ -121,8 +121,8 @@ export interface FullNodeApiVersionResponse {
   min_tx_weight: number;
   min_tx_weight_coefficient: number; // float
   min_tx_weight_k: number;
-  /** @deprecated Float kept for backward compatibility; use the integer fraction fields below. */
-  token_deposit_percentage: number;
+  /** @deprecated Float kept for backward compatibility; fullnodes may omit it in favor of the integer fraction fields below. */
+  token_deposit_percentage?: number;
   // Deposit percentage as an integer fraction in parts per billion; absent on older fullnodes.
   token_deposit_percentage_numerator?: number;
   token_deposit_percentage_denominator?: number;

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -94,7 +94,10 @@ export interface FullNodeVersionData {
   minTxWeight: number;
   minTxWeightCoefficient: number;
   minTxWeightK: number;
+  /** @deprecated Use tokenDepositPercentageNumerator/tokenDepositPercentageDenominator for exact integer math. */
   tokenDepositPercentage: number;
+  tokenDepositPercentageNumerator?: number;
+  tokenDepositPercentageDenominator?: number;
   rewardSpendMinBlocks: number;
   maxNumberInputs: number;
   maxNumberOutputs: number;
@@ -118,7 +121,11 @@ export interface FullNodeApiVersionResponse {
   min_tx_weight: number;
   min_tx_weight_coefficient: number; // float
   min_tx_weight_k: number;
-  token_deposit_percentage: number; // float
+  /** @deprecated Float kept for backward compatibility; use the integer fraction fields below. */
+  token_deposit_percentage: number;
+  // Deposit percentage as an integer fraction in parts per billion; absent on older fullnodes.
+  token_deposit_percentage_numerator?: number;
+  token_deposit_percentage_denominator?: number;
   reward_spend_min_blocks: number;
   max_number_inputs: number;
   max_number_outputs: number;

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -1630,6 +1630,8 @@ test('GET /version', async () => {
     min_tx_weight_coefficient: 1.6,
     min_tx_weight_k: 100,
     token_deposit_percentage: 0.01,
+    token_deposit_percentage_numerator: 10000000,
+    token_deposit_percentage_denominator: 1000000000,
     reward_spend_min_blocks: 300,
     max_number_inputs: 255,
     max_number_outputs: 255,

--- a/packages/wallet-service/tests/nodeConfig.test.ts
+++ b/packages/wallet-service/tests/nodeConfig.test.ts
@@ -70,6 +70,8 @@ test('convertApiVersionData', async () => {
     minTxWeightCoefficient: OLD_VERSION_DATA.min_tx_weight_coefficient,
     minTxWeightK: OLD_VERSION_DATA.min_tx_weight_k,
     tokenDepositPercentage: OLD_VERSION_DATA.token_deposit_percentage,
+    tokenDepositPercentageNumerator: undefined,
+    tokenDepositPercentageDenominator: undefined,
     rewardSpendMinBlocks: OLD_VERSION_DATA.reward_spend_min_blocks,
     maxNumberInputs: OLD_VERSION_DATA.max_number_inputs,
     maxNumberOutputs: OLD_VERSION_DATA.max_number_outputs,
@@ -88,6 +90,8 @@ test('convertApiVersionData', async () => {
     minTxWeightCoefficient: VERSION_DATA.min_tx_weight_coefficient,
     minTxWeightK: VERSION_DATA.min_tx_weight_k,
     tokenDepositPercentage: VERSION_DATA.token_deposit_percentage,
+    tokenDepositPercentageNumerator: undefined,
+    tokenDepositPercentageDenominator: undefined,
     rewardSpendMinBlocks: VERSION_DATA.reward_spend_min_blocks,
     maxNumberInputs: VERSION_DATA.max_number_inputs,
     maxNumberOutputs: VERSION_DATA.max_number_outputs,
@@ -96,6 +100,23 @@ test('convertApiVersionData', async () => {
     nativeTokenSymbol: VERSION_DATA.native_token.symbol,
     genesisBlockHash: VERSION_DATA.genesis_block_hash,
   });
+});
+
+test('convertApiVersionData forwards the token deposit percentage fraction', () => {
+  const data: FullNodeApiVersionResponse = {
+    ...VERSION_DATA,
+    token_deposit_percentage_numerator: 10000000,
+    token_deposit_percentage_denominator: 1000000000,
+  };
+  const converted = convertApiVersionData(data);
+  expect(converted.tokenDepositPercentageNumerator).toBe(10000000);
+  expect(converted.tokenDepositPercentageDenominator).toBe(1000000000);
+});
+
+test('convertApiVersionData omits the fraction for fullnodes that do not provide it', () => {
+  const converted = convertApiVersionData(OLD_VERSION_DATA);
+  expect(converted.tokenDepositPercentageNumerator).toBeUndefined();
+  expect(converted.tokenDepositPercentageDenominator).toBeUndefined();
 });
 
 test('convertApiVersionData handles nano_contracts_enabled correctly', async () => {

--- a/packages/wallet-service/tests/nodeConfig.test.ts
+++ b/packages/wallet-service/tests/nodeConfig.test.ts
@@ -119,6 +119,12 @@ test('convertApiVersionData omits the fraction for fullnodes that do not provide
   expect(converted.tokenDepositPercentageDenominator).toBeUndefined();
 });
 
+test('convertApiVersionData omits the deprecated float when the fullnode does not provide it', () => {
+  const data: FullNodeApiVersionResponse = { ...OLD_VERSION_DATA };
+  delete data.token_deposit_percentage;
+  expect(convertApiVersionData(data).tokenDepositPercentage).toBeUndefined();
+});
+
 test('convertApiVersionData handles nano_contracts_enabled correctly', async () => {
   // Test with nano_contracts_enabled = false
   const versionWithNanoFalse: FullNodeApiVersionResponse = {

--- a/packages/wallet-service/tests/schemas.test.ts
+++ b/packages/wallet-service/tests/schemas.test.ts
@@ -41,3 +41,23 @@ test('FullnodeVersionSchema rejects a non-integer native_token.version', () => {
   expect(error).toBeDefined();
   expect(error!.message).toMatch(/native_token\.version/);
 });
+
+test('FullnodeVersionSchema accepts the token deposit percentage numerator/denominator', () => {
+  const payload = {
+    ...defaultTestVersionData(),
+    token_deposit_percentage_numerator: 10000000,
+    token_deposit_percentage_denominator: 1000000000,
+  };
+  const { error } = FullnodeVersionSchema.validate(payload);
+  expect(error).toBeUndefined();
+});
+
+test('FullnodeVersionSchema rejects a non-integer token_deposit_percentage_numerator', () => {
+  const payload = {
+    ...defaultTestVersionData(),
+    token_deposit_percentage_numerator: 1.5,
+  };
+  const { error } = FullnodeVersionSchema.validate(payload);
+  expect(error).toBeDefined();
+  expect(error!.message).toMatch(/token_deposit_percentage_numerator/);
+});

--- a/packages/wallet-service/tests/schemas.test.ts
+++ b/packages/wallet-service/tests/schemas.test.ts
@@ -42,6 +42,28 @@ test('FullnodeVersionSchema rejects a non-integer native_token.version', () => {
   expect(error!.message).toMatch(/native_token\.version/);
 });
 
+// Forward-compat: the deprecated float is optional as long as the integer fraction is present.
+test('FullnodeVersionSchema accepts a payload that omits the deprecated token_deposit_percentage when the fraction is present', () => {
+  const payload = {
+    ...defaultTestVersionData(),
+    token_deposit_percentage_numerator: 10000000,
+    token_deposit_percentage_denominator: 1000000000,
+  };
+  delete (payload as { token_deposit_percentage?: number }).token_deposit_percentage;
+  const { error } = FullnodeVersionSchema.validate(payload);
+  expect(error).toBeUndefined();
+});
+
+// A response with no deposit-percentage source at all would silently fall back to a
+// compiled-in default downstream, so reject it instead.
+test('FullnodeVersionSchema rejects a payload that omits all deposit percentage fields', () => {
+  const payload = defaultTestVersionData();
+  delete (payload as { token_deposit_percentage?: number }).token_deposit_percentage;
+  const { error } = FullnodeVersionSchema.validate(payload);
+  expect(error).toBeDefined();
+  expect(error!.message).toMatch(/token_deposit_percentage/);
+});
+
 test('FullnodeVersionSchema accepts the token deposit percentage numerator/denominator', () => {
   const payload = {
     ...defaultTestVersionData(),
@@ -56,6 +78,28 @@ test('FullnodeVersionSchema rejects a non-integer token_deposit_percentage_numer
   const payload = {
     ...defaultTestVersionData(),
     token_deposit_percentage_numerator: 1.5,
+  };
+  const { error } = FullnodeVersionSchema.validate(payload);
+  expect(error).toBeDefined();
+  expect(error!.message).toMatch(/token_deposit_percentage_numerator/);
+});
+
+// The fraction is only usable as a complete pair; a half-populated fraction would be
+// ignored downstream and silently fall back to the default, so reject it.
+test('FullnodeVersionSchema rejects a numerator without a denominator', () => {
+  const payload = {
+    ...defaultTestVersionData(),
+    token_deposit_percentage_numerator: 10000000,
+  };
+  const { error } = FullnodeVersionSchema.validate(payload);
+  expect(error).toBeDefined();
+  expect(error!.message).toMatch(/token_deposit_percentage_denominator/);
+});
+
+test('FullnodeVersionSchema rejects a denominator without a numerator', () => {
+  const payload = {
+    ...defaultTestVersionData(),
+    token_deposit_percentage_denominator: 1000000000,
   };
   const { error } = FullnodeVersionSchema.validate(payload);
   expect(error).toBeDefined();


### PR DESCRIPTION
### Motivation

[hathor-core PR #1711](https://github.com/HathorNetwork/hathor-core/pull/1711) exposes the token deposit percentage on `/version` as an integer fraction in **parts per billion** — `token_deposit_percentage_numerator` (`10^7`) / `token_deposit_percentage_denominator` (`10^9` = 1%) — alongside the now-deprecated float `token_deposit_percentage`. The fraction lets wallet clients compute token deposit/withdraw amounts with exact integer math instead of float multiplication, which loses precision for large amounts.

This PR makes the wallet-service support and forward those new fields end to end, so wallet clients receive them from the wallet-service `/version` endpoint, while staying backward compatible with older fullnodes that only return the float.

### Acceptance Criteria

- The `/version` endpoint forwards `tokenDepositPercentageNumerator` / `tokenDepositPercentageDenominator` (camelCase) when the connected fullnode provides them.
- Older fullnodes that return only the float `token_deposit_percentage` keep working: the new fields are simply absent from the response (no breaking change, no migration needed — the value flows through the existing JSON `version_data` cache).
- The schema validates the two new fields as optional positive integers and rejects non-integer values.
- The deprecated float `token_deposit_percentage` is accepted as nullable (`number | null`) and marked `@deprecated` in the types, anticipating fullnodes dropping it in the future.
- Unit tests cover: schema acceptance of a valid numerator/denominator pair, schema rejection of a non-integer numerator, `convertApiVersionData` forwarding the fraction, and `convertApiVersionData` omitting it for fullnodes that don't provide it.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exact token deposit percentages via `numerator`/`denominator` integer fields.
  * Kept the legacy floating-point `tokenDepositPercentage` as deprecated/optional for compatibility.

* **Bug Fixes**
  * Improved `/version` input validation: at least one deposit-percentage representation is required, and numerator/denominator must be provided together.

* **Tests**
  * Expanded tests covering schema validation, API `/version` responses, and conversion behavior for both legacy and fraction-based inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->