### PR TITLE
Fix/shielded outputs 1 review fixes

### DIFF
--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -1155,9 +1155,9 @@ describe('miner list', () => {
     expect(results).toHaveLength(3);
 
     expect(new Set(results)).toStrictEqual(new Set([
-      { address: 'address1', firstBlock: 'txId1', lastBlock: 'txId1', count: 1 },
-      { address: 'address2', firstBlock: 'txId2', lastBlock: 'txId2', count: 1 },
-      { address: 'address3', firstBlock: 'txId3', lastBlock: 'txId5', count: 3 },
+      { address: 'address1', firstBlock: 'txId1', lastBlock: 'txId1', count: 1n },
+      { address: 'address2', firstBlock: 'txId2', lastBlock: 'txId2', count: 1n },
+      { address: 'address3', firstBlock: 'txId3', lastBlock: 'txId5', count: 3n },
     ]));
   });
 });

--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -1142,9 +1142,9 @@ describe('miner list', () => {
 
     expect(results).toHaveLength(3);
     expect(new Set(results)).toStrictEqual(new Set([
-      { address: 'address1', firstBlock: 'txId1', lastBlock: 'txId1', count: 1 },
-      { address: 'address2', firstBlock: 'txId2', lastBlock: 'txId2', count: 1 },
-      { address: 'address3', firstBlock: 'txId3', lastBlock: 'txId3', count: 1 },
+      { address: 'address1', firstBlock: 'txId1', lastBlock: 'txId1', count: 1n },
+      { address: 'address2', firstBlock: 'txId2', lastBlock: 'txId2', count: 1n },
+      { address: 'address3', firstBlock: 'txId3', lastBlock: 'txId3', count: 1n },
     ]));
 
     await addMiner(mysql, 'address3', 'txId4');

--- a/packages/daemon/__tests__/integration/utils/index.ts
+++ b/packages/daemon/__tests__/integration/utils/index.ts
@@ -66,6 +66,8 @@ export const fetchAddressBalances = async (
     tokenId: result.token_id as string,
     unlockedBalance: BigInt(result.unlocked_balance),
     lockedBalance: BigInt(result.locked_balance),
+    unlockedShieldedBalance: BigInt(result.unlocked_shielded_balance),
+    lockedShieldedBalance: BigInt(result.locked_shielded_balance),
     lockedAuthorities: result.locked_authorities as number,
     unlockedAuthorities: result.unlocked_authorities as number,
     timelockExpires: result.timelock_expires as number,

--- a/packages/daemon/__tests__/services/services_with_db.test.ts
+++ b/packages/daemon/__tests__/services/services_with_db.test.ts
@@ -2329,6 +2329,75 @@ describe('handleVertexAccepted with shielded outputs', () => {
     expect(mockAddAlert).not.toHaveBeenCalled();
   });
 
+  it('marks a matched FullyShielded output recovery_failed and alerts when the rewind throws', async () => {
+    expect.hasAssertions();
+
+    // Mode-2 failure fork: distinct from the mode-1 failure test, which throws
+    // in token resolution before any rewind. Here the output is a genuine
+    // FullyShielded one and the rewind itself throws (unprimed mock), so the
+    // failure must come from the rewindFully call and land in the catch.
+    const fixture = JSON.parse(JSON.stringify(eventsFixture.VERTEX_WITH_SHIELDED));
+    fixture.event.data.shielded_outputs[0] = {
+      mode: 2,
+      commitment: '02'.repeat(33),
+      range_proof: '03'.repeat(64),
+      script: '04'.repeat(20),
+      ephemeral_pubkey: '05'.repeat(33),
+      asset_commitment: '06'.repeat(33),
+      surjection_proof: '07'.repeat(64),
+      decoded: {
+        address: 'WShieldedAddress1',
+      },
+    };
+    const txHash = fixture.event.data.hash;
+    const so = fixture.event.data.shielded_outputs[0];
+
+    // Owned shielded address (bip32_account = 2 = CTSpend) so the in-line rewind runs.
+    await mysql.query(
+      `INSERT INTO address (address, wallet_id, \`index\`, bip32_account, scan_privkey, transactions)
+       VALUES (?, 'wallet_alice', 7, 2, ?, 0)`,
+      [so.decoded.address, Buffer.alloc(32, 0x42)],
+    );
+
+    resetCtCryptoMock();
+    mockAddAlert.mockClear();
+    // Intentionally do NOT prime the FullyShielded rewind: the mock throws for an
+    // unprimed (commitment, ephemeralPubkey), driving the recovery-failed fork.
+
+    const context = {
+      socket: expect.any(Object),
+      healthcheck: expect.any(Object),
+      retryAttempt: 0,
+      initialEventId: null,
+      txCache: new LRU(100),
+      rewardMinBlocks: 300,
+      event: fixture,
+    };
+
+    await handleVertexAccepted(context as any, undefined as any);
+
+    const txOutput = await getTxOutput(mysql, txHash, 1, false);
+    expect(txOutput).not.toBeNull();
+    expect(txOutput!.mode).toBe(2);
+    expect(txOutput!.recoveryState).toBe('recovery_failed');
+    expect(txOutput!.value).toBeNull();
+    expect(txOutput!.tokenId).toBeNull();
+
+    // Exactly one alert, carrying the shielded output's concatenated index.
+    expect(mockAddAlert).toHaveBeenCalledTimes(1);
+    const [title, , severity, metadata] = mockAddAlert.mock.calls[0];
+    expect(title).toBe('Shielded recovery failed');
+    expect(severity).toBe(Severity.MAJOR);
+    expect(metadata).toMatchObject({ tx_id: txHash, index: 1 });
+
+    // Nothing recovered → no per-token balance row for the shielded address.
+    const [balRows] = await mysql.query<any[]>(
+      'SELECT * FROM `address_balance` WHERE `address` = ?',
+      [so.decoded.address],
+    );
+    expect(balRows).toHaveLength(0);
+  });
+
   it('writes shielded amount columns on the unified address_balance row for recovered shielded outputs', async () => {
     expect.hasAssertions();
 

--- a/packages/daemon/__tests__/services/services_with_db.test.ts
+++ b/packages/daemon/__tests__/services/services_with_db.test.ts
@@ -3564,6 +3564,15 @@ describe('handleVoidedTx with shielded', () => {
        VALUES ('WShieldedSpendAddr', ?, 0, 0, 0, ?, 0, ?, 1)`,
       [TOKEN_ID, SEEDED_VALUE.toString(), SEEDED_VALUE.toString()],
     );
+    // Production writes the recovered receive to address_tx_history alongside the
+    // balance; seed it so the post-void consistency check has a matching
+    // non-voided sum (the spend's own history row is voided by the void under test).
+    await mysql.query(
+      `INSERT INTO \`address_tx_history\`
+         (address, tx_id, token_id, balance, shielded_balance_delta, timestamp, voided)
+       VALUES ('WShieldedSpendAddr', ?, ?, 0, ?, 1700000000, FALSE)`,
+      [PREV_TX_ID, TOKEN_ID, SEEDED_VALUE.toString()],
+    );
     await mysql.query(
       `INSERT INTO wallet_balance
          (wallet_id, token_id,

--- a/packages/daemon/__tests__/services/totalSupply.test.ts
+++ b/packages/daemon/__tests__/services/totalSupply.test.ts
@@ -10,8 +10,8 @@
  * `handleTokenCreated`.
  *
  * Coverage:
- *  - Token creation sets total_supply to the SUM of non-authority transparent
- *    outputs in the creation tx (path 1).
+ *  - Token creation sets total_supply from the wire `initial_amount` on the
+ *    TOKEN_CREATED event (path 1).
  *  - Block reward increases HTR total_supply on every block (path 2).
  *  - Mint, melt, and burn-address outputs apply a signed delta via
  *    `sum(outputs except burn) - sum(inputs)` (path 3).

--- a/packages/daemon/__tests__/types/token-created-schema.test.ts
+++ b/packages/daemon/__tests__/types/token-created-schema.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { bigIntUtils } from '@hathor/wallet-lib';
+import { FullNodeEventSchema } from '../../src/types';
+
+/**
+ * Events arrive as JSON parsed by `bigIntUtils.JSONBigInt.parse` BEFORE Zod
+ * validation (see WebSocketActor). Any integer above Number.MAX_SAFE_INTEGER is
+ * returned as a BigInt, so `TOKEN_CREATED.initial_amount` must accept bigint —
+ * a bare `z.number()` would reject large token supplies and fail the whole
+ * event, so the token would never be inserted and `total_supply` never set.
+ */
+describe('TOKEN_CREATED initial_amount schema', () => {
+  const buildEventJson = (initialAmount: string): string => `{
+    "stream_id": "stream-id",
+    "peer_id": "peer-id",
+    "network": "mainnet",
+    "type": "FULLNODE_EVENT",
+    "latest_event_id": 1,
+    "event": {
+      "id": 1,
+      "timestamp": 1700000000,
+      "type": "TOKEN_CREATED",
+      "data": {
+        "token_uid": "0000token",
+        "nc_exec_info": null,
+        "token_name": "CreationToken",
+        "token_symbol": "CRT",
+        "token_version": 1,
+        "initial_amount": ${initialAmount}
+      },
+      "group_id": null
+    }
+  }`;
+
+  it('accepts an initial_amount above Number.MAX_SAFE_INTEGER (parsed as bigint)', () => {
+    const parsed = bigIntUtils.JSONBigInt.parse(buildEventJson('9223372036854775807')); // 2^63 - 1
+    const result = FullNodeEventSchema.safeParse(parsed);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const { data } = (result.data as { event: { data: { initial_amount: unknown } } }).event;
+      expect(typeof data.initial_amount).toBe('bigint');
+      expect(data.initial_amount).toBe(9223372036854775807n);
+    }
+  });
+
+  it('still accepts a small numeric initial_amount', () => {
+    const parsed = bigIntUtils.JSONBigInt.parse(buildEventJson('12345'));
+    const result = FullNodeEventSchema.safeParse(parsed);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/daemon/__tests__/utils.ts
+++ b/packages/daemon/__tests__/utils.ts
@@ -225,7 +225,7 @@ export const countTxOutputTable = async (
   );
 
   if (results.length > 0) {
-    return results[0].count as number;
+    return Number(results[0].count);
   }
 
   return 0;
@@ -847,5 +847,5 @@ export const getWalletTxHistoryCount = async (mysql: MysqlConnection, walletId: 
     `SELECT COUNT(*) as count FROM \`wallet_tx_history\` WHERE \`wallet_id\` = ? AND \`tx_id\` = ?`,
     [walletId, txId]
   ) as [any[], any];
-  return results[0].count;
+  return Number(results[0].count);
 };

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -137,6 +137,9 @@ export const getDbConnection = async (): Promise<PoolConnection> => {
       user: DB_USER,
       port: DB_PORT,
       password: DB_PASS,
+      // BIGINT columns should be returned as strings to keep precision on the JS unsafe range.
+      supportBigNumbers: true,
+      bigNumberStrings: true,
     });
 
     pool = newPool;
@@ -510,8 +513,15 @@ export async function markTxOutputRecovered(
 
 /**
  * Record that the rewind threw for an output we believed we owned.
- * Terminal state — we don't keep retrying. Same idempotency guard as
- * markTxOutputRecovered.
+ *
+ * This is NOT a terminal state: an output can land here when the wallet is not
+ * yet registered (or recovery is otherwise impossible at ingest time), and the
+ * RFC requires `recovery_failed`/`unowned` rows to remain re-scannable so they
+ * can still reach `recovered` once the wallet registers. The follow-up catchup
+ * sweep (keyed on `address.catchup_state`) is what re-drives them; it is not
+ * implemented yet. The `recovery_state = 'unowned'` guard below only makes the
+ * inline ingest write idempotent against re-delivery of the same vertex — it
+ * does not preclude the future catchup from reprocessing the row.
  */
 export async function markTxOutputRecoveryFailed(
   conn: any,
@@ -2240,6 +2250,8 @@ export const fetchAddressBalance = async (
     tokenId: result.token_id as string,
     unlockedBalance: BigInt(result.unlocked_balance),
     lockedBalance: BigInt(result.locked_balance),
+    unlockedShieldedBalance: BigInt(result.unlocked_shielded_balance),
+    lockedShieldedBalance: BigInt(result.locked_shielded_balance),
     lockedAuthorities: result.locked_authorities as number,
     unlockedAuthorities: result.unlocked_authorities as number,
     timelockExpires: result.timelock_expires as number,
@@ -2265,6 +2277,7 @@ export const fetchAddressTxHistorySum = async (
     `SELECT address,
             token_id,
             SUM(\`balance\`) AS balance,
+            SUM(\`shielded_balance_delta\`) AS shielded_balance_delta,
             COUNT(\`tx_id\`) AS transactions
        FROM \`address_tx_history\`
       WHERE \`address\` IN (?)
@@ -2278,6 +2291,7 @@ export const fetchAddressTxHistorySum = async (
     address: result.address as string,
     tokenId: result.token_id as string,
     balance: BigInt(result.balance),
+    shieldedBalanceDelta: BigInt(result.shielded_balance_delta),
     transactions: parseInt(result.transactions),
   }));
 };

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -30,7 +30,7 @@ import {
 } from '@wallet-service/common';
 import { isAuthority, toTokenVersion, RecoveryState, Bip32Account } from '@wallet-service/common';
 import { getWalletBalanceMap } from '../utils/wallet';
-import { parseNullableBigInt } from '../utils/helpers';
+import { parseNullableBigInt, parseNullableNumber } from '../utils/helpers';
 import {
   AddressBalanceRow,
   AddressTxHistorySumRow,
@@ -1645,7 +1645,8 @@ export const getMinersList = async (
       address: result.address as string,
       firstBlock: result.first_block as string,
       lastBlock: result.last_block as string,
-      count: result.count as number,
+      // miner.count is BIGINT.UNSIGNED — read it as bigint to match the column.
+      count: BigInt(result.count),
     });
   }
 
@@ -2290,8 +2291,10 @@ export const fetchAddressTxHistorySum = async (
   return results.map((result): AddressTotalBalance => ({
     address: result.address as string,
     tokenId: result.token_id as string,
-    balance: BigInt(result.balance),
-    shieldedBalanceDelta: BigInt(result.shielded_balance_delta),
+    // SUM() can be null (and arrives as a string under bigNumberStrings); a null
+    // aggregate means zero, so coalesce to avoid BigInt(null) throwing.
+    balance: parseNullableBigInt(result.balance) ?? 0n,
+    shieldedBalanceDelta: parseNullableBigInt(result.shielded_balance_delta) ?? 0n,
     transactions: parseInt(result.transactions),
   }));
 };
@@ -2504,8 +2507,10 @@ export const getMaxIndicesForWallets = async (
   return new Map(results.map(r => [
     r.wallet_id,
     {
-      maxAmongAddresses: r.max_among_addresses,
-      maxWalletIndex: r.max_wallet_index
+      // MAX() is null when no rows match, and arrives as a string under
+      // bigNumberStrings — parse to a (bounded) number | null.
+      maxAmongAddresses: parseNullableNumber(r.max_among_addresses),
+      maxWalletIndex: parseNullableNumber(r.max_wallet_index)
     }
   ]));
 };

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -563,6 +563,12 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
         // already covered by bumpAddressInvolvement).
         const shieldedRecoveryResults: ShieldedRecoveryResult[] = [];
 
+        // Shielded-recovery-failure alerts are collected here and emitted AFTER
+        // the transaction commits. addAlert performs an SQS round-trip, which
+        // must not run while the ingest transaction holds tx_output/address
+        // row locks.
+        const failedShieldedRecoveries: { txId: string; index: number; error: string }[] = [];
+
         // Walk shielded_outputs[] with concatenated index = transparentCount + i.
         // Each shielded output produces three rows: the unified `tx_output`, the
         // `shielded_tx_output_data` satellite carrying the per-output crypto payload,
@@ -669,13 +675,8 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
               }
             } catch (e) {
               await markTxOutputRecoveryFailed(mysql, hash, idx);
-              await addAlert(
-                'Shielded recovery failed',
-                `Failed to rewind shielded output ${hash}:${idx} for owned address`,
-                Severity.MAJOR,
-                { tx_id: hash, index: idx, error: String(e) },
-                logger,
-              );
+              // Defer the alert until after commit — see failedShieldedRecoveries.
+              failedShieldedRecoveries.push({ txId: hash, index: idx, error: String(e) });
             }
           }
         }
@@ -891,6 +892,19 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
         await dbUpdateLastSyncedEvent(mysql, fullNodeEvent.event.id);
 
         await mysql.commit();
+
+        // Transaction committed and its row locks released: now emit any
+        // deferred shielded-recovery-failure alerts. addAlert swallows its own
+        // errors, so this cannot affect the already-committed state.
+        for (const failure of failedShieldedRecoveries) {
+          await addAlert(
+            'Shielded recovery failed',
+            `Failed to rewind shielded output ${failure.txId}:${failure.index} for owned address`,
+            Severity.MAJOR,
+            { tx_id: failure.txId, index: failure.index, error: failure.error },
+            logger,
+          );
+        }
       } catch (e) {
         try {
           await mysql.rollback();

--- a/packages/daemon/src/types/address.ts
+++ b/packages/daemon/src/types/address.ts
@@ -19,6 +19,8 @@ export interface AddressBalance {
   tokenId: string;
   unlockedBalance: bigint;
   lockedBalance: bigint;
+  unlockedShieldedBalance: bigint;
+  lockedShieldedBalance: bigint;
   unlockedAuthorities: number;
   lockedAuthorities: number;
   timelockExpires: number;
@@ -29,6 +31,7 @@ export interface AddressTotalBalance {
   address: string;
   tokenId: string;
   balance: bigint;
+  shieldedBalanceDelta: bigint;
   transactions: number;
 }
 

--- a/packages/daemon/src/types/address.ts
+++ b/packages/daemon/src/types/address.ts
@@ -41,5 +41,5 @@ export interface Miner {
   address: string;
   firstBlock: string;
   lastBlock: string;
-  count: number;
+  count: bigint;
 }

--- a/packages/daemon/src/types/db.ts
+++ b/packages/daemon/src/types/db.ts
@@ -45,6 +45,7 @@ export interface AddressTxHistorySumRow extends RowDataPacket {
   address: string;
   token_id: string;
   balance: string;
+  shielded_balance_delta: string;
   transactions: string;
 }
 
@@ -68,6 +69,9 @@ export interface AddressBalanceRow extends RowDataPacket {
   token_id: string;
   unlocked_balance: number;
   locked_balance: number;
+  unlocked_shielded_balance: number;
+  locked_shielded_balance: number;
+  total_shielded_received: number;
   locked_authorities: number;
   unlocked_authorities: number;
   timelock_expires: number;

--- a/packages/daemon/src/types/event.ts
+++ b/packages/daemon/src/types/event.ts
@@ -337,7 +337,12 @@ export const TokenCreatedEventSchema = FullNodeEventBaseSchema.extend({
       token_name: z.string(),
       token_symbol: z.string(),
       token_version: z.number(),
-      initial_amount: z.number().optional(),
+      // Token amounts are BIGINT on the wire (up to 2^63-1). JSONBigInt parses
+      // any value above Number.MAX_SAFE_INTEGER as a BigInt before Zod runs, so
+      // a bare z.number() would reject large supplies and fail the whole event.
+      // Match `value`/`nonce` and coerce, since handleTokenCreated feeds this
+      // straight into setTokenTotalSupply.
+      initial_amount: bigIntUtils.bigIntCoercibleSchema.optional(),
     }),
     group_id: z.number().nullable(),
   }),

--- a/packages/daemon/src/types/wallet.ts
+++ b/packages/daemon/src/types/wallet.ts
@@ -34,9 +34,12 @@ export type TokenBalanceValue = {
   unlockedAuthorities: Record<string, unknown>;
   lockExpires: number | null;
   total: bigint;
-  // Net shielded balance change for this tx (unlocked + locked shielded),
-  // positive on a recovered shielded receive. `total` stays transparent-only;
-  // the push builder combines the two for the displayed amount.
+  // Gross shielded amount RECEIVED in this tx for this token: the sum of the
+  // positive (recovered) shielded receipts, suppressed to 0 on a pure spend.
+  // Always >= 0 — NOT a net delta. The push builder gates on `shieldedAmount > 0`
+  // and adds it to the displayed amount, so it must never carry a negative value
+  // (a "net" reading would emit -value on spends and break the gate). `total`
+  // stays transparent-only; the push builder combines the two.
   shieldedAmount: bigint;
 }
 

--- a/packages/daemon/src/utils/helpers.ts
+++ b/packages/daemon/src/utils/helpers.ts
@@ -23,6 +23,18 @@ export function parseNullableBigInt(value: number | string | null | undefined): 
   return value === null || value === undefined ? null : BigInt(value);
 }
 
+/**
+ * Parse a nullable numeric database column into a number.
+ *
+ * Aggregates (e.g. MAX) and BIGINT-typed reads may arrive as a `string` under
+ * `bigNumberStrings`, and `NULL` as `null`. Use this for bounded integer values
+ * (indices, counts) that are semantically numbers; use parseNullableBigInt for
+ * value columns that can exceed the JS safe-integer range.
+ */
+export function parseNullableNumber(value: number | string | null | undefined): number | null {
+  return value === null || value === undefined ? null : Number(value);
+}
+
 export const getFullnodeHttpUrl = () => {
   const { USE_SSL, FULLNODE_HOST } = getConfig();
   const protocol = USE_SSL ? 'https://' : 'http://';

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -644,8 +644,13 @@ export const validateAddressBalances = async (mysql: MysqlConnection, addresses:
       assert.fail(`No address_tx_history sum for ${key} despite transactions > 0`);
     }
 
-    // transparent balances must match the running sum of per-tx `balance`
-    assert.strictEqual(Number(addressBalance.unlockedBalance + addressBalance.lockedBalance), Number(addressTxHistorySum.balance));
+    // transparent balances must match the running sum of per-tx `balance`.
+    // Compare as bigint directly (both operands already are): Number() would
+    // lose precision above 2^53 and could mask a real mismatch on large balances.
+    assert.strictEqual(
+      addressBalance.unlockedBalance + addressBalance.lockedBalance,
+      addressTxHistorySum.balance,
+    );
 
     // shielded balances must match the signed running sum of per-tx
     // `shielded_balance_delta` (the SUM can be 0 even with movement).

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -641,7 +641,14 @@ export const validateAddressBalances = async (mysql: MysqlConnection, addresses:
     const key = `${addressBalance.address}|${addressBalance.tokenId}`;
     const addressTxHistorySum = sumByKey.get(key);
     if (addressTxHistorySum === undefined) {
-      assert.fail(`No address_tx_history sum for ${key} despite transactions > 0`);
+      // No non-voided history rows for this (address, token): the running sum is
+      // 0, so both the transparent and shielded balances must also be 0.
+      assert.strictEqual(addressBalance.unlockedBalance + addressBalance.lockedBalance, 0n);
+      assert.strictEqual(
+        addressBalance.unlockedShieldedBalance + addressBalance.lockedShieldedBalance,
+        0n,
+      );
+      continue;
     }
 
     // transparent balances must match the running sum of per-tx `balance`.

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -628,14 +628,31 @@ export const validateAddressBalances = async (mysql: MysqlConnection, addresses:
     (addressBalance: AddressBalance) => addressBalance.transactions > 0
   );
 
-  for (let i = 0; i < addressTxHistorySums.length; i++) {
-    const addressBalance: AddressBalance = filteredAddressBalances[i];
-    const addressTxHistorySum: AddressTotalBalance = addressTxHistorySums[i];
+  // Key the history sums by (address, token_id) so each balance row is compared
+  // against its matching pair. A positional zip can misalign once a shielded-only
+  // token produces an address_balance row (transparent balance 0, shielded delta
+  // non-zero) whose ordering/length diverges from the history-sum list.
+  const sumByKey = new Map<string, AddressTotalBalance>();
+  for (const sum of addressTxHistorySums) {
+    sumByKey.set(`${sum.address}|${sum.tokenId}`, sum);
+  }
 
-    assert.strictEqual(addressBalance.tokenId, addressTxHistorySum.tokenId);
+  for (const addressBalance of filteredAddressBalances) {
+    const key = `${addressBalance.address}|${addressBalance.tokenId}`;
+    const addressTxHistorySum = sumByKey.get(key);
+    if (addressTxHistorySum === undefined) {
+      assert.fail(`No address_tx_history sum for ${key} despite transactions > 0`);
+    }
 
-    // balances must match
+    // transparent balances must match the running sum of per-tx `balance`
     assert.strictEqual(Number(addressBalance.unlockedBalance + addressBalance.lockedBalance), Number(addressTxHistorySum.balance));
+
+    // shielded balances must match the signed running sum of per-tx
+    // `shielded_balance_delta` (the SUM can be 0 even with movement).
+    assert.strictEqual(
+      addressBalance.unlockedShieldedBalance + addressBalance.lockedShieldedBalance,
+      addressTxHistorySum.shieldedBalanceDelta,
+    );
   }
 };
 

--- a/packages/wallet-service/src/api/txPushNotificationRequested.ts
+++ b/packages/wallet-service/src/api/txPushNotificationRequested.ts
@@ -127,6 +127,10 @@ export const handleRequest: Handler<StringMap<WalletBalanceValue>, { success: bo
       // verify by the first token balance — count the shielded amount too so a
       // pure shielded receive (transparent total 0) still notifies.
       const firstBalance = wallet.walletBalanceForTx[0];
+      // No balance entries for this wallet → nothing to notify; skip it rather
+      // than dereferencing index 0 (an empty-but-valid payload would otherwise
+      // throw and fail the whole handler).
+      if (!firstBalance) return false;
       // Joi validates these as numbers, so compare as numbers (the declared
       // bigint types don't reflect the runtime values arriving over JSON).
       return Number(firstBalance.total) > 0 || Number(firstBalance.shieldedAmount ?? 0) > 0;

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -2758,8 +2758,20 @@ test('getAvailableAuthorities', async () => {
     spentBy: null,
   }]);
 
+  // A shielded row (mode != 0) must never surface as a spendable authority,
+  // even if it somehow carried an authority bit (shielded outputs don't carry
+  // authorities, so this is a defensive guard). addToUtxoTable always writes
+  // mode = 0, so insert the shielded row directly and assert the `AND mode = 0`
+  // clause excludes it.
+  await mysql.query(
+    `INSERT INTO tx_output (tx_id, \`index\`, token_id, address, value, authorities, timelock, heightlock, locked, voided, spent_by, mode)
+     VALUES ('txId', 4, 'tokenShielded', 'addrShielded', 0, 1, NULL, NULL, FALSE, FALSE, NULL, 1)`,
+  );
+
   expect(await getAvailableAuthorities(mysql, 'token1')).toHaveLength(1);
   expect(await getAvailableAuthorities(mysql, 'token2')).toHaveLength(1);
+  // The shielded (mode = 1) authority row is filtered out by `AND mode = 0`.
+  expect(await getAvailableAuthorities(mysql, 'tokenShielded')).toHaveLength(0);
 });
 
 test('getUtxo, getAuthorityUtxo', async () => {


### PR DESCRIPTION
## Summary

Hardening and review-feedback fixes on top of the shielded-outputs foundations
(#439). No new shielded functionality — these address correctness/robustness
issues, correct stale comments, add missing test coverage, and apply CodeRabbit
suggestions.

## Changes

### Correctness & data integrity
- **`TOKEN_CREATED.initial_amount` accepts bigint.** Switched the Zod schema from
  `z.number()` to `bigIntUtils.bigIntCoercibleSchema` (matching `value`/`nonce`).
  Events are parsed by `JSONBigInt` before Zod runs, so a supply above
  `Number.MAX_SAFE_INTEGER` arrives as a `BigInt` — the old schema rejected it and
  failed the whole `TOKEN_CREATED` event, so the token was never inserted and
  `total_supply` never set.
- **`validateAddressBalances` covers shielded balances.** The consistency guard now
  selects the shielded balance columns, asserts
  `unlocked_shielded + locked_shielded == SUM(shielded_balance_delta)`, and matches
  `address_balance` rows to their `address_tx_history` sums by `(address, token_id)`
  instead of a positional zip (which can misalign once shielded-only tokens exist).
- **Shielded-recovery alerts fire after commit.** The `addAlert` SQS round-trip on a
  failed shielded rewind is no longer awaited inside the ingest transaction; failures
  are collected during the loop and alerts are emitted after `commit()`, so they
  don't hold `tx_output`/`address` row locks.
- **Push notifications skip empty-balance wallets.** `txPushNotificationRequested`
  now skips a wallet whose `walletBalanceForTx` is empty instead of dereferencing
  index 0 and failing the whole handler. _(CodeRabbit)_

### Comment / doc corrections
- `markTxOutputRecoveryFailed`: `recovery_failed`/`unowned` rows stay re-scannable by
  the (deferred) catchup sweep — clarified that this is not a terminal state.
- `TokenBalanceValue.shieldedAmount`: documented as the **gross** shielded amount
  received in the tx (≥ 0, 0 on a pure spend) that the push gate relies on — not a
  net delta.
- `totalSupply` test suite header: token creation reads the wire `initial_amount`,
  not a sum of outputs. _(CodeRabbit)_

### Tests
- New schema test: a `TOKEN_CREATED` with `initial_amount > 2^53-1` parses to a bigint.
- New mode-2 (FullyShielded) recovery-failure test: an owned output whose rewind
  throws → `recovery_failed`, value/token left NULL, one alert, no balance row.
- `getAvailableAuthorities`: inserts a `mode = 1` authority row and asserts it is
  excluded, pinning the `AND mode = 0` clause.

## Out of scope / follow-ups
- Real shielded crypto wiring (replacing the throwing `ctRewind` stub) is deferred
  pending a `@hathor/ct-crypto-node` release that bundles a provider.
- Wallet-service read-API `mode = 0` guards, token-creation HTR `total_supply`
  semantics, dead-code cleanup, and the catchup sweep are tracked for follow-up PRs.

## Testing
- `packages/daemon` `tsc` build green; `packages/wallet-service` `tsc --noEmit` green.
- New schema unit test passing; DB-backed suites (`services_with_db`, `db.test`,
  `totalSupply`) to run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shielded balance handling so recovery failures are reported cleanly and don’t leave incomplete balance data behind.
  * Token creation now accepts very large initial amounts without losing precision.
  * Wallet push notifications no longer fail when a wallet has an empty balance list.
  * Authority lookup now correctly excludes shielded-only entries where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->