### PR TITLE
feat(daemon): make idle-event alert severity configurable (IDLE_EVENT_SEVERITY)

### DIFF
--- a/packages/daemon/__tests__/actors/MonitoringActor.test.ts
+++ b/packages/daemon/__tests__/actors/MonitoringActor.test.ts
@@ -116,6 +116,32 @@ describe('MonitoringActor', () => {
     expect(processExitSpy).not.toHaveBeenCalled();
   });
 
+  it('should fire the idle alert with the configured IDLE_EVENT_SEVERITY', async () => {
+    config['IDLE_EVENT_SEVERITY'] = Severity.MINOR;
+    MonitoringActor(mockCallback, mockReceive, config);
+    sendEvent('CONNECTED');
+
+    jest.advanceTimersByTime(config['IDLE_EVENT_TIMEOUT_MS'] + 1);
+    await Promise.resolve();
+    await Promise.resolve(); // flush the .finally() microtask
+
+    expect(mockAddAlert).toHaveBeenCalledTimes(1);
+    expect(mockAddAlert.mock.calls[0][2]).toBe(Severity.MINOR);
+  });
+
+  it('should fall back to MAJOR when IDLE_EVENT_SEVERITY is not a valid severity', async () => {
+    config['IDLE_EVENT_SEVERITY'] = 'bogus';
+    MonitoringActor(mockCallback, mockReceive, config);
+    sendEvent('CONNECTED');
+
+    jest.advanceTimersByTime(config['IDLE_EVENT_TIMEOUT_MS'] + 1);
+    await Promise.resolve();
+    await Promise.resolve(); // flush the .finally() microtask
+
+    expect(mockAddAlert).toHaveBeenCalledTimes(1);
+    expect(mockAddAlert.mock.calls[0][2]).toBe(Severity.MAJOR);
+  });
+
   it('should NOT fire an idle alert when events keep arriving', async () => {
     MonitoringActor(mockCallback, mockReceive, config);
     sendEvent('CONNECTED');

--- a/packages/daemon/src/actors/MonitoringActor.ts
+++ b/packages/daemon/src/actors/MonitoringActor.ts
@@ -22,8 +22,9 @@ import { getDbConnection } from '../db';
  * Responsibilities:
  *
  * 1. Idle-stream detection — no EVENT_RECEIVED for >IDLE_EVENT_TIMEOUT_MS while
- *    connected fires a MAJOR alert so operators know the fullnode stream may have
- *    stalled without triggering a WebSocket disconnect.
+ *    connected fires an alert (severity configurable via IDLE_EVENT_SEVERITY,
+ *    default MAJOR) so operators know the fullnode stream may have stalled without
+ *    triggering a WebSocket disconnect.
  *
  * 2. Stuck-processing detection — PROCESSING_STARTED begins a one-shot timer;
  *    PROCESSING_COMPLETED cancels it.  If the timer fires the actor fires a
@@ -45,6 +46,18 @@ export default (callback: any, receive: any, config = getConfig()) => {
   logger.info('Starting monitoring actor');
 
   const idleTimeoutMs = config.IDLE_EVENT_TIMEOUT_MS;
+  // Severity for the idle alert is configurable so low-activity networks can avoid
+  // paging at MAJOR (P2) on benign quiet periods. Validate against the enum and fall
+  // back to MAJOR if the configured value is not a recognised severity.
+  const validSeverities = new Set<string>(Object.values(Severity));
+  let idleSeverity = Severity.MAJOR;
+  if (validSeverities.has(config.IDLE_EVENT_SEVERITY)) {
+    idleSeverity = config.IDLE_EVENT_SEVERITY as Severity;
+  } else {
+    logger.warn(
+      `[monitoring] Unrecognised IDLE_EVENT_SEVERITY "${config.IDLE_EVENT_SEVERITY}" — falling back to ${Severity.MAJOR}`,
+    );
+  }
   const stuckTimeoutMs = config.STUCK_PROCESSING_TIMEOUT_MS;
   const stormThreshold = config.RECONNECTION_STORM_THRESHOLD;
   const stormWindowMs = config.RECONNECTION_STORM_WINDOW_MS;
@@ -75,7 +88,7 @@ export default (callback: any, receive: any, config = getConfig()) => {
           'Daemon Idle — No Events Received',
           `No fullnode events received for ${idleMinutes} minute(s) while the WebSocket is connected. ` +
             'Terminating the process so Kubernetes can restart it.',
-          Severity.MAJOR,
+          idleSeverity,
           { idleMs: String(idleMs) },
           logger,
         ).finally(() => {

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -90,6 +90,11 @@ export const ACK_TIMEOUT_MS = parseInt(process.env.ACK_TIMEOUT_MS ?? '20000', 10
 // Monitoring configuration
 // Timeout (ms) before alerting when no fullnode events received while WebSocket connected
 export const IDLE_EVENT_TIMEOUT_MS = parseInt(process.env.IDLE_EVENT_TIMEOUT_MS ?? String(5 * 60 * 1000), 10);  // 5 minutes
+// Severity of the idle-event alert. Defaults to 'major' (P2). Low-activity networks
+// (e.g. testnet-playground) where quiet periods are normal can lower this to avoid
+// paging on a benign, self-healing restart. Validated against the Severity enum in
+// the MonitoringActor; an unrecognised value falls back to 'major'.
+export const IDLE_EVENT_SEVERITY = process.env.IDLE_EVENT_SEVERITY ?? 'major';
 // Timeout (ms) before alerting when stuck in a single processing state
 export const STUCK_PROCESSING_TIMEOUT_MS = parseInt(process.env.STUCK_PROCESSING_TIMEOUT_MS ?? String(60 * 60 * 1000), 10);  // 1 hour
 // Number of reconnections within RECONNECTION_STORM_WINDOW_MS to trigger a storm alert
@@ -152,6 +157,7 @@ export default () => ({
   HEALTHCHECK_PING_INTERVAL,
   ACK_TIMEOUT_MS,
   IDLE_EVENT_TIMEOUT_MS,
+  IDLE_EVENT_SEVERITY,
   STUCK_PROCESSING_TIMEOUT_MS,
   RECONNECTION_STORM_THRESHOLD,
   RECONNECTION_STORM_WINDOW_MS,


### PR DESCRIPTION
## What

Adds an `IDLE_EVENT_SEVERITY` config for the daemon's `MonitoringActor` idle-stream alert ("Daemon Idle — No Events Received"). Default is `major`, so **existing deployments are unchanged**.

## Why

The idle alert was hardcoded to `Severity.MAJOR`, which alert-manager maps to OpsGenie **P2**. On low-activity networks like **testnet-playground**, normal quiet periods (no new blocks/txs) trip the daemon's idle self-restart and page on-call at P2 with a benign, self-healing false positive.

This came out of an on-call triage — see HathorNetwork/on-call-incidents#246. The companion ops-tools change raises the idle timeout and sets `IDLE_EVENT_SEVERITY` for playground.

## How

- New `IDLE_EVENT_SEVERITY` env (default `'major'`) in `config.ts`.
- `MonitoringActor` validates it against the `Severity` enum and **falls back to `MAJOR` if unrecognised** (with a warn log), so a typo in the env can't silently drop the alert's severity.
- Idle `addAlert` now uses the resolved severity instead of the hardcoded `Severity.MAJOR`.

## Tests

`packages/daemon/__tests__/actors/MonitoringActor.test.ts`:
- existing default test still asserts `MAJOR` (no env → unchanged behaviour),
- new test: configured `minor` is used,
- new test: invalid value falls back to `MAJOR`.

All 34 MonitoringActor tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Idle-timeout alerts (“Daemon Idle — No Events Received”) now use a configurable severity via `IDLE_EVENT_SEVERITY` (default: **major**).
* **Bug Fixes**
  * Invalid `IDLE_EVENT_SEVERITY` values now fall back to **major**.
* **Tests**
  * Added test coverage for both valid and invalid idle severity configurations, including timer-based alert assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->