### PR TITLE
feat(shielded-outputs): combined transparent+shielded wallet load

### DIFF
--- a/packages/common/__tests__/crypto/ctRewind.test.ts
+++ b/packages/common/__tests__/crypto/ctRewind.test.ts
@@ -8,6 +8,7 @@
 import {
   rewindAmount,
   rewindFully,
+  normalizeShieldedTokenId,
   RewindError,
   setShieldedCryptoProvider,
   clearShieldedCryptoProvider,
@@ -87,11 +88,11 @@ describe('ctRewind wrapper', () => {
     await expect(rewindFully(fullyArgs())).rejects.toBeInstanceOf(RewindError);
   });
 
-  it('rewindFully delegates and returns the provider result (hex tokenUid)', async () => {
+  it('rewindFully delegates and returns the provider result (custom token passes through)', async () => {
     const result = {
       value: 42n,
       blindingFactor: buf(32, 8),
-      tokenUid: '00'.repeat(32),
+      tokenUid: 'ab'.repeat(32), // custom token uid — already canonical
       assetBlindingFactor: buf(32, 7),
     };
     const received: unknown[][] = [];
@@ -113,5 +114,32 @@ describe('ctRewind wrapper', () => {
       args.rangeProof,
       args.assetCommitment,
     ]);
+  });
+
+  it('rewindFully canonicalizes the native token uid (all-zero -> "00")', async () => {
+    setShieldedCryptoProvider(
+      stubProvider({
+        rewindFullShieldedOutput: async () => ({
+          value: 42n,
+          blindingFactor: buf(32, 8),
+          tokenUid: '00'.repeat(32), // provider yields the raw on-chain native uid
+          assetBlindingFactor: buf(32, 7),
+        }),
+      }),
+    );
+
+    const r = await rewindFully(fullyArgs());
+    expect(r.tokenUid).toBe('00'); // folded to the canonical NATIVE_TOKEN_UID
+    expect(r.value).toBe(42n);
+  });
+});
+
+describe('normalizeShieldedTokenId', () => {
+  it('folds the all-zero native uid to the canonical NATIVE_TOKEN_UID', () => {
+    expect(normalizeShieldedTokenId('00'.repeat(32))).toBe('00');
+  });
+
+  it('leaves a custom token uid unchanged', () => {
+    expect(normalizeShieldedTokenId('ab'.repeat(32))).toBe('ab'.repeat(32));
   });
 });

--- a/packages/common/src/crypto/ctRewind.ts
+++ b/packages/common/src/crypto/ctRewind.ts
@@ -17,6 +17,7 @@
  * register a deterministic stub provider via `setShieldedCryptoProvider`.
  */
 
+import hathorLib from '@hathor/wallet-lib';
 import type {
   IShieldedCryptoProvider,
   IRewoundAmountShieldedOutput,
@@ -111,21 +112,43 @@ export async function rewindAmount(
 }
 
 /**
+ * Canonicalize a token uid recovered from a fully-shielded rewind.
+ *
+ * `rewindFully` returns the token uid in its raw 32-byte on-chain form; for the
+ * native token (HTR) that is `NATIVE_TOKEN_UID_HEX` — 64 zero hex chars.
+ * Everywhere else in the system HTR is the canonical `NATIVE_TOKEN_UID` ("00"),
+ * so a fully-shielded HTR output must be normalized before it is stored, or its
+ * balance lands under a separate token_id row that every balance query misses.
+ * Custom tokens need no normalization: their on-chain uid is already canonical.
+ */
+export const normalizeShieldedTokenId = (tokenUidHex: string): string => (
+  tokenUidHex === hathorLib.constants.NATIVE_TOKEN_UID_HEX
+    ? hathorLib.constants.NATIVE_TOKEN_UID
+    : tokenUidHex
+);
+
+/**
  * Recover {value, tokenUid, blindingFactor, assetBlindingFactor} from a
  * fully-shielded output that hides both amount and token.
+ *
+ * The returned `tokenUid` is canonicalized: the provider yields the raw on-chain
+ * uid, and for the native token (HTR) that is the all-zero `NATIVE_TOKEN_UID_HEX`
+ * form; this folds it back to the system-wide `NATIVE_TOKEN_UID` so callers never
+ * have to remember to normalize (custom tokens are already canonical, unchanged).
  */
 export async function rewindFully(
   args: FullyRewindArgs,
 ): Promise<IRewoundFullShieldedOutput> {
   const p = requireProvider();
   try {
-    return await p.rewindFullShieldedOutput(
+    const result = await p.rewindFullShieldedOutput(
       args.scanPrivkey,
       args.ephemeralPubkey,
       args.commitment,
       args.rangeProof,
       args.assetCommitment,
     );
+    return { ...result, tokenUid: normalizeShieldedTokenId(result.tokenUid) };
   } catch (e) {
     if (e instanceof RewindError) throw e;
     throw new RewindError('shielded full rewind failed', e);

--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -1559,14 +1559,14 @@ describe('address generation and index methods', () => {
     // Check wallet1 indices
     const wallet1Indices = indices.get(wallet1);
     expect(wallet1Indices).toBeDefined();
-    expect(wallet1Indices?.maxAmongAddresses).toBe(15);
-    expect(wallet1Indices?.maxWalletIndex).toBe(15);
+    expect(wallet1Indices?.maxTransparentAmongAddresses).toBe(15);
+    expect(wallet1Indices?.maxTransparentWalletIndex).toBe(15);
 
     // Check wallet2 indices
     const wallet2Indices = indices.get(wallet2);
     expect(wallet2Indices).toBeDefined();
-    expect(wallet2Indices?.maxAmongAddresses).toBe(12);
-    expect(wallet2Indices?.maxWalletIndex).toBe(12);
+    expect(wallet2Indices?.maxTransparentAmongAddresses).toBe(12);
+    expect(wallet2Indices?.maxTransparentWalletIndex).toBe(12);
 
     // Test with empty wallet data
     const emptyIndices = await getMaxIndicesForWallets(mysql, []);
@@ -1584,8 +1584,51 @@ describe('address generation and index methods', () => {
     ]);
     const subsetWallet1 = subsetIndices.get(wallet1);
     expect(subsetWallet1).toBeDefined();
-    expect(subsetWallet1?.maxAmongAddresses).toBe(10);
-    expect(subsetWallet1?.maxWalletIndex).toBe(15);
+    expect(subsetWallet1?.maxTransparentAmongAddresses).toBe(10);
+    expect(subsetWallet1?.maxTransparentWalletIndex).toBe(15);
+  });
+
+  test('getMaxIndicesForWallets partitions both index pairs by bip32 account', async () => {
+    expect.hasAssertions();
+
+    // transparent rows for w1: indices 0..3 (bip32_account 0 and NULL both count as transparent)
+    await mysql.query(
+      'INSERT INTO `address` (`address`, `index`, `wallet_id`, `transactions`, `bip32_account`) VALUES ' +
+      "('taddr0', 0, 'w1', 0, 0), ('taddr1', 1, 'w1', 2, NULL), ('taddr2', 2, 'w1', 0, 0), ('taddr3', 3, 'w1', 0, 0)",
+    );
+    // claimed CTSpend rows: frontier at 21, usage in this tx at 12
+    await mysql.query(
+      'INSERT INTO `address` (`address`, `index`, `wallet_id`, `transactions`, `bip32_account`) VALUES ' +
+      "('saddr12', 12, 'w1', 1, 2), ('saddr21', 21, 'w1', 0, 2)",
+    );
+
+    // the tx involves one transparent address (index 1) and one CTSpend address (index 12)
+    const result = await getMaxIndicesForWallets(mysql, [
+      { walletId: 'w1', addresses: ['taddr1', 'saddr12'] },
+    ]);
+    expect(result.get('w1')).toStrictEqual({
+      // transparent pair: CTSpend indices must not leak into either side
+      maxTransparentAmongAddresses: 1, // NOT 12 — the CTSpend involvement stays out
+      maxTransparentWalletIndex: 3,    // NOT 21 — the CTSpend frontier stays out
+      // CT pair: available for the shielded gap-extension follow-up
+      maxCtAmongAddresses: 12,
+      maxCtWalletIndex: 21,
+    });
+  });
+
+  test('getMaxIndicesForWallets yields null CT maxes for a wallet with no shielded rows', async () => {
+    expect.hasAssertions();
+
+    await mysql.query(
+      "INSERT INTO `address` (`address`, `index`, `wallet_id`, `transactions`, `bip32_account`) VALUES ('taddr0', 0, 'w1', 1, 0)",
+    );
+    const result = await getMaxIndicesForWallets(mysql, [{ walletId: 'w1', addresses: ['taddr0'] }]);
+    expect(result.get('w1')).toStrictEqual({
+      maxTransparentAmongAddresses: 0,
+      maxTransparentWalletIndex: 0,
+      maxCtAmongAddresses: null,
+      maxCtWalletIndex: null,
+    });
   });
 });
 

--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -1559,14 +1559,14 @@ describe('address generation and index methods', () => {
     // Check wallet1 indices
     const wallet1Indices = indices.get(wallet1);
     expect(wallet1Indices).toBeDefined();
-    expect(wallet1Indices?.maxTransparentAmongAddresses).toBe(15);
-    expect(wallet1Indices?.maxTransparentWalletIndex).toBe(15);
+    expect(wallet1Indices?.maxLegacyAmongAddresses).toBe(15);
+    expect(wallet1Indices?.maxLegacyWalletIndex).toBe(15);
 
     // Check wallet2 indices
     const wallet2Indices = indices.get(wallet2);
     expect(wallet2Indices).toBeDefined();
-    expect(wallet2Indices?.maxTransparentAmongAddresses).toBe(12);
-    expect(wallet2Indices?.maxTransparentWalletIndex).toBe(12);
+    expect(wallet2Indices?.maxLegacyAmongAddresses).toBe(12);
+    expect(wallet2Indices?.maxLegacyWalletIndex).toBe(12);
 
     // Test with empty wallet data
     const emptyIndices = await getMaxIndicesForWallets(mysql, []);
@@ -1584,8 +1584,8 @@ describe('address generation and index methods', () => {
     ]);
     const subsetWallet1 = subsetIndices.get(wallet1);
     expect(subsetWallet1).toBeDefined();
-    expect(subsetWallet1?.maxTransparentAmongAddresses).toBe(10);
-    expect(subsetWallet1?.maxTransparentWalletIndex).toBe(15);
+    expect(subsetWallet1?.maxLegacyAmongAddresses).toBe(10);
+    expect(subsetWallet1?.maxLegacyWalletIndex).toBe(15);
   });
 
   test('getMaxIndicesForWallets partitions both index pairs by bip32 account', async () => {
@@ -1608,8 +1608,8 @@ describe('address generation and index methods', () => {
     ]);
     expect(result.get('w1')).toStrictEqual({
       // transparent pair: CTSpend indices must not leak into either side
-      maxTransparentAmongAddresses: 1, // NOT 12 — the CTSpend involvement stays out
-      maxTransparentWalletIndex: 3,    // NOT 21 — the CTSpend frontier stays out
+      maxLegacyAmongAddresses: 1, // NOT 12 — the CTSpend involvement stays out
+      maxLegacyWalletIndex: 3,    // NOT 21 — the CTSpend frontier stays out
       // CT pair: available for the shielded gap-extension follow-up
       maxCtAmongAddresses: 12,
       maxCtWalletIndex: 21,
@@ -1624,8 +1624,8 @@ describe('address generation and index methods', () => {
     );
     const result = await getMaxIndicesForWallets(mysql, [{ walletId: 'w1', addresses: ['taddr0'] }]);
     expect(result.get('w1')).toStrictEqual({
-      maxTransparentAmongAddresses: 0,
-      maxTransparentWalletIndex: 0,
+      maxLegacyAmongAddresses: 0,
+      maxLegacyWalletIndex: 0,
       maxCtAmongAddresses: null,
       maxCtWalletIndex: null,
     });

--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -766,8 +766,14 @@ describe('address and wallet related tests', () => {
 
   test('getAddressWalletInfo', async () => {
     expect.hasAssertions();
-    const wallet1 = { walletId: 'wallet1', xpubkey: 'xpubkey1', authXpubkey: 'authXpubkey', maxGap: 5 };
-    const wallet2 = { walletId: 'wallet2', xpubkey: 'xpubkey2', authXpubkey: 'authXpubkey2', maxGap: 5 };
+    // status/ctStatus come back too — callers need them to tell an attributable
+    // (fully loaded) wallet from one whose load is still rebuilding balances.
+    const wallet1 = {
+      walletId: 'wallet1', xpubkey: 'xpubkey1', authXpubkey: 'authXpubkey', maxGap: 5, status: WalletStatus.READY, ctStatus: 'none',
+    };
+    const wallet2 = {
+      walletId: 'wallet2', xpubkey: 'xpubkey2', authXpubkey: 'authXpubkey2', maxGap: 5, status: WalletStatus.READY, ctStatus: 'none',
+    };
     const finalMap = {
       addr1: wallet1,
       addr2: wallet1,

--- a/packages/daemon/__tests__/utils/wallet.test.ts
+++ b/packages/daemon/__tests__/utils/wallet.test.ts
@@ -12,10 +12,14 @@ import {
   EventTxInput,
   EventTxOutput,
   ShieldedOutput,
+  StringMap,
+  Wallet,
+  WalletStatus,
 } from '../../src/types';
 import {
   getInvolvedAddresses,
   getUnifiedBalanceMap,
+  getWalletBalanceMap,
   prepareInputs,
   prepareOutputs,
   unlockUtxos,
@@ -399,5 +403,44 @@ describe('getUnifiedBalanceMap (pure portions)', () => {
     expect(Object.keys(map)).toEqual(['Hnano']);
     expect(map.Hnano).toBeInstanceOf(TokenBalanceMap);
     expect(map.Hnano.get(constants.NATIVE_TOKEN_UID)).toBeDefined();
+  });
+});
+
+describe('getWalletBalanceMap attributability filter', () => {
+  const balances = () => ({
+    addr1: TokenBalanceMap.fromStringMap({ [constants.NATIVE_TOKEN_UID]: { unlocked: 5n, locked: 0n } }),
+  });
+  const walletAt = (status: WalletStatus, ctStatus: WalletStatus | 'none'): StringMap<Wallet> => ({
+    addr1: {
+      walletId: 'w1', xpubkey: 'xpub', authXpubkey: 'auth', maxGap: 20, status, ctStatus,
+    },
+  });
+
+  it('attributes a fully-loaded wallet', () => {
+    const map = getWalletBalanceMap(walletAt(WalletStatus.READY, 'none'), balances());
+    expect(Object.keys(map)).toEqual(['w1']);
+  });
+
+  it('attributes a ready wallet whose shielded side is also ready', () => {
+    const map = getWalletBalanceMap(walletAt(WalletStatus.READY, WalletStatus.READY), balances());
+    expect(Object.keys(map)).toEqual(['w1']);
+  });
+
+  it('skips a wallet whose legacy load is still running', () => {
+    // The load rebuilds wallet_balance absolutely; an increment here would be clobbered.
+    const map = getWalletBalanceMap(walletAt(WalletStatus.CREATING, 'none'), balances());
+    expect(Object.keys(map)).toEqual([]);
+  });
+
+  it('skips a wallet mid shielded upgrade (status ready, ct_status creating)', () => {
+    // The upgrade case: the legacy side is already ready, so a status-only check
+    // would wrongly attribute here while the load is rebuilding both column families.
+    const map = getWalletBalanceMap(walletAt(WalletStatus.READY, WalletStatus.CREATING), balances());
+    expect(Object.keys(map)).toEqual([]);
+  });
+
+  it('skips a wallet whose load errored', () => {
+    const map = getWalletBalanceMap(walletAt(WalletStatus.ERROR, 'none'), balances());
+    expect(Object.keys(map)).toEqual([]);
   });
 });

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -9,6 +9,7 @@ import {
   DbTxOutput,
   StringMap,
   Wallet,
+  WalletStatus,
   EventTxInput,
   AddressIndexMap,
   LastSyncedEvent,
@@ -1442,11 +1443,15 @@ export const getAddressWalletInfo = async (mysql: MysqlConnection, addresses: st
 
   const addressWalletMap: StringMap<Wallet> = {};
   const [results, _] = await mysql.query<AddressesWalletsRow[]>(
+    // Both lifecycle columns come back so callers can tell an attributable
+    // (fully loaded) wallet from one whose load is still rebuilding balances.
     `SELECT DISTINCT a.\`address\`,
                      a.\`wallet_id\`,
                      w.\`auth_xpubkey\`,
                      w.\`xpubkey\`,
-                     w.\`max_gap\`
+                     w.\`max_gap\`,
+                     w.\`status\`,
+                     w.\`ct_status\`
        FROM \`address\` a
  INNER JOIN \`wallet\` w
          ON a.wallet_id = w.id
@@ -1461,6 +1466,8 @@ export const getAddressWalletInfo = async (mysql: MysqlConnection, addresses: st
       authXpubkey: entry.auth_xpubkey,
       xpubkey: entry.xpubkey,
       maxGap: entry.max_gap,
+      status: entry.status as WalletStatus,
+      ctStatus: entry.ct_status as WalletStatus | 'none',
     };
     addressWalletMap[entry.address] = walletInfo;
   }

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -2414,7 +2414,7 @@ export const getTokenSymbols = async (
 
 /**
  * Get maximum indices for multiple wallets in a single query, partitioned by
- * BIP32 account so transparent and shielded (CTSpend) index spaces never mix.
+ * BIP32 account so legacy and shielded (CTSpend) index spaces never mix.
  *
  * This function retrieves two key metrics per account for each wallet:
  *
@@ -2424,15 +2424,15 @@ export const getTokenSymbols = async (
  * How it works:
  * - The SQL query operates on the `address` table, grouped by `wallet_id`.
  * - Each `MAX` is scoped by a `bip32_account` CASE: transparent rows are those
- *   with account 0 **or NULL** (transparent claims leave the column NULL), and
+ *   with account 0 **or NULL** (legacy claims leave the column NULL), and
  *   CTSpend rows carry account 2 — a claimed shielded index must never leak
- *   into the transparent gap math, in either direction.
+ *   into the legacy gap math, in either direction.
  * - If no addresses for a wallet match the provided input, the `amongAddresses`
  *   value for that account will be `NULL`.
  * - A wallet with no rows for an account yields `NULL` for that account's pair
  *   (e.g. no shielded window claimed -> both CT maxes are `NULL`).
  *
- * The transparent pair feeds the transparent gap extension; the CT pair is the
+ * The legacy pair feeds the legacy gap extension; the CT pair is the
  * input for the shielded gap extension (follow-up work).
  *
  * @param mysql - Database connection
@@ -2443,8 +2443,8 @@ export const getMaxIndicesForWallets = async (
   mysql: MysqlConnection,
   walletData: Array<{ walletId: string, addresses: string[] }>
 ): Promise<Map<string, {
-  maxTransparentAmongAddresses: number | null,
-  maxTransparentWalletIndex: number | null,
+  maxLegacyAmongAddresses: number | null,
+  maxLegacyWalletIndex: number | null,
   maxCtAmongAddresses: number | null,
   maxCtWalletIndex: number | null,
 }>> => {
@@ -2458,8 +2458,8 @@ export const getMaxIndicesForWallets = async (
   const [results] = await mysql.query<MaxAddressIndexRow[]>(
     `SELECT
        wallet_id,
-       MAX(CASE WHEN (bip32_account IS NULL OR bip32_account = ?) AND address IN (?) THEN \`index\` END) as max_transparent_among_addresses,
-       MAX(CASE WHEN (bip32_account IS NULL OR bip32_account = ?) THEN \`index\` END) as max_transparent_wallet_index,
+       MAX(CASE WHEN (bip32_account IS NULL OR bip32_account = ?) AND address IN (?) THEN \`index\` END) as max_legacy_among_addresses,
+       MAX(CASE WHEN (bip32_account IS NULL OR bip32_account = ?) THEN \`index\` END) as max_legacy_wallet_index,
        MAX(CASE WHEN bip32_account = ? AND address IN (?) THEN \`index\` END) as max_ct_among_addresses,
        MAX(CASE WHEN bip32_account = ? THEN \`index\` END) as max_ct_wallet_index
      FROM address
@@ -2479,8 +2479,8 @@ export const getMaxIndicesForWallets = async (
     {
       // MAX() is null when no rows match, and arrives as a string under
       // bigNumberStrings — parse to a (bounded) number | null.
-      maxTransparentAmongAddresses: parseNullableNumber(r.max_transparent_among_addresses),
-      maxTransparentWalletIndex: parseNullableNumber(r.max_transparent_wallet_index),
+      maxLegacyAmongAddresses: parseNullableNumber(r.max_legacy_among_addresses),
+      maxLegacyWalletIndex: parseNullableNumber(r.max_legacy_wallet_index),
       maxCtAmongAddresses: parseNullableNumber(r.max_ct_among_addresses),
       maxCtWalletIndex: parseNullableNumber(r.max_ct_wallet_index)
     }

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -2413,33 +2413,41 @@ export const getTokenSymbols = async (
 };
 
 /**
- * Get maximum indices for multiple wallets in a single query.
+ * Get maximum indices for multiple wallets in a single query, partitioned by
+ * BIP32 account so transparent and shielded (CTSpend) index spaces never mix.
  *
- * This function retrieves two key metrics for each wallet:
+ * This function retrieves two key metrics per account for each wallet:
  *
- * 1. `max_among_addresses`: The highest `index` value for the wallet, but only considering the specified addresses provided in `walletData`.
- * 2. `max_wallet_index`: The highest `index` value for the wallet across all its addresses in the database.
+ * 1. `max*AmongAddresses`: The highest `index` value for the wallet, but only considering the specified addresses provided in `walletData`.
+ * 2. `max*WalletIndex`: The highest `index` value for the wallet across all its addresses in the database.
  *
  * How it works:
- * - The SQL query operates on the `address` table.
- * - It groups the rows by `wallet_id` using `GROUP BY wallet_id`.
- * - For each wallet group:
- *   - The `MAX` function calculates the highest `index` value in two contexts:
- *     a. For addresses explicitly listed in the input (`CASE WHEN address IN (?) THEN index END`).
- *     b. For all addresses associated with the wallet (`MAX(index)`).
- * - If no addresses for a wallet match the provided input, `max_among_addresses` will be `NULL`.
- * - If a wallet has no addresses in the database, both `max_among_addresses` and `max_wallet_index` will be `NULL`.
+ * - The SQL query operates on the `address` table, grouped by `wallet_id`.
+ * - Each `MAX` is scoped by a `bip32_account` CASE: transparent rows are those
+ *   with account 0 **or NULL** (transparent claims leave the column NULL), and
+ *   CTSpend rows carry account 2 — a claimed shielded index must never leak
+ *   into the transparent gap math, in either direction.
+ * - If no addresses for a wallet match the provided input, the `amongAddresses`
+ *   value for that account will be `NULL`.
+ * - A wallet with no rows for an account yields `NULL` for that account's pair
+ *   (e.g. no shielded window claimed -> both CT maxes are `NULL`).
  *
- * This allows the function to return a consolidated view of the maximum indices for each wallet
+ * The transparent pair feeds the transparent gap extension; the CT pair is the
+ * input for the shielded gap extension (follow-up work).
  *
  * @param mysql - Database connection
  * @param walletData - Array of objects containing wallet IDs and their associated addresses
- * @returns Map of wallet IDs to their maximum indices (both among specific addresses and overall)
+ * @returns Map of wallet IDs to their per-account maximum indices
  */
 export const getMaxIndicesForWallets = async (
   mysql: MysqlConnection,
   walletData: Array<{ walletId: string, addresses: string[] }>
-): Promise<Map<string, { maxAmongAddresses: number | null, maxWalletIndex: number | null }>> => {
+): Promise<Map<string, {
+  maxTransparentAmongAddresses: number | null,
+  maxTransparentWalletIndex: number | null,
+  maxCtAmongAddresses: number | null,
+  maxCtWalletIndex: number | null,
+}>> => {
   if (walletData.length === 0) {
     return new Map();
   }
@@ -2450,12 +2458,20 @@ export const getMaxIndicesForWallets = async (
   const [results] = await mysql.query<MaxAddressIndexRow[]>(
     `SELECT
        wallet_id,
-       MAX(CASE WHEN address IN (?) THEN \`index\` END) as max_among_addresses,
-       MAX(\`index\`) as max_wallet_index
+       MAX(CASE WHEN (bip32_account IS NULL OR bip32_account = ?) AND address IN (?) THEN \`index\` END) as max_transparent_among_addresses,
+       MAX(CASE WHEN (bip32_account IS NULL OR bip32_account = ?) THEN \`index\` END) as max_transparent_wallet_index,
+       MAX(CASE WHEN bip32_account = ? AND address IN (?) THEN \`index\` END) as max_ct_among_addresses,
+       MAX(CASE WHEN bip32_account = ? THEN \`index\` END) as max_ct_wallet_index
      FROM address
      WHERE wallet_id IN (?)
      GROUP BY wallet_id`,
-    [allAddresses, walletIds]
+    [
+      Bip32Account.Legacy, allAddresses,
+      Bip32Account.Legacy,
+      Bip32Account.CTSpend, allAddresses,
+      Bip32Account.CTSpend,
+      walletIds,
+    ]
   );
 
   return new Map(results.map(r => [
@@ -2463,8 +2479,10 @@ export const getMaxIndicesForWallets = async (
     {
       // MAX() is null when no rows match, and arrives as a string under
       // bigNumberStrings — parse to a (bounded) number | null.
-      maxAmongAddresses: parseNullableNumber(r.max_among_addresses),
-      maxWalletIndex: parseNullableNumber(r.max_wallet_index)
+      maxTransparentAmongAddresses: parseNullableNumber(r.max_transparent_among_addresses),
+      maxTransparentWalletIndex: parseNullableNumber(r.max_transparent_wallet_index),
+      maxCtAmongAddresses: parseNullableNumber(r.max_ct_among_addresses),
+      maxCtWalletIndex: parseNullableNumber(r.max_ct_wallet_index)
     }
   ]));
 };

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -668,9 +668,13 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
               continue;
             }
 
-            const { maxAmongAddresses, maxWalletIndex } = indices;
+            // Transparent gap extension reads the transparent pair only — a
+            // claimed shielded (CTSpend) index must never drive or suppress
+            // transparent derivation. The CT pair feeds the shielded gap
+            // extension (follow-up work).
+            const { maxTransparentAmongAddresses, maxTransparentWalletIndex } = indices;
 
-            if (maxAmongAddresses == null || maxWalletIndex == null) {
+            if (maxTransparentAmongAddresses == null || maxTransparentWalletIndex == null) {
               // Do nothing, wallet is most likely not loaded yet.
               if (walletDetails.status === WalletStatus.READY) {
                 logger.error('[ERROR] A wallet marked as READY does not have a max wallet index or address index was not found in the database');
@@ -678,12 +682,12 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
               continue;
             }
 
-            const diff = maxWalletIndex - maxAmongAddresses;
+            const diff = maxTransparentWalletIndex - maxTransparentAmongAddresses;
 
             if (diff < walletDetails.maxGap) {
               // We need to generate addresses
-              const addresses = await generateAddresses(NETWORK as string, walletDetails.xpubkey, maxWalletIndex + 1, walletDetails.maxGap - diff);
-              await addNewAddresses(mysql, walletId, addresses, maxAmongAddresses);
+              const addresses = await generateAddresses(NETWORK as string, walletDetails.xpubkey, maxTransparentWalletIndex + 1, walletDetails.maxGap - diff);
+              await addNewAddresses(mysql, walletId, addresses, maxTransparentAmongAddresses);
             }
           }
 

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -668,13 +668,13 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
               continue;
             }
 
-            // Transparent gap extension reads the transparent pair only — a
+            // Legacy gap extension reads the legacy pair only — a
             // claimed shielded (CTSpend) index must never drive or suppress
-            // transparent derivation. The CT pair feeds the shielded gap
+            // legacy derivation. The CT pair feeds the shielded gap
             // extension (follow-up work).
-            const { maxTransparentAmongAddresses, maxTransparentWalletIndex } = indices;
+            const { maxLegacyAmongAddresses, maxLegacyWalletIndex } = indices;
 
-            if (maxTransparentAmongAddresses == null || maxTransparentWalletIndex == null) {
+            if (maxLegacyAmongAddresses == null || maxLegacyWalletIndex == null) {
               // Do nothing, wallet is most likely not loaded yet.
               if (walletDetails.status === WalletStatus.READY) {
                 logger.error('[ERROR] A wallet marked as READY does not have a max wallet index or address index was not found in the database');
@@ -682,12 +682,12 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
               continue;
             }
 
-            const diff = maxTransparentWalletIndex - maxTransparentAmongAddresses;
+            const diff = maxLegacyWalletIndex - maxLegacyAmongAddresses;
 
             if (diff < walletDetails.maxGap) {
               // We need to generate addresses
-              const addresses = await generateAddresses(NETWORK as string, walletDetails.xpubkey, maxTransparentWalletIndex + 1, walletDetails.maxGap - diff);
-              await addNewAddresses(mysql, walletId, addresses, maxTransparentAmongAddresses);
+              const addresses = await generateAddresses(NETWORK as string, walletDetails.xpubkey, maxLegacyWalletIndex + 1, walletDetails.maxGap - diff);
+              await addNewAddresses(mysql, walletId, addresses, maxLegacyAmongAddresses);
             }
           }
 

--- a/packages/daemon/src/services/index.ts
+++ b/packages/daemon/src/services/index.ts
@@ -561,7 +561,7 @@ export const handleVertexAccepted = async (context: Context, _event: Event) => {
                   rangeProof: range,
                   assetCommitment: assetCommit,
                 });
-                const tokenIdHexFull = r.tokenUid;
+                const tokenIdHexFull = r.tokenUid; // canonicalized by rewindFully
                 await markTxOutputRecovered(mysql, hash, idx, {
                   value: r.value,
                   token_id: tokenIdHexFull,

--- a/packages/daemon/src/types/db.ts
+++ b/packages/daemon/src/types/db.ts
@@ -149,8 +149,8 @@ export interface TokenSymbolsRow extends RowDataPacket {
 }
 
 export interface MaxAddressIndexRow extends RowDataPacket {
-  max_transparent_among_addresses: number | null,
-  max_transparent_wallet_index: number | null,
+  max_legacy_among_addresses: number | null,
+  max_legacy_wallet_index: number | null,
   max_ct_among_addresses: number | null,
   max_ct_wallet_index: number | null,
 }

--- a/packages/daemon/src/types/db.ts
+++ b/packages/daemon/src/types/db.ts
@@ -161,6 +161,8 @@ export interface AddressesWalletsRow extends RowDataPacket {
   auth_xpubkey: string,
   xpubkey: string,
   maxGap: number,
+  status: string,
+  ct_status: string,
 }
 
 export interface AddressRow extends RowDataPacket {

--- a/packages/daemon/src/types/db.ts
+++ b/packages/daemon/src/types/db.ts
@@ -149,8 +149,10 @@ export interface TokenSymbolsRow extends RowDataPacket {
 }
 
 export interface MaxAddressIndexRow extends RowDataPacket {
-  max_among_addresses: number,
-  max_wallet_index: number
+  max_transparent_among_addresses: number | null,
+  max_transparent_wallet_index: number | null,
+  max_ct_among_addresses: number | null,
+  max_ct_wallet_index: number | null,
 }
 
 export interface AddressesWalletsRow extends RowDataPacket {

--- a/packages/daemon/src/types/wallet.ts
+++ b/packages/daemon/src/types/wallet.ts
@@ -19,10 +19,28 @@ export interface Wallet {
   authXpubkey: string,
   maxGap: number;
   status?: WalletStatus;
+  /** Shielded lifecycle: 'none' when the wallet has no shielded keys registered. */
+  ctStatus?: WalletStatus | 'none';
   retryCount?: number;
   createdAt?: number;
   readyAt?: number;
 }
+
+/**
+ * A wallet is only attributable for balance once BOTH lifecycles have settled.
+ *
+ * While either side is still loading, the load worker is rebuilding
+ * `wallet_balance` absolutely from `address_balance`; attributing incremental
+ * deltas at the same time races that rebuild and the increment is silently lost.
+ * Note this must consider `ct_status` too — a shielded upgrade runs with
+ * `status = 'ready'` while `ct_status = 'creating'`.
+ */
+export const isWalletAttributable = (wallet: Wallet): boolean => (
+  wallet.status === WalletStatus.READY
+  && (wallet.ctStatus === undefined
+    || wallet.ctStatus === 'none'
+    || wallet.ctStatus === WalletStatus.READY)
+);
 
 export type TokenBalanceValue = {
   tokenId: string,

--- a/packages/daemon/src/utils/wallet.ts
+++ b/packages/daemon/src/utils/wallet.ts
@@ -22,6 +22,7 @@ import {
   Wallet,
   WalletBalance,
   WalletBalanceValue,
+  isWalletAttributable,
 } from '../types';
 import {
   Transaction,
@@ -471,6 +472,13 @@ export const getWalletBalanceMap = (
 
     // if this address is not from a started wallet, ignore
     if (!walletId) continue;
+
+    // A wallet mid-load is skipped: its load worker rebuilds `wallet_balance`
+    // absolutely from `address_balance`, so an incremental delta written here
+    // would be clobbered by that rebuild and lost for good. `address_balance`
+    // is still updated (it is written before this map is built), so the
+    // rebuild picks the transaction up and the wallet stays correct.
+    if (!isWalletAttributable(wallet)) continue;
 
     walletBalanceMap[walletId] = TokenBalanceMap.merge(walletBalanceMap[walletId], balanceMap);
   }

--- a/packages/wallet-service/serverless.yml
+++ b/packages/wallet-service/serverless.yml
@@ -243,27 +243,8 @@ functions:
           arn:aws:lambda:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:function:hathor-explorer-service-${self:custom.explorerServiceStage}-create_or_update_dag_metadata
   loadWalletAsync:
     # Canonical async load: derives transparent + shielded address paths and
-    # reconstructs both balances in one pass (combined load).
-    handler: src/api/wallet.loadWalletCombined
-    memorySize: 1024
-    timeout: 600 # 10 minutes should be enough for most wallets
-    onError: arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
-    warmup:
-      walletWarmer:
-        enabled: false
-    iamRoleStatements:
-      - Effect: Allow
-        Action:
-          - SNS:Publish
-        Resource:
-          arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}
-  deprecatedLoad:
-    # Deprecated transparent-only async load, kept until the combined load above
-    # subsumes it entirely.
+    # reconstructs both balances in one pass.
     handler: src/api/wallet.loadWallet
-    # This lambda is currently running out of memory when wallets with a big
-    # number of transactions (> 300k) is being loaded. I chose 1024 because the
-    # average memory usage of the largest test wallet we have is 800mb.
     memorySize: 1024
     timeout: 600 # 10 minutes should be enough for most wallets
     onError: arn:aws:sns:${self:provider.region}:${self:provider.environment.ACCOUNT_ID}:WalletServiceLoadAsyncFailed_${self:custom.stage}

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -26,6 +26,7 @@ import {
   advanceLastUsedShieldedIndex,
   markWalletLoadReady,
   markWalletLoadError,
+  markLegacyLoadError,
 } from '@src/db';
 import {
   GenerateShieldedAddresses,
@@ -74,6 +75,14 @@ import errorHandler from '@src/api/middlewares/errorHandler';
 const mysql = getDbConnection();
 
 const MAX_LOAD_WALLET_RETRIES: number = config.maxLoadWalletRetries;
+
+/**
+ * Alert-safe error detail. `String(e)` drops the stack of a real Error, leaving
+ * the alert with only a message and no way to join it to the logged throw.
+ */
+const errorDetail = (e: unknown): string => (
+  e instanceof Error ? (e.stack ?? `${e.name}: ${e.message}`) : String(e)
+);
 
 // Network instance used to encode shielded (ct) addresses — carries the
 // shielded/p2pkh version bytes that address derivation reads.
@@ -528,12 +537,17 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
   }
 
   /* The async loads below are invoked as "Event", so we don't care about the
-   * response here, only whether the invocation itself failed. On failure the
-   * wallet is marked 'error' and the latest status is re-read for the response. */
+   * response here, only whether the invocation itself failed. On failure only the
+   * side this request was loading is marked 'error' — an upgrade whose invoke
+   * fails must leave the already-ready legacy wallet working — and the latest
+   * status is re-read for the response. */
   const onAsyncInvokeError = async (e: unknown): Promise<void> => {
     logger.error(e);
-    const newRetryCount = wallet.retryCount ? wallet.retryCount + 1 : 1;
-    await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, newRetryCount);
+    if (hasShielded) {
+      await markWalletLoadError(mysql, walletId, wallet.status !== WalletStatus.READY);
+    } else {
+      await markLegacyLoadError(mysql, walletId);
+    }
     wallet = await getWallet(mysql, walletId);
   };
 
@@ -797,11 +811,19 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
     //    from tx_output), so everything revealed lands in a single rebuild.
     const ctSpendAddresses = hasShieldedKeys ? await getWalletCtSpendAddresses(mysql, walletId) : [];
     if (hasShieldedKeys) {
-      await findAndRewindShielded(mysql, walletId, logger);
+      const firstSweep = await findAndRewindShielded(mysql, walletId, logger);
       // Settle drain: a daemon ingest whose ownership check snapshotted the
       // world before our claim committed lands its output unowned moments
       // later — one more (cheap when empty) sweep closes that window.
-      await findAndRewindShielded(mysql, walletId, logger);
+      const settleSweep = await findAndRewindShielded(mysql, walletId, logger);
+      // A rewind that fails is recorded as `recovery_failed` and re-driven by a
+      // later catch-up, so the load still completes — but the balance is
+      // incomplete until then, so make the count greppable next to the
+      // per-output alerts rather than letting it pass silently.
+      const failedRewinds = firstSweep.failed + settleSweep.failed;
+      if (failedRewinds > 0) {
+        logger.error('Shielded outputs failed to recover during load', { walletId, failed: failedRewinds });
+      }
       await rebuildShieldedAddressBalances(mysql, ctSpendAddresses);
       await rebuildShieldedAddressTxHistory(mysql, ctSpendAddresses);
     }
@@ -817,23 +839,37 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
       await updateWalletStatus(mysql, walletId, WalletStatus.READY);
     }
 
-    await closeDbConnection(mysql);
     return { success: true, walletId, xpubkey };
   } catch (e) {
-    logger.error('Erroed on loadWallet: ', e);
-    await addAlert(
-      'Wallet load failed',
-      `The legacy+shielded load for wallet ${walletId} failed and was marked for retry.`,
-      Severity.MINOR,
-      { wallet_id: walletId, error: String(e), source: 'wallet-service' },
-      logger,
-    );
-    if (hasShieldedKeys) {
-      await markWalletLoadError(mysql, walletId, !legacyWasReady);
-    } else {
-      await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, (wallet.retryCount ?? 0) + 1);
+    logger.error('Errored on loadWallet: ', e);
+    // The dominant failure here is a dead connection/pool, which would make the
+    // recovery writes below throw too. Contain that: a secondary failure must not
+    // escape and flip this Lambda from "don't retry" to the crash/DLQ channel,
+    // where the same degraded pool is waiting.
+    try {
+      await addAlert(
+        'Wallet load failed',
+        `The legacy+shielded load for wallet ${walletId} failed and was marked for retry.`,
+        Severity.MINOR,
+        { wallet_id: walletId, error: errorDetail(e), source: 'wallet-service' },
+        logger,
+      );
+      if (hasShieldedKeys) {
+        await markWalletLoadError(mysql, walletId, !legacyWasReady);
+      } else {
+        await markLegacyLoadError(mysql, walletId);
+      }
+    } catch (recoveryError) {
+      logger.error('Failed to record the load failure', { walletId, originalError: e, recoveryError });
     }
-    await closeDbConnection(mysql);
     return { success: false, walletId, xpubkey };
+  } finally {
+    // Covers both paths — a throw in the finalize writes must not leak the
+    // pooled connection in a long-lived Lambda.
+    try {
+      await closeDbConnection(mysql);
+    } catch (closeError) {
+      logger.error('Failed to close the db connection', { walletId, closeError });
+    }
   }
 };

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -23,6 +23,8 @@ import {
   updateWalletAuthXpub,
   registerWalletShieldedKeys,
   casWalletErrorToCreating,
+  pinTransparentLoadFailed,
+  pinShieldedLoadFailed,
   upsertNewAddresses,
   advanceLastUsedShieldedIndex,
   markWalletCombinedReady,
@@ -550,18 +552,40 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
     wallet = await getWallet(mysql, walletId);
   };
 
+  /** 409 for a submitted key set that disagrees with the one already stored. */
+  const rejectKeysConflict = async () => {
+    await closeDbConnection(mysql);
+    return {
+      statusCode: 409,
+      body: JSON.stringify({ success: false, error: ApiError.SHIELDED_KEYS_CONFLICT }),
+    };
+  };
+
   if (hasShielded) {
+    // Whether this request is the one attaching keys to a transparent wallet, and
+    // whether it won that race — only the winner may drive the load.
+    let upgrading = false;
+    let attachedKeys = false;
+
     // Reconcile keys for an existing wallet: reject a conflicting set; attach keys
     // to a transparent wallet being upgraded. A fresh wallet already has its keys.
     if (walletExisted) {
       if (wallet.scanXpriv == null) {
-        await registerWalletShieldedKeys(mysql, walletId, value.scanXpriv, value.spendXpub, config.shieldedMaxAddressGap);
+        upgrading = true;
+        attachedKeys = await registerWalletShieldedKeys(
+          mysql, walletId, value.scanXpriv, value.spendXpub, config.shieldedMaxAddressGap,
+        );
+        if (!attachedKeys) {
+          // A concurrent request attached keys between our read and this write.
+          // Re-read and hold a differing set to the same conflict rule a
+          // sequential submit would have hit.
+          wallet = await getWallet(mysql, walletId);
+          if (wallet.scanXpriv !== value.scanXpriv || wallet.spendXpub !== value.spendXpub) {
+            return rejectKeysConflict();
+          }
+        }
       } else if (wallet.scanXpriv !== value.scanXpriv || wallet.spendXpub !== value.spendXpub) {
-        await closeDbConnection(mysql);
-        return {
-          statusCode: 409,
-          body: JSON.stringify({ success: false, error: ApiError.SHIELDED_KEYS_CONFLICT }),
-        };
+        return rejectKeysConflict();
       }
     }
 
@@ -582,19 +606,27 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
       && wallet.spendXpub === value.spendXpub
       && computeUnifiedStatus(wallet.status, wallet.ctStatus ?? 'none') !== WalletStatus.ERROR;
 
-    if (!settledWithSameKeys) {
+    let shouldInvoke: boolean;
+    if (upgrading) {
+      // Only the request that actually attached the keys drives the upgrade load;
+      // the loser of that race would otherwise spawn a duplicate.
+      shouldInvoke = attachedKeys;
+    } else if (settledWithSameKeys) {
+      shouldInvoke = false;
+    } else {
       // A retry of an errored load must atomically transition back to creating
       // first — a lost race means another request already spawned the load, so
       // this one must not double-invoke.
       const entryUnified = computeUnifiedStatus(wallet.status, wallet.ctStatus ?? 'none');
-      const shouldInvoke = entryUnified !== WalletStatus.ERROR
+      shouldInvoke = entryUnified !== WalletStatus.ERROR
         || await casWalletErrorToCreating(mysql, walletId);
-      if (shouldInvoke) {
-        try {
-          await invokeLoadWalletAsync(xpubkeyStr, maxGap);
-        } catch (e) {
-          await onAsyncInvokeError(e);
-        }
+    }
+
+    if (shouldInvoke) {
+      try {
+        await invokeLoadWalletAsync(xpubkeyStr, maxGap);
+      } catch (e) {
+        await onAsyncInvokeError(e);
       }
     }
     wallet = await getWallet(mysql, walletId);
@@ -673,17 +705,12 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
       // working transparent state untouched.
       const failedWallet = await getWallet(mysql, walletId);
       if (failedWallet && failedWallet.scanXpriv != null) {
-        if (failedWallet.status === WalletStatus.READY) {
-          await mysql.query(
-            'UPDATE `wallet` SET `ct_status` = ?, `retry_count` = ? WHERE `id` = ?',
-            [WalletStatus.ERROR, MAX_LOAD_WALLET_RETRIES, walletId],
-          );
-        } else {
-          await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, MAX_LOAD_WALLET_RETRIES);
-          await mysql.query('UPDATE `wallet` SET `ct_status` = ? WHERE `id` = ?', [WalletStatus.ERROR, walletId]);
+        if (failedWallet.status !== WalletStatus.READY) {
+          await pinTransparentLoadFailed(mysql, walletId, MAX_LOAD_WALLET_RETRIES);
         }
+        await pinShieldedLoadFailed(mysql, walletId, MAX_LOAD_WALLET_RETRIES);
       } else {
-        await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, MAX_LOAD_WALLET_RETRIES);
+        await pinTransparentLoadFailed(mysql, walletId, MAX_LOAD_WALLET_RETRIES);
       }
 
       logger.error(`${walletId} failed to load.`);

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -642,9 +642,24 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
 
       const walletId = getWalletId(loadEvent.xpubkey);
 
-      // update wallet status to 'error' and set the number of retries to MAX so
-      // it doesn't get retried
-      await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, MAX_LOAD_WALLET_RETRIES);
+      // Pin the wallet at the retry cap so it is not retried. A wallet with
+      // shielded keys pins its shielded lifecycle too, and an upgrade — whose
+      // transparent side was already ready before the crashed load — keeps its
+      // working transparent state untouched.
+      const failedWallet = await getWallet(mysql, walletId);
+      if (failedWallet && failedWallet.scanXpriv != null) {
+        if (failedWallet.status === WalletStatus.READY) {
+          await mysql.query(
+            'UPDATE `wallet` SET `ct_status` = ?, `retry_count` = ? WHERE `id` = ?',
+            [WalletStatus.ERROR, MAX_LOAD_WALLET_RETRIES, walletId],
+          );
+        } else {
+          await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, MAX_LOAD_WALLET_RETRIES);
+          await mysql.query('UPDATE `wallet` SET `ct_status` = ? WHERE `id` = ?', [WalletStatus.ERROR, walletId]);
+        }
+      } else {
+        await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, MAX_LOAD_WALLET_RETRIES);
+      }
 
       logger.error(`${walletId} failed to load.`);
       logger.error({

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -22,6 +22,7 @@ import {
   updateWalletStatus,
   updateWalletAuthXpub,
   registerWalletShieldedKeys,
+  casWalletErrorToCreating,
 } from '@src/db';
 import {
   beginTransaction,
@@ -566,10 +567,18 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
       && computeUnifiedStatus(wallet.status, wallet.ctStatus ?? 'none') !== WalletStatus.ERROR;
 
     if (!settledWithSameKeys) {
-      try {
-        await invokeLoadWalletAsync(xpubkeyStr, maxGap);
-      } catch (e) {
-        await onAsyncInvokeError(e);
+      // A retry of an errored load must atomically transition back to creating
+      // first — a lost race means another request already spawned the load, so
+      // this one must not double-invoke.
+      const entryUnified = computeUnifiedStatus(wallet.status, wallet.ctStatus ?? 'none');
+      const shouldInvoke = entryUnified !== WalletStatus.ERROR
+        || await casWalletErrorToCreating(mysql, walletId);
+      if (shouldInvoke) {
+        try {
+          await invokeLoadWalletAsync(xpubkeyStr, maxGap);
+        } catch (e) {
+          await onAsyncInvokeError(e);
+        }
       }
     }
     wallet = await getWallet(mysql, walletId);

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -12,12 +12,9 @@ import 'source-map-support/register';
 import { createLambdaClient } from '@src/utils/aws.utils';
 import { ApiError } from '@src/api/errors';
 import {
-  addNewAddresses,
   createWallet,
   generateAddresses,
   getWallet,
-  initWalletBalance,
-  initWalletTxHistory,
   updateExistingAddresses,
   updateWalletStatus,
   updateWalletAuthXpub,
@@ -27,8 +24,8 @@ import {
   pinShieldedLoadFailed,
   upsertNewAddresses,
   advanceLastUsedShieldedIndex,
-  markWalletCombinedReady,
-  markWalletCombinedError,
+  markWalletLoadReady,
+  markWalletLoadError,
 } from '@src/db';
 import {
   GenerateShieldedAddresses,
@@ -149,13 +146,14 @@ const loadBodySchema = Joi.object({
 }).and('scanXpriv', 'spendXpub', 'firstCtAddress', 'spendXpubSignature', 'ctAddressSignature');
 
 /**
- * Invoke the loadWalletAsync function
+ * Invoke the async wallet-load lambda — derives both the transparent and
+ * shielded address paths and reconstructs both balances in a single pass.
  *
  * @param xpubkey - The xpubkey to load
  * @param maxGap - The max gap
  */
 /* istanbul ignore next */
-const invokeAsyncLoad = async (functionName: string, xpubkey: string, maxGap: number): Promise<void> => {
+export const invokeLoadWalletAsync = async (xpubkey: string, maxGap: number): Promise<void> => {
   const client = createLambdaClient({
     endpoint: config.stage === 'dev'
       ? 'http://localhost:3002'
@@ -164,7 +162,7 @@ const invokeAsyncLoad = async (functionName: string, xpubkey: string, maxGap: nu
   });
   const command = new InvokeCommand({
     // FunctionName is composed of: service name - stage - function name
-    FunctionName: `${config.serviceName}-${config.stage}-${functionName}`,
+    FunctionName: `${config.serviceName}-${config.stage}-loadWalletAsync`,
     InvocationType: 'Event',
     Payload: JSON.stringify({ xpubkey, maxGap }),
   });
@@ -176,21 +174,6 @@ const invokeAsyncLoad = async (functionName: string, xpubkey: string, maxGap: nu
     throw new Error('Lambda invoke failed');
   }
 };
-
-/**
- * Invoke the canonical async wallet load — derives both the transparent and
- * shielded address paths and reconstructs both balances in a single pass. Used
- * whenever a load request carries shielded keys.
- */
-/* istanbul ignore next */
-export const invokeLoadWalletAsync = (xpubkey: string, maxGap: number): Promise<void> => invokeAsyncLoad('loadWalletAsync', xpubkey, maxGap);
-
-/**
- * Invoke the deprecated transparent-only async wallet load. Still used for load
- * requests that carry no shielded keys, until the combined load subsumes it.
- */
-/* istanbul ignore next */
-export const invokeDeprecatedLoad = (xpubkey: string, maxGap: number): Promise<void> => invokeAsyncLoad('deprecatedLoad', xpubkey, maxGap);
 
 /**
  * Calls verifySignature for both the wallet's xpub signature and
@@ -471,7 +454,9 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
     return closeDbAndGetError(mysql, ApiError.WALLET_MAX_RETRIES, { status: toWalletStatusResponse(wallet) });
   };
 
+  // Client did not send CT keys and the wallet already exists
   // check if wallet is already loaded so we can fail early
+  // possibly an old client loading a wallet
   if (wallet && !hasShielded) {
     if (wallet.status === WalletStatus.READY
       || wallet.status === WalletStatus.CREATING) {
@@ -596,7 +581,7 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
       return rejectMaxRetries();
     }
 
-    // (Re)invoke the canonical combined load — which derives both the transparent
+    // (Re)invoke the canonical async load — which derives both the transparent
     // and shielded address paths and reconstructs both balances in one pass —
     // unless this is an identical resubmit on a wallet that is already loaded or in
     // progress. Fresh registrations and upgrades always load; a same-keys resubmit
@@ -631,10 +616,10 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
     }
     wallet = await getWallet(mysql, walletId);
   } else {
-    // Transparent-only load: the deprecated path, kept until the combined load
-    // subsumes it entirely.
+    // Transparent-only load: the load worker derives the transparent path and
+    // reconstructs its balance (shielded steps are no-ops without keys).
     try {
-      await invokeDeprecatedLoad(xpubkeyStr, maxGap);
+      await invokeLoadWalletAsync(xpubkeyStr, maxGap);
     } catch (e) {
       await onAsyncInvokeError(e);
     }
@@ -746,81 +731,6 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
 };
 
 /*
- * Deprecated transparent-only async wallet load: derives the transparent address
- * path and seeds the transparent balance. Kept for load requests that carry no
- * shielded keys, until the combined load subsumes it. It expects a wallet entry
- * already on the database.
- *
- * This lambda is called async by another lambda, the one reponsible for the load wallet API
- */
-export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
-  const logger = createDefaultLogger();
-  // Can't use a middleware on this event, so we should just check the source (added by the warmup plugin) as
-  // our default middleware does
-  if (event.source === 'serverless-plugin-warmup') {
-    return {
-      success: true,
-      walletId: '',
-      xpubkey: '',
-    };
-  }
-
-  const xpubkey = event.xpubkey;
-  const maxGap = event.maxGap;
-  const walletId = getWalletId(xpubkey);
-
-  try {
-    const { addresses, existingAddresses, newAddresses, lastUsedAddressIndex } = await generateAddresses(mysql, xpubkey, maxGap);
-
-    // Wrap all wallet initialization operations in a transaction to prevent partial wallet state
-    try {
-      await beginTransaction(mysql);
-
-      // update address table with new addresses
-      await addNewAddresses(mysql, walletId, newAddresses, lastUsedAddressIndex);
-
-      // update existing addresses' walletId and index
-      await updateExistingAddresses(mysql, walletId, existingAddresses);
-
-      // from address_tx_history, update wallet_tx_history
-      await initWalletTxHistory(mysql, walletId, addresses);
-
-      // from address_balance table, update balance table
-      await initWalletBalance(mysql, walletId, addresses);
-
-      // update wallet status to 'ready'
-      await updateWalletStatus(mysql, walletId, WalletStatus.READY);
-
-      await commitTransaction(mysql);
-    } catch (txError) {
-      await rollbackTransaction(mysql);
-      throw txError;
-    }
-
-    await closeDbConnection(mysql);
-
-    return {
-      success: true,
-      walletId,
-      xpubkey,
-    };
-  } catch (e) {
-    logger.error('Erroed on loadWalletAsync: ', e);
-
-    const wallet = await getWallet(mysql, walletId);
-    const newRetryCount = wallet.retryCount ? wallet.retryCount + 1 : 1;
-
-    await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, newRetryCount);
-
-    return {
-      success: false,
-      walletId,
-      xpubkey,
-    };
-  }
-};
-
-/*
  * Canonical async wallet load: derives both the transparent and shielded address
  * paths, claims the ownership rows, and reconstructs both balances in one pass.
  * It expects a wallet entry (with shielded keys, when applicable) already on the
@@ -831,7 +741,7 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
  * so AWS async retries and user-driven re-invocations converge. reconstructWallet
  * runs OUTSIDE any DB transaction (paged crypto must not hold row locks).
  */
-export const loadWalletCombined: Handler<LoadEvent, LoadResult> = async (event) => {
+export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
   const logger = createDefaultLogger();
   if (event.source === 'serverless-plugin-warmup') {
     return { success: true, walletId: '', xpubkey: '' };
@@ -843,7 +753,7 @@ export const loadWalletCombined: Handler<LoadEvent, LoadResult> = async (event) 
   // invoking) — throw so the crash channel surfaces the bug.
   const wallet = await getWallet(mysql, walletId);
   if (!wallet) {
-    throw new Error(`loadWalletCombined: wallet ${walletId} not found`);
+    throw new Error(`loadWallet: wallet ${walletId} not found`);
   }
   const transparentWasReady = wallet.status === WalletStatus.READY;
   // consts (not the wallet fields) so the null checks narrow them below
@@ -901,7 +811,7 @@ export const loadWalletCombined: Handler<LoadEvent, LoadResult> = async (event) 
     if (hasShieldedKeys) {
       const highestDerivedIndex = shielded.rows[shielded.rows.length - 1].index;
       await markShieldedCatchupDone(mysql, walletId, highestDerivedIndex);
-      await markWalletCombinedReady(mysql, walletId, !transparentWasReady);
+      await markWalletLoadReady(mysql, walletId, !transparentWasReady);
     } else {
       // Defensive transparent-only path: no shielded lifecycle is fabricated.
       await updateWalletStatus(mysql, walletId, WalletStatus.READY);
@@ -910,16 +820,16 @@ export const loadWalletCombined: Handler<LoadEvent, LoadResult> = async (event) 
     await closeDbConnection(mysql);
     return { success: true, walletId, xpubkey };
   } catch (e) {
-    logger.error('Erroed on loadWalletCombined: ', e);
+    logger.error('Erroed on loadWallet: ', e);
     await addAlert(
-      'Combined wallet load failed',
-      `The combined transparent+shielded load for wallet ${walletId} failed and was marked for retry.`,
+      'Wallet load failed',
+      `The transparent+shielded load for wallet ${walletId} failed and was marked for retry.`,
       Severity.MINOR,
       { wallet_id: walletId, error: String(e), source: 'wallet-service' },
       logger,
     );
     if (hasShieldedKeys) {
-      await markWalletCombinedError(mysql, walletId, !transparentWasReady);
+      await markWalletLoadError(mysql, walletId, !transparentWasReady);
     } else {
       await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, (wallet.retryCount ?? 0) + 1);
     }

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -20,6 +20,7 @@ import {
   updateWalletAuthXpub,
   registerWalletShieldedKeys,
   casWalletErrorToCreating,
+  lockAddressBalancesForUpdate,
   pinLegacyLoadFailed,
   pinShieldedLoadFailed,
   upsertNewAddresses,
@@ -840,16 +841,30 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
       await rebuildShieldedAddressBalances(mysql, ctSpendAddresses);
       await rebuildShieldedAddressTxHistory(mysql, ctSpendAddresses);
     }
-    await rebuildWalletBalance(mysql, walletId, [...legacy.addresses, ...ctSpendAddresses]);
-    await rebuildWalletTxHistory(mysql, walletId, [...legacy.addresses, ...ctSpendAddresses]);
+    // 4. Settle: recompute the wallet totals and flip it ready as one atomic
+    //    step, holding locks on the address rows the totals are summed from.
+    //    The daemon skips a mid-load wallet's `wallet_balance` but still writes
+    //    `address_balance`, so a write landing between the sum and the ready flip
+    //    would be missed by both — the locks make it wait until we're ready.
+    const ownedAddresses = [...legacy.addresses, ...ctSpendAddresses];
+    await beginTransaction(mysql);
+    try {
+      await lockAddressBalancesForUpdate(mysql, ownedAddresses);
+      await rebuildWalletBalance(mysql, walletId, ownedAddresses);
+      await rebuildWalletTxHistory(mysql, walletId, ownedAddresses);
 
-    if (hasShieldedKeys) {
-      const highestDerivedIndex = shielded.rows[shielded.rows.length - 1].index;
-      await markShieldedCatchupDone(mysql, walletId, highestDerivedIndex);
-      await markWalletLoadReady(mysql, walletId, !legacyWasReady);
-    } else {
-      // Defensive legacy-only path: no shielded lifecycle is fabricated.
-      await updateWalletStatus(mysql, walletId, WalletStatus.READY);
+      if (hasShieldedKeys) {
+        const highestDerivedIndex = shielded.rows[shielded.rows.length - 1].index;
+        await markShieldedCatchupDone(mysql, walletId, highestDerivedIndex);
+        await markWalletLoadReady(mysql, walletId, !legacyWasReady);
+      } else {
+        // Defensive legacy-only path: no shielded lifecycle is fabricated.
+        await updateWalletStatus(mysql, walletId, WalletStatus.READY);
+      }
+      await commitTransaction(mysql);
+    } catch (settleError) {
+      await rollbackTransaction(mysql);
+      throw settleError;
     }
 
     return { success: true, walletId, xpubkey };

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -574,6 +574,12 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
         attachedKeys = await registerWalletShieldedKeys(
           mysql, walletId, value.scanXpriv, value.spendXpub, config.shieldedMaxAddressGap,
         );
+        if (attachedKeys) {
+          // The attach reset retry_count in the db; mirror it in the snapshot so
+          // the max-retries check below lets this upgrade load even if the legacy
+          // side had previously bricked at the cap.
+          wallet.retryCount = 0;
+        }
         if (!attachedKeys) {
           // A concurrent request attached keys between our read and this write.
           // Re-read and hold a differing set to the same conflict rule a
@@ -631,12 +637,19 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
     wallet = await getWallet(mysql, walletId);
   } else {
     // Legacy-only load: the load worker derives the legacy path and
-    // reconstructs its balance (shielded steps are no-ops without keys).
-    try {
-      await invokeLoadWalletAsync(xpubkeyStr, maxGap);
-    } catch (e) {
-      await onAsyncInvokeError(e);
+    // reconstructs its balance (shielded steps are no-ops without keys). A retry
+    // of an errored wallet must CAS error->creating first, so concurrent retries
+    // don't each spawn a duplicate load (same guard the shielded path uses).
+    const shouldInvoke = wallet.status !== WalletStatus.ERROR
+      || await casWalletErrorToCreating(mysql, walletId);
+    if (shouldInvoke) {
+      try {
+        await invokeLoadWalletAsync(xpubkeyStr, maxGap);
+      } catch (e) {
+        await onAsyncInvokeError(e);
+      }
     }
+    wallet = await getWallet(mysql, walletId);
   }
 
   await closeDbConnection(mysql);

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -23,7 +23,23 @@ import {
   updateWalletAuthXpub,
   registerWalletShieldedKeys,
   casWalletErrorToCreating,
+  upsertNewAddresses,
+  advanceLastUsedShieldedIndex,
+  markWalletCombinedReady,
+  markWalletCombinedError,
 } from '@src/db';
+import {
+  GenerateShieldedAddresses,
+  generateShieldedAddresses,
+  upsertShieldedAddressOwnership,
+  getWalletCtSpendAddresses,
+  markShieldedCatchupDone,
+  rebuildShieldedAddressBalances,
+  rebuildShieldedAddressTxHistory,
+  rebuildWalletBalance,
+  rebuildWalletTxHistory,
+} from '@src/db/shielded';
+import { findAndRewindShielded } from '@src/shieldedRecovery';
 import {
   beginTransaction,
   commitTransaction,
@@ -779,21 +795,108 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
 
 /*
  * Canonical async wallet load: derives both the transparent and shielded address
- * paths and reconstructs both balances (via reconstructWallet) in one pass. It
- * expects a wallet entry (with shielded keys) already on the database.
+ * paths, claims the ownership rows, and reconstructs both balances in one pass.
+ * It expects a wallet entry (with shielded keys, when applicable) already on the
+ * database — the load API persists keys before invoking this.
  *
- * Invoked async by the load-wallet API whenever the request carries shielded keys.
- *
- * NOTE: the body is implemented in a follow-up PR; for now this is a registered
- * stub so the API has a stable invoke target. It leaves the wallet in 'creating'.
+ * Idempotent end to end: derivations are recomputed, claims are upserts, rewinds
+ * are guarded by tx_output.recovery_state, and the rebuilds recompute absolutes —
+ * so AWS async retries and user-driven re-invocations converge. reconstructWallet
+ * runs OUTSIDE any DB transaction (paged crypto must not hold row locks).
  */
 export const loadWalletCombined: Handler<LoadEvent, LoadResult> = async (event) => {
   const logger = createDefaultLogger();
   if (event.source === 'serverless-plugin-warmup') {
     return { success: true, walletId: '', xpubkey: '' };
   }
-  logger.info('loadWalletCombined invoked (stub — combined transparent+shielded load lands in a follow-up)', {
-    xpubkey: event.xpubkey,
-  });
-  return { success: true, walletId: getWalletId(event.xpubkey), xpubkey: event.xpubkey };
+
+  const { xpubkey, maxGap } = event;
+  const walletId = getWalletId(xpubkey);
+  // A missing wallet row is an invariant violation (the API creates it before
+  // invoking) — throw so the crash channel surfaces the bug.
+  const wallet = await getWallet(mysql, walletId);
+  if (!wallet) {
+    throw new Error(`loadWalletCombined: wallet ${walletId} not found`);
+  }
+  const transparentWasReady = wallet.status === WalletStatus.READY;
+  // consts (not the wallet fields) so the null checks narrow them below
+  const scanXpriv = wallet.scanXpriv ?? null;
+  const spendXpub = wallet.spendXpub ?? null;
+  const hasShieldedKeys = scanXpriv !== null && spendXpub !== null;
+
+  try {
+    // 1. Read-only derivation of both windows. Already-claimed shielded rows
+    //    are reused from storage, so a retry re-derives nothing.
+    const transparent = await generateAddresses(mysql, xpubkey, maxGap);
+    const shielded: GenerateShieldedAddresses = scanXpriv !== null && spendXpub !== null
+      ? await generateShieldedAddresses(
+        mysql,
+        walletId,
+        scanXpriv,
+        spendXpub,
+        wallet.shieldedMaxGap ?? config.shieldedMaxAddressGap,
+        shieldedNetwork,
+      )
+      : { rows: [], addresses: [], lastUsedShieldedIndex: null, newRows: [] };
+
+    // 2. One short claim transaction: address ownership + frontier indices.
+    await beginTransaction(mysql);
+    try {
+      await upsertNewAddresses(mysql, walletId, transparent.newAddresses, transparent.lastUsedAddressIndex);
+      await updateExistingAddresses(mysql, walletId, transparent.existingAddresses);
+      await upsertShieldedAddressOwnership(mysql, walletId, shielded.newRows);
+      if (shielded.lastUsedShieldedIndex != null) {
+        await advanceLastUsedShieldedIndex(mysql, walletId, shielded.lastUsedShieldedIndex);
+      }
+      await commitTransaction(mysql);
+    } catch (txError) {
+      await rollbackTransaction(mysql);
+      throw txError;
+    }
+
+    // 3. Reconstruction — outside any transaction. The CTSpend set is read back
+    //    from the database so previously-claimed rows stay covered on re-loads.
+    //    The rewind drains run BEFORE the rebuilds (which recompute absolutes
+    //    from tx_output), so everything revealed lands in a single rebuild.
+    const ctSpendAddresses = hasShieldedKeys ? await getWalletCtSpendAddresses(mysql, walletId) : [];
+    if (hasShieldedKeys) {
+      await findAndRewindShielded(mysql, walletId, logger);
+      // Settle drain: a daemon ingest whose ownership check snapshotted the
+      // world before our claim committed lands its output unowned moments
+      // later — one more (cheap when empty) sweep closes that window.
+      await findAndRewindShielded(mysql, walletId, logger);
+      await rebuildShieldedAddressBalances(mysql, ctSpendAddresses);
+      await rebuildShieldedAddressTxHistory(mysql, ctSpendAddresses);
+    }
+    await rebuildWalletBalance(mysql, walletId, [...transparent.addresses, ...ctSpendAddresses]);
+    await rebuildWalletTxHistory(mysql, walletId, [...transparent.addresses, ...ctSpendAddresses]);
+
+    if (hasShieldedKeys) {
+      const highestDerivedIndex = shielded.rows[shielded.rows.length - 1].index;
+      await markShieldedCatchupDone(mysql, walletId, highestDerivedIndex);
+      await markWalletCombinedReady(mysql, walletId, !transparentWasReady);
+    } else {
+      // Defensive transparent-only path: no shielded lifecycle is fabricated.
+      await updateWalletStatus(mysql, walletId, WalletStatus.READY);
+    }
+
+    await closeDbConnection(mysql);
+    return { success: true, walletId, xpubkey };
+  } catch (e) {
+    logger.error('Erroed on loadWalletCombined: ', e);
+    await addAlert(
+      'Combined wallet load failed',
+      `The combined transparent+shielded load for wallet ${walletId} failed and was marked for retry.`,
+      Severity.MINOR,
+      { wallet_id: walletId, error: String(e), source: 'wallet-service' },
+      logger,
+    );
+    if (hasShieldedKeys) {
+      await markWalletCombinedError(mysql, walletId, !transparentWasReady);
+    } else {
+      await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, (wallet.retryCount ?? 0) + 1);
+    }
+    await closeDbConnection(mysql);
+    return { success: false, walletId, xpubkey };
+  }
 };

--- a/packages/wallet-service/src/api/wallet.ts
+++ b/packages/wallet-service/src/api/wallet.ts
@@ -20,7 +20,7 @@ import {
   updateWalletAuthXpub,
   registerWalletShieldedKeys,
   casWalletErrorToCreating,
-  pinTransparentLoadFailed,
+  pinLegacyLoadFailed,
   pinShieldedLoadFailed,
   upsertNewAddresses,
   advanceLastUsedShieldedIndex,
@@ -81,7 +81,7 @@ const shieldedNetwork = new Network(config.network);
 
 /**
  * Shape a wallet row into the API status payload: the `status` field is the
- * unified transparent+shielded lifecycle value, and the two shielded fields are
+ * unified legacy+shielded lifecycle value, and the two shielded fields are
  * surfaced for clients that use them. Scan/spend keys are deliberately omitted —
  * `scan_xpriv` is a secret and must never leave the service.
  */
@@ -146,7 +146,7 @@ const loadBodySchema = Joi.object({
 }).and('scanXpriv', 'spendXpub', 'firstCtAddress', 'spendXpubSignature', 'ctAddressSignature');
 
 /**
- * Invoke the async wallet-load lambda — derives both the transparent and
+ * Invoke the async wallet-load lambda — derives both the legacy and
  * shielded address paths and reconstructs both balances in a single pass.
  *
  * @param xpubkey - The xpubkey to load
@@ -438,11 +438,11 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
 
   // A request carrying shielded fields (all-or-none, guaranteed by the schema)
   // may be a shielded upgrade of an already-loaded wallet, so the "already
-  // loaded" early-return below applies only to transparent-only requests.
+  // loaded" early-return below applies only to legacy-only requests.
   const hasShielded = value.scanXpriv != null;
 
   // Alert ops + reject when a wallet has failed to load too many times. The cap is
-  // shared by the transparent, shielded and upgrade paths.
+  // shared by the legacy, shielded and upgrade paths.
   const rejectMaxRetries = async () => {
     await addAlert(
       'Wallet load exceeded max retries',
@@ -494,7 +494,7 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
   }
 
   // Validate the shielded proof before mutating anything, so an invalid shielded
-  // upgrade cannot leave the transparent side half-processed.
+  // upgrade cannot leave the legacy side half-processed.
   if (hasShielded) {
     const reg = validateShieldedRegistration({
       timestamp,
@@ -547,13 +547,13 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
   };
 
   if (hasShielded) {
-    // Whether this request is the one attaching keys to a transparent wallet, and
+    // Whether this request is the one attaching keys to a legacy wallet, and
     // whether it won that race — only the winner may drive the load.
     let upgrading = false;
     let attachedKeys = false;
 
     // Reconcile keys for an existing wallet: reject a conflicting set; attach keys
-    // to a transparent wallet being upgraded. A fresh wallet already has its keys.
+    // to a legacy wallet being upgraded. A fresh wallet already has its keys.
     if (walletExisted) {
       if (wallet.scanXpriv == null) {
         upgrading = true;
@@ -581,7 +581,7 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
       return rejectMaxRetries();
     }
 
-    // (Re)invoke the canonical async load — which derives both the transparent
+    // (Re)invoke the canonical async load — which derives both the legacy
     // and shielded address paths and reconstructs both balances in one pass —
     // unless this is an identical resubmit on a wallet that is already loaded or in
     // progress. Fresh registrations and upgrades always load; a same-keys resubmit
@@ -616,7 +616,7 @@ export const load: APIGatewayProxyHandler = middy(async (event) => {
     }
     wallet = await getWallet(mysql, walletId);
   } else {
-    // Transparent-only load: the load worker derives the transparent path and
+    // Legacy-only load: the load worker derives the legacy path and
     // reconstructs its balance (shielded steps are no-ops without keys).
     try {
       await invokeLoadWalletAsync(xpubkeyStr, maxGap);
@@ -686,16 +686,16 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
 
       // Pin the wallet at the retry cap so it is not retried. A wallet with
       // shielded keys pins its shielded lifecycle too, and an upgrade — whose
-      // transparent side was already ready before the crashed load — keeps its
-      // working transparent state untouched.
+      // legacy side was already ready before the crashed load — keeps its
+      // working legacy state untouched.
       const failedWallet = await getWallet(mysql, walletId);
       if (failedWallet && failedWallet.scanXpriv != null) {
         if (failedWallet.status !== WalletStatus.READY) {
-          await pinTransparentLoadFailed(mysql, walletId, MAX_LOAD_WALLET_RETRIES);
+          await pinLegacyLoadFailed(mysql, walletId, MAX_LOAD_WALLET_RETRIES);
         }
         await pinShieldedLoadFailed(mysql, walletId, MAX_LOAD_WALLET_RETRIES);
       } else {
-        await pinTransparentLoadFailed(mysql, walletId, MAX_LOAD_WALLET_RETRIES);
+        await pinLegacyLoadFailed(mysql, walletId, MAX_LOAD_WALLET_RETRIES);
       }
 
       logger.error(`${walletId} failed to load.`);
@@ -731,7 +731,7 @@ export const loadWalletFailed: Handler<SNSEvent> = async (event) => {
 };
 
 /*
- * Canonical async wallet load: derives both the transparent and shielded address
+ * Canonical async wallet load: derives both the legacy and shielded address
  * paths, claims the ownership rows, and reconstructs both balances in one pass.
  * It expects a wallet entry (with shielded keys, when applicable) already on the
  * database — the load API persists keys before invoking this.
@@ -755,7 +755,7 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
   if (!wallet) {
     throw new Error(`loadWallet: wallet ${walletId} not found`);
   }
-  const transparentWasReady = wallet.status === WalletStatus.READY;
+  const legacyWasReady = wallet.status === WalletStatus.READY;
   // consts (not the wallet fields) so the null checks narrow them below
   const scanXpriv = wallet.scanXpriv ?? null;
   const spendXpub = wallet.spendXpub ?? null;
@@ -764,7 +764,7 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
   try {
     // 1. Read-only derivation of both windows. Already-claimed shielded rows
     //    are reused from storage, so a retry re-derives nothing.
-    const transparent = await generateAddresses(mysql, xpubkey, maxGap);
+    const legacy = await generateAddresses(mysql, xpubkey, maxGap);
     const shielded: GenerateShieldedAddresses = scanXpriv !== null && spendXpub !== null
       ? await generateShieldedAddresses(
         mysql,
@@ -779,8 +779,8 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
     // 2. One short claim transaction: address ownership + frontier indices.
     await beginTransaction(mysql);
     try {
-      await upsertNewAddresses(mysql, walletId, transparent.newAddresses, transparent.lastUsedAddressIndex);
-      await updateExistingAddresses(mysql, walletId, transparent.existingAddresses);
+      await upsertNewAddresses(mysql, walletId, legacy.newAddresses, legacy.lastUsedAddressIndex);
+      await updateExistingAddresses(mysql, walletId, legacy.existingAddresses);
       await upsertShieldedAddressOwnership(mysql, walletId, shielded.newRows);
       if (shielded.lastUsedShieldedIndex != null) {
         await advanceLastUsedShieldedIndex(mysql, walletId, shielded.lastUsedShieldedIndex);
@@ -805,15 +805,15 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
       await rebuildShieldedAddressBalances(mysql, ctSpendAddresses);
       await rebuildShieldedAddressTxHistory(mysql, ctSpendAddresses);
     }
-    await rebuildWalletBalance(mysql, walletId, [...transparent.addresses, ...ctSpendAddresses]);
-    await rebuildWalletTxHistory(mysql, walletId, [...transparent.addresses, ...ctSpendAddresses]);
+    await rebuildWalletBalance(mysql, walletId, [...legacy.addresses, ...ctSpendAddresses]);
+    await rebuildWalletTxHistory(mysql, walletId, [...legacy.addresses, ...ctSpendAddresses]);
 
     if (hasShieldedKeys) {
       const highestDerivedIndex = shielded.rows[shielded.rows.length - 1].index;
       await markShieldedCatchupDone(mysql, walletId, highestDerivedIndex);
-      await markWalletLoadReady(mysql, walletId, !transparentWasReady);
+      await markWalletLoadReady(mysql, walletId, !legacyWasReady);
     } else {
-      // Defensive transparent-only path: no shielded lifecycle is fabricated.
+      // Defensive legacy-only path: no shielded lifecycle is fabricated.
       await updateWalletStatus(mysql, walletId, WalletStatus.READY);
     }
 
@@ -823,13 +823,13 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
     logger.error('Erroed on loadWallet: ', e);
     await addAlert(
       'Wallet load failed',
-      `The transparent+shielded load for wallet ${walletId} failed and was marked for retry.`,
+      `The legacy+shielded load for wallet ${walletId} failed and was marked for retry.`,
       Severity.MINOR,
       { wallet_id: walletId, error: String(e), source: 'wallet-service' },
       logger,
     );
     if (hasShieldedKeys) {
-      await markWalletLoadError(mysql, walletId, !transparentWasReady);
+      await markWalletLoadError(mysql, walletId, !legacyWasReady);
     } else {
       await updateWalletStatus(mysql, walletId, WalletStatus.ERROR, (wallet.retryCount ?? 0) + 1);
     }

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -564,6 +564,29 @@ export const pinShieldedLoadFailed = async (
 };
 
 /**
+ * Take row locks on a wallet's `address_balance` rows for the rest of the
+ * caller's transaction.
+ *
+ * The load finishes by recomputing `wallet_balance` absolutely from these rows
+ * and then flipping the wallet ready. Without the locks the daemon can commit an
+ * `address_balance` write in between: that transaction is skipped for
+ * `wallet_balance` (the wallet is not attributable while loading) *and* missed
+ * by the rebuild's snapshot, so it is lost for good — the daemon only ever
+ * increments from the now-wrong total. Holding the locks makes such a write wait
+ * until the wallet is ready, after which it applies to both tables normally.
+ */
+export const lockAddressBalancesForUpdate = async (
+  mysql: ServerlessMysql,
+  addresses: string[],
+): Promise<void> => {
+  if (addresses.length === 0) return;
+  await mysql.query(
+    'SELECT 1 FROM `address_balance` WHERE `address` IN (?) FOR UPDATE',
+    [addresses],
+  );
+};
+
+/**
  * Compare-and-set (`cas`) an errored wallet back to `creating` before the caller
  * re-invokes the async load: the read of the current state and the write are one
  * atomic statement, so concurrent retries of the same wallet cannot both win.

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -382,22 +382,31 @@ export const updateWalletAuthXpub = async (
  * @param spendXpub - The change-level spend xpub (base58)
  * @param shieldedMaxGap - The shielded gap limit
  */
+/**
+ * Attach shielded keys to a wallet that has none, flipping `ct_status` to
+ * 'creating'. Returns whether this call actually attached them.
+ *
+ * The `scan_xpriv IS NULL` guard makes this a compare-and-set: concurrent
+ * upgrades of the same wallet race here, and only the winner gets `true`, so
+ * only the winner drives a load.
+ */
 export const registerWalletShieldedKeys = async (
   mysql: ServerlessMysql,
   walletId: string,
   scanXpriv: string,
   spendXpub: string,
   shieldedMaxGap: number,
-): Promise<void> => {
-  await mysql.query(
+): Promise<boolean> => {
+  const result: OkPacket = await mysql.query(
     `UPDATE \`wallet\`
         SET \`scan_xpriv\` = ?,
             \`spend_xpub\` = ?,
             \`shielded_max_gap\` = ?,
             \`ct_status\` = 'creating'
-      WHERE \`id\` = ?`,
+      WHERE \`id\` = ? AND \`scan_xpriv\` IS NULL`,
     [Buffer.from(scanXpriv, 'utf8'), spendXpub, shieldedMaxGap, walletId],
   );
+  return result.affectedRows > 0;
 };
 
 /**
@@ -494,6 +503,43 @@ export const markWalletCombinedError = async (
  * the async load. Returns false when there was nothing to flip — the caller
  * lost the race to another request and must not spawn a duplicate load.
  */
+/**
+ * Pin a crashed wallet's transparent side at the retry cap so it is not retried.
+ *
+ * Guarded on the wallet still being mid-load: a crash DLQ event can be delivered
+ * after a later attempt already recovered the wallet, and demoting a recovered
+ * wallet would strand it behind the max-retries rejection with no client-side fix.
+ */
+export const pinTransparentLoadFailed = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  retryCount: number,
+): Promise<void> => {
+  await mysql.query(
+    `UPDATE \`wallet\`
+        SET \`status\` = ?,
+            \`ready_at\` = ?,
+            \`retry_count\` = ?
+      WHERE \`id\` = ? AND \`status\` IN (?, ?)`,
+    [WalletStatus.ERROR, getUnixTimestamp(), retryCount, walletId, WalletStatus.CREATING, WalletStatus.ERROR],
+  );
+};
+
+/** Shielded counterpart of `pinTransparentLoadFailed`, under the same recovery guard. */
+export const pinShieldedLoadFailed = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  retryCount: number,
+): Promise<void> => {
+  await mysql.query(
+    `UPDATE \`wallet\`
+        SET \`ct_status\` = ?,
+            \`retry_count\` = ?
+      WHERE \`id\` = ? AND \`ct_status\` IN (?, ?)`,
+    [WalletStatus.ERROR, retryCount, walletId, WalletStatus.CREATING, WalletStatus.ERROR],
+  );
+};
+
 export const casWalletErrorToCreating = async (
   mysql: ServerlessMysql,
   walletId: string,

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -401,6 +401,114 @@ export const registerWalletShieldedKeys = async (
 };
 
 /**
+ * Upsert-variant of addNewAddresses for the combined load: an upgrade runs on a
+ * live wallet whose gap the daemon may extend concurrently, so pre-existing rows
+ * must not dup-key crash, and the frontier index only ever moves forward.
+ */
+export const upsertNewAddresses = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  addresses: AddressIndexMap,
+  lastUsedAddressIndex: number,
+): Promise<void> => {
+  if (Object.keys(addresses).length > 0) {
+    const entries = Object.entries(addresses).map(([address, index]) => [address, index, walletId, 0]);
+    await mysql.query(
+      `INSERT INTO \`address\`(\`address\`, \`index\`, \`wallet_id\`, \`transactions\`)
+       VALUES ?
+       ON DUPLICATE KEY UPDATE \`wallet_id\` = VALUES(\`wallet_id\`), \`index\` = VALUES(\`index\`)`,
+      [entries],
+    );
+  }
+  await mysql.query(
+    'UPDATE `wallet` SET `last_used_address_index` = GREATEST(`last_used_address_index`, ?) WHERE `id` = ?',
+    [lastUsedAddressIndex, walletId],
+  );
+};
+
+/**
+ * Advance the shielded usage frontier — never regresses (the daemon's live path
+ * may move it concurrently) and preserves the NULL = "never used" semantics: only
+ * call this when a used index actually exists.
+ */
+export const advanceLastUsedShieldedIndex = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  index: number,
+): Promise<void> => {
+  await mysql.query(
+    'UPDATE `wallet` SET `last_used_shielded_index` = GREATEST(COALESCE(`last_used_shielded_index`, -1), ?) WHERE `id` = ?',
+    [index, walletId],
+  );
+};
+
+/**
+ * Finalize a successful combined load in one statement: shielded side ready,
+ * retry counter cleared, and — unless the transparent side was already ready
+ * before the load (upgrade) — transparent status/ready_at too.
+ */
+export const markWalletCombinedReady = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  alsoTransparent: boolean,
+): Promise<void> => {
+  if (alsoTransparent) {
+    await mysql.query(
+      'UPDATE `wallet` SET `status` = ?, `ready_at` = ?, `retry_count` = 0, `ct_status` = ? WHERE `id` = ?',
+      [WalletStatus.READY, getUnixTimestamp(), WalletStatus.READY, walletId],
+    );
+  } else {
+    await mysql.query(
+      'UPDATE `wallet` SET `ct_status` = ?, `retry_count` = 0 WHERE `id` = ?',
+      [WalletStatus.READY, walletId],
+    );
+  }
+};
+
+/**
+ * Record a combined-load failure in one statement with an atomic retry bump
+ * (concurrent executions must not lose increments). The transparent status is
+ * only marked when it was not already ready before the load — an upgrade
+ * failure must leave a working transparent wallet untouched.
+ */
+export const markWalletCombinedError = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  alsoTransparent: boolean,
+): Promise<void> => {
+  if (alsoTransparent) {
+    await mysql.query(
+      'UPDATE `wallet` SET `status` = ?, `ct_status` = ?, `retry_count` = `retry_count` + 1 WHERE `id` = ?',
+      [WalletStatus.ERROR, WalletStatus.ERROR, walletId],
+    );
+  } else {
+    await mysql.query(
+      'UPDATE `wallet` SET `ct_status` = ?, `retry_count` = `retry_count` + 1 WHERE `id` = ?',
+      [WalletStatus.ERROR, walletId],
+    );
+  }
+};
+
+/**
+ * Atomically transition an errored wallet back to creating before re-invoking
+ * the async load. Returns false when there was nothing to flip — the caller
+ * lost the race to another request and must not spawn a duplicate load.
+ */
+export const casWalletErrorToCreating = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+): Promise<boolean> => {
+  const result: OkPacket = await mysql.query(
+    `UPDATE \`wallet\`
+        SET \`status\` = IF(\`status\` = 'error', 'creating', \`status\`),
+            \`ct_status\` = IF(\`ct_status\` = 'error', 'creating', \`ct_status\`)
+      WHERE \`id\` = ? AND (\`status\` = 'error' OR \`ct_status\` = 'error')`,
+    [walletId],
+  );
+  return result.affectedRows > 0;
+};
+
+/**
  * Add addresses to address table.
  *
  * @remarks

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -372,23 +372,21 @@ export const updateWalletAuthXpub = async (
 };
 
 /**
- * Persist a wallet's shielded registration keys and move its shielded lifecycle
- * into `creating`. `scan_xpriv` is a BLOB: the base58 xpriv is stored as its
- * UTF-8 bytes so it round-trips back to the string address derivation consumes.
+ * Attach shielded keys to a wallet that has none, moving its shielded lifecycle
+ * into `creating`. Returns whether this call actually attached them.
+ *
+ * The `scan_xpriv IS NULL` guard makes this a compare-and-set: concurrent
+ * upgrades of the same wallet race here, and only the winner gets `true`, so
+ * only the winner drives a load.
+ *
+ * `scan_xpriv` is a BLOB: the base58 xpriv is stored as its UTF-8 bytes so it
+ * round-trips back to the string address derivation consumes.
  *
  * @param mysql - Database connection
  * @param walletId - The wallet id
  * @param scanXpriv - The change-level scan xpriv (base58)
  * @param spendXpub - The change-level spend xpub (base58)
  * @param shieldedMaxGap - The shielded gap limit
- */
-/**
- * Attach shielded keys to a wallet that has none, flipping `ct_status` to
- * 'creating'. Returns whether this call actually attached them.
- *
- * The `scan_xpriv IS NULL` guard makes this a compare-and-set: concurrent
- * upgrades of the same wallet race here, and only the winner gets `true`, so
- * only the winner drives a load.
  */
 export const registerWalletShieldedKeys = async (
   mysql: ServerlessMysql,
@@ -488,22 +486,42 @@ export const markWalletLoadError = async (
 ): Promise<void> => {
   if (alsoLegacy) {
     await mysql.query(
-      'UPDATE `wallet` SET `status` = ?, `ct_status` = ?, `retry_count` = `retry_count` + 1 WHERE `id` = ?',
-      [WalletStatus.ERROR, WalletStatus.ERROR, walletId],
+      `UPDATE \`wallet\`
+          SET \`status\` = ?, \`ct_status\` = ?, \`retry_count\` = \`retry_count\` + 1
+        WHERE \`id\` = ? AND \`status\` IN (?, ?) AND \`ct_status\` IN (?, ?)`,
+      [
+        WalletStatus.ERROR, WalletStatus.ERROR, walletId,
+        WalletStatus.CREATING, WalletStatus.ERROR,
+        WalletStatus.CREATING, WalletStatus.ERROR,
+      ],
     );
   } else {
     await mysql.query(
-      'UPDATE `wallet` SET `ct_status` = ?, `retry_count` = `retry_count` + 1 WHERE `id` = ?',
-      [WalletStatus.ERROR, walletId],
+      `UPDATE \`wallet\`
+          SET \`ct_status\` = ?, \`retry_count\` = \`retry_count\` + 1
+        WHERE \`id\` = ? AND \`ct_status\` IN (?, ?)`,
+      [WalletStatus.ERROR, walletId, WalletStatus.CREATING, WalletStatus.ERROR],
     );
   }
 };
 
 /**
- * Atomically transition an errored wallet back to creating before re-invoking
- * the async load. Returns false when there was nothing to flip — the caller
- * lost the race to another request and must not spawn a duplicate load.
+ * Record a legacy-only load failure with an atomic retry bump, under the same
+ * still-mid-load guard: a stale attempt must not demote a wallet another attempt
+ * already recovered, and must not bump its retry counter.
  */
+export const markLegacyLoadError = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+): Promise<void> => {
+  await mysql.query(
+    `UPDATE \`wallet\`
+        SET \`status\` = ?, \`ready_at\` = ?, \`retry_count\` = \`retry_count\` + 1
+      WHERE \`id\` = ? AND \`status\` IN (?, ?)`,
+    [WalletStatus.ERROR, getUnixTimestamp(), walletId, WalletStatus.CREATING, WalletStatus.ERROR],
+  );
+};
+
 /**
  * Pin a crashed wallet's legacy side at the retry cap so it is not retried.
  *
@@ -541,6 +559,15 @@ export const pinShieldedLoadFailed = async (
   );
 };
 
+/**
+ * Compare-and-set (`cas`) an errored wallet back to `creating` before the caller
+ * re-invokes the async load: the read of the current state and the write are one
+ * atomic statement, so concurrent retries of the same wallet cannot both win.
+ *
+ * Returns true only for the request that actually flipped a side out of `error`.
+ * A false return means another request already claimed the retry, and this one
+ * must not spawn a duplicate load.
+ */
 export const casWalletErrorToCreating = async (
   mysql: ServerlessMysql,
   walletId: string,

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -410,9 +410,10 @@ export const registerWalletShieldedKeys = async (
 };
 
 /**
- * Upsert-variant of addNewAddresses for the combined load: an upgrade runs on a
- * live wallet whose gap the daemon may extend concurrently, so pre-existing rows
- * must not dup-key crash, and the frontier index only ever moves forward.
+ * Insert a wallet's freshly derived addresses for the async load: an upgrade
+ * runs on a live wallet whose gap the daemon may extend concurrently, so
+ * pre-existing rows must not dup-key crash (upsert), and the frontier index only
+ * ever moves forward.
  */
 export const upsertNewAddresses = async (
   mysql: ServerlessMysql,
@@ -452,11 +453,11 @@ export const advanceLastUsedShieldedIndex = async (
 };
 
 /**
- * Finalize a successful combined load in one statement: shielded side ready,
+ * Finalize a successful wallet load in one statement: shielded side ready,
  * retry counter cleared, and — unless the transparent side was already ready
  * before the load (upgrade) — transparent status/ready_at too.
  */
-export const markWalletCombinedReady = async (
+export const markWalletLoadReady = async (
   mysql: ServerlessMysql,
   walletId: string,
   alsoTransparent: boolean,
@@ -475,12 +476,12 @@ export const markWalletCombinedReady = async (
 };
 
 /**
- * Record a combined-load failure in one statement with an atomic retry bump
+ * Record a load failure in one statement with an atomic retry bump
  * (concurrent executions must not lose increments). The transparent status is
  * only marked when it was not already ready before the load — an upgrade
  * failure must leave a working transparent wallet untouched.
  */
-export const markWalletCombinedError = async (
+export const markWalletLoadError = async (
   mysql: ServerlessMysql,
   walletId: string,
   alsoTransparent: boolean,
@@ -555,43 +556,6 @@ export const casWalletErrorToCreating = async (
 };
 
 /**
- * Add addresses to address table.
- *
- * @remarks
- * The addresses are added with the given walletId and 0 transactions.
- *
- * @param mysql - Database connection
- * @param walletId - The wallet id
- * @param addresses - A map of addresses and corresponding indexes
- */
-export const addNewAddresses = async (
-  mysql: ServerlessMysql,
-  walletId: string,
-  addresses: AddressIndexMap,
-  lastUsedAddressIndex: number,
-): Promise<void> => {
-  if (Object.keys(addresses).length === 0) return;
-  const entries = [];
-  for (const [address, index] of Object.entries(addresses)) {
-    entries.push([address, index, walletId, 0]);
-  }
-  await mysql.query(
-    `INSERT INTO \`address\`(\`address\`, \`index\`,
-                             \`wallet_id\`, \`transactions\`)
-     VALUES ?`,
-    [entries],
-  );
-
-  // Store on the wallet table the highest used index
-  await mysql.query(
-    `UPDATE \`wallet\`
-        SET \`last_used_address_index\` = ?
-      WHERE \`id\` = ?`,
-    [lastUsedAddressIndex, walletId],
-  );
-};
-
-/**
  * Update addresses on the address table.
  *
  * @remarks
@@ -661,125 +625,6 @@ export const incrementAddressSeqnum = async (mysql: ServerlessMysql, walletId: s
      WHERE \`wallet_id\` = ?
          AND \`address\` = ?`,
     [walletId, address]);
-};
-
-/**
- * Initialize a wallet's transaction history.
- *
- * @remarks
- * This function adds entries to wallet_tx_history table, using data from address_tx_history.
- *
- * @param mysql - Database connection
- * @param walletId - The wallet id
- * @param addresses - The addresses that belong to this wallet
- */
-export const initWalletTxHistory = async (mysql: ServerlessMysql, walletId: string, addresses: string[]): Promise<void> => {
-  // XXX we could also get the addresses from the address table, but the caller probably has this info already
-
-  if (addresses.length === 0) return;
-
-  const results: DbSelectResult = await mysql.query(
-    `SELECT \`tx_id\`,
-            \`token_id\`,
-            SUM(\`balance\`) AS balance,
-            \`timestamp\`
-       FROM \`address_tx_history\`
-      WHERE \`address\` IN (?)
-        AND \`voided\` = FALSE
-   GROUP BY \`tx_id\`,
-            \`token_id\`,
-            \`timestamp\``,
-    [addresses],
-  );
-  if (results.length === 0) return;
-
-  const walletTxHistory = [];
-  for (const row of results) {
-    walletTxHistory.push([walletId, row.token_id, row.tx_id, row.balance, row.timestamp]);
-  }
-  await mysql.query(
-    `INSERT INTO \`wallet_tx_history\`(\`wallet_id\`, \`token_id\`,
-                                       \`tx_id\`, \`balance\`,
-                                       \`timestamp\`)
-          VALUES ?`,
-    [walletTxHistory],
-  );
-};
-
-/**
- * Initialize a wallet's balance.
- *
- * @remarks
- * This function adds entries to wallet_balance table, using data from address_balance and address_tx_history.
- *
- * @param mysql - Database connection
- * @param walletId - The wallet id
- * @param addresses - The addresses that belong to this wallet
- */
-export const initWalletBalance = async (mysql: ServerlessMysql, walletId: string, addresses: string[]): Promise<void> => {
-  // XXX we could also do a join between address and address_balance tables so we don't
-  // need to receive the addresses, but the caller probably has this info already
-  const results1: DbSelectResult = await mysql.query(
-    `SELECT \`token_id\`,
-            SUM(\`total_received\`) AS \`total_received\`,
-            SUM(\`unlocked_balance\`) AS \`unlocked_balance\`,
-            SUM(\`locked_balance\`) AS \`locked_balance\`,
-            MIN(\`timelock_expires\`) AS \`timelock_expires\`,
-            BIT_OR(\`unlocked_authorities\`) AS \`unlocked_authorities\`,
-            BIT_OR(\`locked_authorities\`) AS \`locked_authorities\`
-       FROM \`address_balance\`
-      WHERE \`address\`
-         IN (?)
-   GROUP BY \`token_id\`
-   ORDER BY \`token_id\``,
-    [addresses],
-  );
-  // we need to use table address_tx_history for the transaction count. We can't simply
-  // sum the transaction count for each address_balance, as they may share transactions
-  const results2: DbSelectResult = await mysql.query(
-    `SELECT \`token_id\`,
-            SUM(\`balance\`) AS \`balance\`,
-            COUNT(DISTINCT \`tx_id\`) AS \`transactions\`
-       FROM \`address_tx_history\`
-      WHERE \`address\` IN (?)
-        AND \`voided\` = FALSE
-   GROUP BY \`token_id\`
-   ORDER BY \`token_id\``,
-    [addresses],
-  );
-
-  assert.strictEqual(results1.length, results2.length);
-
-  const balanceEntries = [];
-  for (let i = 0; i < results1.length; i++) {
-    // as both queries had ORDER BY, we should get the results in the same order
-    const row1 = results1[i];
-    const row2 = results2[i];
-    assert.strictEqual(row1.token_id, row2.token_id);
-    assert.strictEqual(BigInt(row1.unlocked_balance as string) + BigInt(row1.locked_balance as string), BigInt(row2.balance as string));
-    balanceEntries.push([
-      walletId,
-      row1.token_id,
-      row1.total_received,
-      row1.unlocked_balance,
-      row1.locked_balance,
-      row1.timelock_expires,
-      row1.locked_authorities,
-      row1.unlocked_authorities,
-      row2.transactions,
-    ]);
-  }
-  if (balanceEntries.length > 0) {
-    await mysql.query(
-      `INSERT INTO \`wallet_balance\`(\`wallet_id\`, \`token_id\`,
-                                      \`total_received\`,
-                                      \`unlocked_balance\`, \`locked_balance\`,
-                                      \`timelock_expires\`, \`locked_authorities\`,
-                                      \`unlocked_authorities\`, \`transactions\`)
-            VALUES ?`,
-      [balanceEntries],
-    );
-  }
 };
 
 /**

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -454,15 +454,15 @@ export const advanceLastUsedShieldedIndex = async (
 
 /**
  * Finalize a successful wallet load in one statement: shielded side ready,
- * retry counter cleared, and — unless the transparent side was already ready
- * before the load (upgrade) — transparent status/ready_at too.
+ * retry counter cleared, and — unless the legacy side was already ready
+ * before the load (upgrade) — legacy status/ready_at too.
  */
 export const markWalletLoadReady = async (
   mysql: ServerlessMysql,
   walletId: string,
-  alsoTransparent: boolean,
+  alsoLegacy: boolean,
 ): Promise<void> => {
-  if (alsoTransparent) {
+  if (alsoLegacy) {
     await mysql.query(
       'UPDATE `wallet` SET `status` = ?, `ready_at` = ?, `retry_count` = 0, `ct_status` = ? WHERE `id` = ?',
       [WalletStatus.READY, getUnixTimestamp(), WalletStatus.READY, walletId],
@@ -477,16 +477,16 @@ export const markWalletLoadReady = async (
 
 /**
  * Record a load failure in one statement with an atomic retry bump
- * (concurrent executions must not lose increments). The transparent status is
+ * (concurrent executions must not lose increments). The legacy status is
  * only marked when it was not already ready before the load — an upgrade
- * failure must leave a working transparent wallet untouched.
+ * failure must leave a working legacy wallet untouched.
  */
 export const markWalletLoadError = async (
   mysql: ServerlessMysql,
   walletId: string,
-  alsoTransparent: boolean,
+  alsoLegacy: boolean,
 ): Promise<void> => {
-  if (alsoTransparent) {
+  if (alsoLegacy) {
     await mysql.query(
       'UPDATE `wallet` SET `status` = ?, `ct_status` = ?, `retry_count` = `retry_count` + 1 WHERE `id` = ?',
       [WalletStatus.ERROR, WalletStatus.ERROR, walletId],
@@ -505,13 +505,13 @@ export const markWalletLoadError = async (
  * lost the race to another request and must not spawn a duplicate load.
  */
 /**
- * Pin a crashed wallet's transparent side at the retry cap so it is not retried.
+ * Pin a crashed wallet's legacy side at the retry cap so it is not retried.
  *
  * Guarded on the wallet still being mid-load: a crash DLQ event can be delivered
  * after a later attempt already recovered the wallet, and demoting a recovered
  * wallet would strand it behind the max-retries rejection with no client-side fix.
  */
-export const pinTransparentLoadFailed = async (
+export const pinLegacyLoadFailed = async (
   mysql: ServerlessMysql,
   walletId: string,
   retryCount: number,
@@ -526,7 +526,7 @@ export const pinTransparentLoadFailed = async (
   );
 };
 
-/** Shielded counterpart of `pinTransparentLoadFailed`, under the same recovery guard. */
+/** Shielded counterpart of `pinLegacyLoadFailed`, under the same recovery guard. */
 export const pinShieldedLoadFailed = async (
   mysql: ServerlessMysql,
   walletId: string,

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -396,11 +396,15 @@ export const registerWalletShieldedKeys = async (
   shieldedMaxGap: number,
 ): Promise<boolean> => {
   const result: OkPacket = await mysql.query(
+    // Attaching keys is a deliberate upgrade — a fresh combined load — so the
+    // legacy retry counter is reset. Guarded on `scan_xpriv IS NULL`, this only
+    // ever fires for the first-time attach, never on a resubmit.
     `UPDATE \`wallet\`
         SET \`scan_xpriv\` = ?,
             \`spend_xpub\` = ?,
             \`shielded_max_gap\` = ?,
-            \`ct_status\` = 'creating'
+            \`ct_status\` = 'creating',
+            \`retry_count\` = 0
       WHERE \`id\` = ? AND \`scan_xpriv\` IS NULL`,
     [Buffer.from(scanXpriv, 'utf8'), spendXpub, shieldedMaxGap, walletId],
   );

--- a/packages/wallet-service/src/db/shielded.ts
+++ b/packages/wallet-service/src/db/shielded.ts
@@ -419,6 +419,8 @@ export interface GenerateShieldedAddresses {
   rows: ShieldedOwnershipRow[];
   addresses: string[];
   lastUsedShieldedIndex: number | null;
+  /** The subset of `rows` not yet claimed in the database — what a caller must upsert. */
+  newRows: ShieldedOwnershipRow[];
 }
 
 /**
@@ -427,16 +429,40 @@ export interface GenerateShieldedAddresses {
  * addresses show no on-chain usage. Usage is decided from observed non-voided
  * `tx_output` rows at the derived spend address — any mode, since these P2PKH
  * addresses can also receive transparent outputs — with no rewinding involved.
- * Read-only: claiming the rows is the caller's job.
+ *
+ * Indices the wallet already claimed are reused from storage instead of
+ * re-derived: keys are immutable per wallet (a conflicting re-registration is
+ * rejected upstream), so stored derivations are authoritative, and per-index
+ * private derivation is the dominant CPU cost — a retry re-derives nothing.
+ * Read-only: claiming the returned `newRows` is the caller's job.
  */
 export const generateShieldedAddresses = async (
   mysql: ServerlessMysql,
+  walletId: string,
   scanXpriv: string,
   spendXpub: string,
   maxGap: number,
   network: Network,
 ): Promise<GenerateShieldedAddresses> => {
+  const stored: DbSelectResult = await mysql.query(
+    `SELECT \`address\`, \`index\`, \`scan_privkey\`, \`ct_address\`
+       FROM \`address\`
+      WHERE \`wallet_id\` = ? AND \`bip32_account\` = ?
+        AND \`index\` IS NOT NULL AND \`scan_privkey\` IS NOT NULL AND \`ct_address\` IS NOT NULL`,
+    [walletId, Bip32Account.CTSpend],
+  );
+  const storedByIndex = new Map<number, ShieldedOwnershipRow>(stored.map((r): [number, ShieldedOwnershipRow] => [
+    Number(r.index),
+    {
+      index: Number(r.index),
+      spendAddress: r.address as string,
+      ctAddress: r.ct_address as string,
+      scanPrivkey: r.scan_privkey as Buffer,
+    },
+  ]));
+
   const allRows: ShieldedOwnershipRow[] = [];
+  const derivedRows: ShieldedOwnershipRow[] = [];
   let highestCheckedIndex = -1;
   let lastUsedIndex = -1;
 
@@ -444,13 +470,20 @@ export const generateShieldedAddresses = async (
     const blockStart = highestCheckedIndex + 1;
     const block: ShieldedOwnershipRow[] = [];
     for (let index = blockStart; index < blockStart + maxGap; index++) {
-      const derived = deriveCtAddress(scanXpriv, spendXpub, index, network);
-      block.push({
-        index,
-        spendAddress: derived.spendAddress,
-        ctAddress: derived.ctAddress,
-        scanPrivkey: derived.scanPrivkey,
-      });
+      const storedRow = storedByIndex.get(index);
+      if (storedRow) {
+        block.push(storedRow);
+      } else {
+        const derived = deriveCtAddress(scanXpriv, spendXpub, index, network);
+        const row = {
+          index,
+          spendAddress: derived.spendAddress,
+          ctAddress: derived.ctAddress,
+          scanPrivkey: derived.scanPrivkey,
+        };
+        block.push(row);
+        derivedRows.push(row);
+      }
     }
     allRows.push(...block);
 
@@ -467,10 +500,12 @@ export const generateShieldedAddresses = async (
     highestCheckedIndex += maxGap;
   } while (lastUsedIndex + maxGap > highestCheckedIndex);
 
-  const rows = allRows.filter((r) => r.index <= lastUsedIndex + maxGap);
+  const windowEnd = lastUsedIndex + maxGap;
+  const rows = allRows.filter((r) => r.index <= windowEnd);
   return {
     rows,
     addresses: rows.map((r) => r.spendAddress),
     lastUsedShieldedIndex: lastUsedIndex === -1 ? null : lastUsedIndex,
+    newRows: derivedRows.filter((r) => r.index <= windowEnd),
   };
 };

--- a/packages/wallet-service/src/db/shielded.ts
+++ b/packages/wallet-service/src/db/shielded.ts
@@ -7,6 +7,8 @@
 
 import { ServerlessMysql } from 'serverless-mysql';
 import { Bip32Account, RecoveryState, ShieldedOutputMode } from '@wallet-service/common';
+import { deriveCtAddress } from '@wallet-service/common/src/crypto/shieldedAddress';
+import type { Network } from '@hathor/wallet-lib';
 import { DbSelectResult } from '@src/types';
 
 // The two shielded output modes (AmountShielded, FullyShielded) as query params.
@@ -411,4 +413,64 @@ export const markShieldedCatchupDone = async (
     'UPDATE `address` SET `catchup_state` = ? WHERE `wallet_id` = ? AND `bip32_account` = ? AND `index` <= ?',
     ['done', walletId, Bip32Account.CTSpend, maxIndex],
   );
+};
+
+export interface GenerateShieldedAddresses {
+  rows: ShieldedOwnershipRow[];
+  addresses: string[];
+  lastUsedShieldedIndex: number | null;
+}
+
+/**
+ * Derive the wallet's shielded (CTSpend) address window under the BIP32 gap
+ * rule: keep deriving blocks of maxGap until maxGap consecutive trailing
+ * addresses show no on-chain usage. Usage is decided from observed non-voided
+ * `tx_output` rows at the derived spend address — any mode, since these P2PKH
+ * addresses can also receive transparent outputs — with no rewinding involved.
+ * Read-only: claiming the rows is the caller's job.
+ */
+export const generateShieldedAddresses = async (
+  mysql: ServerlessMysql,
+  scanXpriv: string,
+  spendXpub: string,
+  maxGap: number,
+  network: Network,
+): Promise<GenerateShieldedAddresses> => {
+  const allRows: ShieldedOwnershipRow[] = [];
+  let highestCheckedIndex = -1;
+  let lastUsedIndex = -1;
+
+  do {
+    const blockStart = highestCheckedIndex + 1;
+    const block: ShieldedOwnershipRow[] = [];
+    for (let index = blockStart; index < blockStart + maxGap; index++) {
+      const derived = deriveCtAddress(scanXpriv, spendXpub, index, network);
+      block.push({
+        index,
+        spendAddress: derived.spendAddress,
+        ctAddress: derived.ctAddress,
+        scanPrivkey: derived.scanPrivkey,
+      });
+    }
+    allRows.push(...block);
+
+    const results: DbSelectResult = await mysql.query(
+      'SELECT DISTINCT `address` FROM `tx_output` WHERE `address` IN (?) AND `voided` = FALSE',
+      [block.map((r) => r.spendAddress)],
+    );
+    const used = new Set(results.map((r) => r.address as string));
+    for (const row of block) {
+      if (used.has(row.spendAddress) && row.index > lastUsedIndex) {
+        lastUsedIndex = row.index;
+      }
+    }
+    highestCheckedIndex += maxGap;
+  } while (lastUsedIndex + maxGap > highestCheckedIndex);
+
+  const rows = allRows.filter((r) => r.index <= lastUsedIndex + maxGap);
+  return {
+    rows,
+    addresses: rows.map((r) => r.spendAddress),
+    lastUsedShieldedIndex: lastUsedIndex === -1 ? null : lastUsedIndex,
+  };
 };

--- a/packages/wallet-service/src/db/shielded.ts
+++ b/packages/wallet-service/src/db/shielded.ts
@@ -259,9 +259,9 @@ export const rebuildShieldedAddressTxHistory = async (
  * Rebuild a wallet's `wallet_balance` rows by aggregating its addresses'
  * `address_balance` (both transparent and shielded column families), with the
  * per-token `transactions` count taken from `address_tx_history` (distinct txs,
- * so shared txs aren't double-counted). Upsert → idempotent. This subsumes the
- * transparent-only `initWalletBalance`, so it credits caught-up shielded receives
- * in the same pass old clients get their transparent balance.
+ * so shared txs aren't double-counted). Upsert → idempotent. Credits the
+ * transparent balance and any caught-up shielded receives in the same pass, so
+ * it serves both transparent-only and shielded wallets.
  */
 export const rebuildWalletBalance = async (
   mysql: ServerlessMysql,
@@ -318,7 +318,7 @@ export const rebuildWalletBalance = async (
  * Rebuild a wallet's `wallet_tx_history` by aggregating its addresses'
  * `address_tx_history` per (tx, token): transparent `balance` and
  * `shielded_balance_delta` are summed across the wallet's addresses. Upsert →
- * idempotent. Subsumes the transparent-only `initWalletTxHistory`.
+ * idempotent. Serves both transparent-only and shielded wallets.
  */
 export const rebuildWalletTxHistory = async (
   mysql: ServerlessMysql,

--- a/packages/wallet-service/src/db/shielded.ts
+++ b/packages/wallet-service/src/db/shielded.ts
@@ -338,3 +338,77 @@ export const rebuildWalletTxHistory = async (
     [walletId, addresses],
   );
 };
+
+export interface ShieldedOwnershipRow {
+  index: number;
+  spendAddress: string;
+  ctAddress: string;
+  scanPrivkey: Buffer;
+}
+
+/**
+ * Claim shielded ownership of the given derived addresses for a wallet: upsert
+ * `address` rows with the CTSpend account, per-index scan privkey, display
+ * ct_address and a pending catch-up state. Safe over daemon observation rows —
+ * the daemon only ever writes (address, transactions), so ownership columns are
+ * disjoint; `transactions` appears ONLY in the insert list (never zeroed on
+ * duplicate) and a `done` catch-up state is preserved via COALESCE.
+ */
+export const upsertShieldedAddressOwnership = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  rows: ShieldedOwnershipRow[],
+): Promise<void> => {
+  if (rows.length === 0) return;
+  const values = rows.map((r) => [
+    r.spendAddress, r.index, walletId, 0, Bip32Account.CTSpend, r.scanPrivkey, 'pending', r.ctAddress,
+  ]);
+  await mysql.query(
+    `INSERT INTO \`address\`
+       (\`address\`, \`index\`, \`wallet_id\`, \`transactions\`, \`bip32_account\`, \`scan_privkey\`, \`catchup_state\`, \`ct_address\`)
+     VALUES ?
+     ON DUPLICATE KEY UPDATE
+       \`bip32_account\` = VALUES(\`bip32_account\`),
+       \`wallet_id\` = VALUES(\`wallet_id\`),
+       \`index\` = VALUES(\`index\`),
+       \`ct_address\` = VALUES(\`ct_address\`),
+       \`scan_privkey\` = VALUES(\`scan_privkey\`),
+       \`catchup_state\` = COALESCE(\`catchup_state\`, VALUES(\`catchup_state\`))`,
+    [values],
+  );
+};
+
+/**
+ * All CTSpend addresses claimed by a wallet, in index order — the shielded half
+ * of the address set a reconstruction pass must cover. Reading this back from
+ * the database (rather than trusting one run's derived list) keeps re-loads
+ * covering previously-claimed rows even if the usage window shrank.
+ */
+export const getWalletCtSpendAddresses = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+): Promise<string[]> => {
+  const results: DbSelectResult = await mysql.query(
+    'SELECT `address` FROM `address` WHERE `wallet_id` = ? AND `bip32_account` = ? ORDER BY `index`',
+    [walletId, Bip32Account.CTSpend],
+  );
+  return results.map((r) => r.address as string);
+};
+
+/**
+ * Mark the catch-up pass complete for a wallet's CTSpend rows up to (and
+ * including) maxIndex — scoped so rows this pass did not derive are untouched.
+ * NOTE: `catchup_state` records "the registration pass ran over this address";
+ * re-driving unrecovered outputs is keyed on `tx_output.recovery_state`, never
+ * on this column.
+ */
+export const markShieldedCatchupDone = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  maxIndex: number,
+): Promise<void> => {
+  await mysql.query(
+    'UPDATE `address` SET `catchup_state` = ? WHERE `wallet_id` = ? AND `bip32_account` = ? AND `index` <= ?',
+    ['done', walletId, Bip32Account.CTSpend, maxIndex],
+  );
+};

--- a/packages/wallet-service/src/db/utils.ts
+++ b/packages/wallet-service/src/db/utils.ts
@@ -94,9 +94,9 @@ export const getWalletFromDbEntry = (entry: Record<string, unknown>): Wallet => 
 });
 
 /**
- * Collapse a wallet's transparent `status` and shielded `ct_status` into the
+ * Collapse a wallet's legacy `status` and shielded `ct_status` into the
  * single lifecycle value exposed by the API:
- *  - no shielded keys registered (`none`) → the transparent status
+ *  - no shielded keys registered (`none`) → the legacy status
  *  - either side errored → error
  *  - either side still creating → creating
  *  - both ready → ready

--- a/packages/wallet-service/src/shieldedRecovery.ts
+++ b/packages/wallet-service/src/shieldedRecovery.ts
@@ -81,7 +81,7 @@ export const recoverShieldedOutput = async (
         assetCommitment: output.assetCommitment,
       });
       value = r.value;
-      tokenId = r.tokenUid;
+      tokenId = r.tokenUid; // canonicalized by rewindFully (native HTR folded to "00")
     }
 
     await markShieldedTxOutputRecovered(mysql, output.txId, output.index, { value, tokenId });

--- a/packages/wallet-service/src/shieldedRecovery.ts
+++ b/packages/wallet-service/src/shieldedRecovery.ts
@@ -150,18 +150,18 @@ export const findAndRewindShielded = async (
 
 /**
  * One-time seed of a wallet's balances + history from current DB state, unified
- * across the two derivation paths. Transparent addresses are already daemon-
+ * across the two derivation paths. Legacy addresses are already daemon-
  * maintained, so they only feed the wallet-level aggregation; CT-spend addresses
  * are first found + rewound and their `address_*` rebuilt from `tx_output`.
  * Everything is recompute-from-source, so a repeat (or an error-restart) is safe.
  *
  * Passing an empty `ctSpendAddresses` (an old client with no CT keys) yields a
- * clean transparent-only reconstruction.
+ * clean legacy-only reconstruction.
  */
 export const reconstructWallet = async (
   mysql: ServerlessMysql,
   walletId: string,
-  transparentAddresses: string[],
+  legacyAddresses: string[],
   ctSpendAddresses: string[],
   logger: Logger,
 ): Promise<{ recovered: number; failed: number }> => {
@@ -172,7 +172,7 @@ export const reconstructWallet = async (
     await rebuildShieldedAddressTxHistory(mysql, ctSpendAddresses);
   }
 
-  const allAddresses = [...transparentAddresses, ...ctSpendAddresses];
+  const allAddresses = [...legacyAddresses, ...ctSpendAddresses];
   await rebuildWalletBalance(mysql, walletId, allAddresses);
   await rebuildWalletTxHistory(mysql, walletId, allAddresses);
   return rewind;

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -2790,4 +2790,41 @@ describe('shielded wallet registration', () => {
       expect.anything(),
     );
   }, SHIELDED_TEST_TIMEOUT_MS);
+
+  test('a same-keys retry flips the wallet back to creating before re-invoking', async () => {
+    await cleanDatabase(mysql);
+    const walletId = getWalletId(XPUBKEY);
+    const { combined } = spyInvokes();
+    const now = Math.floor(Date.now() / 1000);
+    const body = buildShieldedLoadBody(now);
+    await addToWalletTable(mysql, [{
+      id: walletId, xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY, status: 'error', maxGap: 5, createdAt: 10000, readyAt: 10001,
+    }]);
+    await Db.registerWalletShieldedKeys(mysql, walletId, body.scanXpriv, body.spendXpub, 20);
+    await mysql.query('UPDATE `wallet` SET `ct_status` = ? WHERE `id` = ?', ['error', walletId]);
+
+    const result = await walletLoad(makeGatewayEvent({}, JSON.stringify(body)), null, null) as APIGatewayProxyResult;
+    expect(result.statusCode).toBe(200);
+    expect(combined).toHaveBeenCalledTimes(1);
+    const w = await Db.getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.CREATING);   // CAS flipped it before the invoke
+    expect(w.ctStatus).toBe(WalletStatus.CREATING);
+  }, SHIELDED_TEST_TIMEOUT_MS);
+
+  test('a lost CAS race skips the duplicate invoke', async () => {
+    await cleanDatabase(mysql);
+    const walletId = getWalletId(XPUBKEY);
+    const { combined } = spyInvokes();
+    const now = Math.floor(Date.now() / 1000);
+    const body = buildShieldedLoadBody(now);
+    await addToWalletTable(mysql, [{
+      id: walletId, xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY, status: 'error', maxGap: 5, createdAt: 10000, readyAt: 10001,
+    }]);
+    await Db.registerWalletShieldedKeys(mysql, walletId, body.scanXpriv, body.spendXpub, 20);
+    jest.spyOn(Db, 'casWalletErrorToCreating').mockResolvedValueOnce(false); // another request won
+
+    const result = await walletLoad(makeGatewayEvent({}, JSON.stringify(body)), null, null) as APIGatewayProxyResult;
+    expect(result.statusCode).toBe(200);
+    expect(combined).not.toHaveBeenCalled();
+  }, SHIELDED_TEST_TIMEOUT_MS);
 });

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -21,7 +21,6 @@ import { getFilteredUtxos, getFilteredTxOutputs } from '@src/api/txOutputs';
 import {
   get as walletGet,
   load as walletLoad,
-  loadWallet,
   loadWalletFailed,
   changeAuthXpub,
   validateShieldedRegistration,
@@ -867,7 +866,7 @@ test('POST /wallet', async () => {
 
   await cleanDatabase(mysql);
 
-  const spy = jest.spyOn(Wallet, 'invokeDeprecatedLoad');
+  const spy = jest.spyOn(Wallet, 'invokeLoadWalletAsync');
 
   const mockImplementationSuccess = jest.fn(() => Promise.resolve());
   const mockImplementationFailure = jest.fn(() => Promise.reject(new Error('error!')));
@@ -1003,7 +1002,7 @@ test('POST /wallet should fail with ApiError.WALLET_MAX_RETRIES when max retries
   const authMessage = new bitcore.Message(String(now).concat(walletId).concat(authAddress));
   const authXpubkeySignature = authMessage.sign(authDerivedPrivKey.privateKey);
 
-  const spy = jest.spyOn(Wallet, 'invokeDeprecatedLoad');
+  const spy = jest.spyOn(Wallet, 'invokeLoadWalletAsync');
   const mockImplementationFailure = jest.fn(() => Promise.reject(new Error('error!')));
   spy.mockImplementation(mockImplementationFailure);
 
@@ -1311,7 +1310,7 @@ test('loadWallet API should fail if a wrong signature is sent', async () => {
   const authMessage = new bitcore.Message(String(now).concat(walletId).concat(authAddress));
   const authXpubkeySignature = authMessage.sign(authDerivedPrivKey.privateKey);
 
-  const loadWalletAsyncSpy = jest.spyOn(Wallet, 'invokeDeprecatedLoad');
+  const loadWalletAsyncSpy = jest.spyOn(Wallet, 'invokeLoadWalletAsync');
   const mockImplementationSuccess = jest.fn(() => Promise.resolve());
   loadWalletAsyncSpy.mockImplementation(mockImplementationSuccess);
 
@@ -1365,67 +1364,6 @@ test('loadWallet should fail if timestamp is shifted for more than 30s', async (
   expect(returnBody.details).toHaveLength(1);
   expect(returnBody.details[0].message).toBe('The timestamp is shifted 40(s). Limit is 30(s).');
 });
-
-test('loadWallet should update wallet status to ERROR if an error occurs', async () => {
-  expect.hasAssertions();
-
-  const now = Math.floor(Date.now() / 1000);
-  const {
-    walletId,
-    xpubkey,
-    xpubkeySignature,
-    authXpubkey,
-    authXpubkeySignature,
-    firstAddress,
-  } = getAuthData(now);
-
-  const loadWalletAsyncSpy = jest.spyOn(Wallet, 'invokeDeprecatedLoad');
-  const mockImplementationSuccess = jest.fn(() => Promise.resolve());
-  loadWalletAsyncSpy.mockImplementation(mockImplementationSuccess);
-
-  // wallet should be 'creating'
-  const event = makeGatewayEvent({}, JSON.stringify({
-    xpubkey,
-    xpubkeySignature,
-    authXpubkey,
-    authXpubkeySignature,
-    firstAddress,
-    timestamp: now,
-  }));
-  const result = await walletLoad(event, null, null) as APIGatewayProxyResult;
-  const returnBody = JSON.parse(result.body as string);
-
-  expect(result.statusCode).toBe(200);
-  expect(returnBody.status.status).toStrictEqual(WalletStatus.CREATING);
-
-  const dbSpy = jest.spyOn(Db, 'addNewAddresses');
-  const mockImplementationFailure = jest.fn(() => Promise.reject(new Error('error!')));
-  dbSpy.mockImplementation(mockImplementationFailure);
-
-  const loadEvent = { xpubkey: XPUBKEY, maxGap: 10 };
-
-  const noop = () => false;
-
-  // mocking an event call from aws
-  await loadWallet(loadEvent, {
-    callbackWaitsForEmptyEventLoop: true,
-    logGroupName: '/aws/lambda/mock-lambda',
-    logStreamName: '2018/11/29/[$LATEST]xxxxxxxxxxxb',
-    functionName: 'loadWalletAsync',
-    memoryLimitInMB: '1024',
-    functionVersion: '$LATEST',
-    awsRequestId: 'xxxxxx-xxxxx-11e8-xxxx-xxxxxxxxx',
-    invokedFunctionArn: 'arn:aws:lambda:us-east-1:xxxxxxxx:function:loadWalletAsync',
-    getRemainingTimeInMillis: () => 1000,
-    done: noop,
-    fail: noop,
-    succeed: noop,
-  }, noop);
-
-  const wallet = await Db.getWallet(mysql, walletId);
-
-  expect(wallet.status).toStrictEqual(WalletStatus.ERROR);
-}, 30000);
 
 test('loadWalletFailed should create alert if xpubkey is missing', async () => {
   expect.hasAssertions();
@@ -1486,7 +1424,7 @@ test('loadWalletFailed does not demote a shielded wallet that already recovered'
   await Db.registerWalletShieldedKeys(mysql, walletId, 'scanx', 'spendx', 20);
   // A later attempt already recovered both sides; the DLQ event for the earlier
   // crashed attempt is only now being delivered.
-  await Db.markWalletCombinedReady(mysql, walletId, true);
+  await Db.markWalletLoadReady(mysql, walletId, true);
 
   await loadWalletFailed(makeLoadWalletFailedSNSEvent(1, XPUBKEY), null, null);
 
@@ -2645,20 +2583,17 @@ describe('shielded wallet registration', () => {
     readyAt: 10001,
   }]);
 
-  // Spy both async-load invokes, cleared (spyOn accumulates calls across tests).
-  // `combined` is the canonical transparent+shielded load; `deprecated` is the
-  // transparent-only load, which a shielded request must never trigger.
+  // Spy the async-load invoke, cleared (spyOn accumulates calls across tests).
+  // Every load — transparent or shielded — goes through this single combined load.
   const spyInvokes = () => {
     const combined = jest.spyOn(Wallet, 'invokeLoadWalletAsync').mockResolvedValue(undefined);
-    const deprecated = jest.spyOn(Wallet, 'invokeDeprecatedLoad').mockResolvedValue(undefined);
     combined.mockClear();
-    deprecated.mockClear();
-    return { combined, deprecated };
+    return { combined };
   };
 
   test('registers shielded keys on a brand-new wallet via the combined load and never leaks scan_xpriv', async () => {
     await cleanDatabase(mysql);
-    const { combined, deprecated } = spyInvokes();
+    const { combined } = spyInvokes();
     const now = Math.floor(Date.now() / 1000);
     const body = buildShieldedLoadBody(now);
 
@@ -2676,14 +2611,12 @@ describe('shielded wallet registration', () => {
     expect(wallet.scanXpriv).toBe(body.scanXpriv);
     expect(wallet.spendXpub).toBe(body.spendXpub);
 
-    // Shielded requests go through the canonical combined load, never the deprecated one.
     expect(combined).toHaveBeenCalledTimes(1);
-    expect(deprecated).not.toHaveBeenCalled();
   }, SHIELDED_TEST_TIMEOUT_MS);
 
   test('marks the wallet error and bumps retryCount when the combined load invoke fails', async () => {
     await cleanDatabase(mysql);
-    const { combined, deprecated } = spyInvokes();
+    const { combined } = spyInvokes();
     combined.mockRejectedValueOnce(new Error('invoke failed'));
     const now = Math.floor(Date.now() / 1000);
     const body = buildShieldedLoadBody(now);
@@ -2699,15 +2632,13 @@ describe('shielded wallet registration', () => {
     const wallet = await Db.getWallet(mysql, getWalletId(XPUBKEY));
     expect(wallet.status).toBe(WalletStatus.ERROR);
     expect(wallet.retryCount).toBe(1);
-    // The failing invoke is the combined load, never the deprecated transparent-only one.
     expect(combined).toHaveBeenCalledTimes(1);
-    expect(deprecated).not.toHaveBeenCalled();
   }, SHIELDED_TEST_TIMEOUT_MS);
 
   test('upgrades an already-loaded transparent wallet via the combined load', async () => {
     await cleanDatabase(mysql);
     await seedReadyWallet();
-    const { combined, deprecated } = spyInvokes();
+    const { combined } = spyInvokes();
     const now = Math.floor(Date.now() / 1000);
     const body = buildShieldedLoadBody(now);
 
@@ -2718,16 +2649,15 @@ describe('shielded wallet registration', () => {
     const wallet = await Db.getWallet(mysql, getWalletId(XPUBKEY));
     expect(wallet.ctStatus).toBe('creating');
     expect(wallet.scanXpriv).toBe(body.scanXpriv);
-    // The upgrade runs the combined load (which idempotently re-reconstructs
-    // transparent too), not the deprecated transparent-only load.
+    // The upgrade runs the combined load, which idempotently re-reconstructs the
+    // transparent side too.
     expect(combined).toHaveBeenCalledTimes(1);
-    expect(deprecated).not.toHaveBeenCalled();
   }, SHIELDED_TEST_TIMEOUT_MS);
 
   test('is a no-op when the same shielded keys are re-submitted', async () => {
     await cleanDatabase(mysql);
     await seedReadyWallet();
-    const { combined, deprecated } = spyInvokes();
+    const { combined } = spyInvokes();
     const now = Math.floor(Date.now() / 1000);
     const body = buildShieldedLoadBody(now);
     await Db.registerWalletShieldedKeys(mysql, getWalletId(XPUBKEY), body.scanXpriv, body.spendXpub, 20);
@@ -2739,13 +2669,12 @@ describe('shielded wallet registration', () => {
     expect(wallet.scanXpriv).toBe(body.scanXpriv);
     // Identical keys already stored -> no load is (re-)triggered.
     expect(combined).not.toHaveBeenCalled();
-    expect(deprecated).not.toHaveBeenCalled();
   }, SHIELDED_TEST_TIMEOUT_MS);
 
   test('rejects a different shielded key set with 409', async () => {
     await cleanDatabase(mysql);
     await seedReadyWallet();
-    const { combined, deprecated } = spyInvokes();
+    const { combined } = spyInvokes();
     const now = Math.floor(Date.now() / 1000);
     // Store one key set, then submit a different one.
     const stored = buildShieldedFields(getWalletId(XPUBKEY), now, { seedHex: '02'.repeat(32) });
@@ -2756,12 +2685,11 @@ describe('shielded wallet registration', () => {
     expect(result.statusCode).toBe(409);
     expect(JSON.parse(result.body as string).error).toBe(ApiError.SHIELDED_KEYS_CONFLICT);
     expect(combined).not.toHaveBeenCalled();
-    expect(deprecated).not.toHaveBeenCalled();
   }, SHIELDED_TEST_TIMEOUT_MS);
 
   test('rejects an invalid shielded signature with 403', async () => {
     await cleanDatabase(mysql);
-    const { combined, deprecated } = spyInvokes();
+    const { combined } = spyInvokes();
     const now = Math.floor(Date.now() / 1000);
     const body = { ...buildShieldedLoadBody(now), ctAddressSignature: Buffer.from('invalid').toString('base64') };
 
@@ -2770,13 +2698,12 @@ describe('shielded wallet registration', () => {
     // No wallet should have been created — shielded validation runs before any load.
     expect(await Db.getWallet(mysql, getWalletId(XPUBKEY))).toBeNull();
     expect(combined).not.toHaveBeenCalled();
-    expect(deprecated).not.toHaveBeenCalled();
   }, SHIELDED_TEST_TIMEOUT_MS);
 
   test('re-runs the combined load when the same keys are re-submitted after a failed load', async () => {
     await cleanDatabase(mysql);
     const walletId = getWalletId(XPUBKEY);
-    const { combined, deprecated } = spyInvokes();
+    const { combined } = spyInvokes();
     const now = Math.floor(Date.now() / 1000);
     const body = buildShieldedLoadBody(now);
     // The wallet holds these keys but a previous load errored (retryCount below the cap).
@@ -2789,13 +2716,12 @@ describe('shielded wallet registration', () => {
     expect(result.statusCode).toBe(200);
     // Same keys + error state -> retry via the combined load.
     expect(combined).toHaveBeenCalledTimes(1);
-    expect(deprecated).not.toHaveBeenCalled();
   }, SHIELDED_TEST_TIMEOUT_MS);
 
   test('rejects a shielded resubmit with WALLET_MAX_RETRIES + alert once the cap is reached', async () => {
     await cleanDatabase(mysql);
     const walletId = getWalletId(XPUBKEY);
-    const { combined, deprecated } = spyInvokes();
+    const { combined } = spyInvokes();
     const now = Math.floor(Date.now() / 1000);
     const body = buildShieldedLoadBody(now);
     await addToWalletTable(mysql, [{
@@ -2812,7 +2738,6 @@ describe('shielded wallet registration', () => {
     // No retry is kicked off, and reaching the cap raises an ops alert carrying
     // the wallet id + retry count at MINOR severity.
     expect(combined).not.toHaveBeenCalled();
-    expect(deprecated).not.toHaveBeenCalled();
     expect(mockedAddAlert).toHaveBeenCalledTimes(1);
     expect(mockedAddAlert).toHaveBeenCalledWith(
       'Wallet load exceeded max retries',

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -1414,6 +1414,7 @@ test('loadWalletFailed pins both sides for a fresh shielded wallet crash', async
   expect(w.status).toBe(WalletStatus.ERROR);
   expect(w.ctStatus).toBe(WalletStatus.ERROR);
   expect(w.retryCount).toBe(5);
+  expect(w.readyAt).toEqual(expect.any(Number)); // the legacy pin stamps ready_at
 });
 
 test('loadWalletFailed does not demote a shielded wallet that already recovered', async () => {

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -1448,6 +1448,36 @@ test('loadWalletFailed should create alert if xpubkey is missing', async () => {
   );
 });
 
+test('loadWalletFailed pins only the shielded side when the transparent side was ready (upgrade crash)', async () => {
+  expect.hasAssertions();
+  await cleanDatabase(mysql);
+  const walletId = getWalletId(XPUBKEY);
+  await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, 5);
+  await Db.updateWalletStatus(mysql, walletId, WalletStatus.READY);
+  await Db.registerWalletShieldedKeys(mysql, walletId, 'scanx', 'spendx', 20);
+
+  await loadWalletFailed(makeLoadWalletFailedSNSEvent(1, XPUBKEY), null, null);
+
+  const w = await Db.getWallet(mysql, walletId);
+  expect(w.status).toBe(WalletStatus.READY);   // working transparent state untouched
+  expect(w.ctStatus).toBe(WalletStatus.ERROR); // shielded side pinned
+  expect(w.retryCount).toBe(5);                // pinned at the cap (config.maxLoadWalletRetries in the test env)
+});
+
+test('loadWalletFailed pins both sides for a fresh shielded wallet crash', async () => {
+  expect.hasAssertions();
+  await cleanDatabase(mysql);
+  const walletId = getWalletId(XPUBKEY);
+  await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, 5, { scanXpriv: 'scanx', spendXpub: 'spendx', shieldedMaxGap: 20 });
+
+  await loadWalletFailed(makeLoadWalletFailedSNSEvent(1, XPUBKEY), null, null);
+
+  const w = await Db.getWallet(mysql, walletId);
+  expect(w.status).toBe(WalletStatus.ERROR);
+  expect(w.ctStatus).toBe(WalletStatus.ERROR);
+  expect(w.retryCount).toBe(5);
+});
+
 test('GET /wallet/tokens', async () => {
   expect.hasAssertions();
 

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -2828,4 +2828,63 @@ describe('shielded wallet registration', () => {
     expect(result.statusCode).toBe(200);
     expect(combined).not.toHaveBeenCalled();
   }, SHIELDED_TEST_TIMEOUT_MS);
+
+  test('a legacy-only retry flips an errored wallet to creating before re-invoking', async () => {
+    await cleanDatabase(mysql);
+    const walletId = getWalletId(XPUBKEY);
+    const { combined } = spyInvokes();
+    const now = Math.floor(Date.now() / 1000);
+    // transparent-only body — the schema rejects unknown keys, so build it from
+    // getAuthData's fields rather than passing the helper's object (it carries walletId).
+    const { xpubkey, xpubkeySignature, authXpubkey, authXpubkeySignature, firstAddress, timestamp } = getAuthData(now);
+    const body = { xpubkey, xpubkeySignature, authXpubkey, authXpubkeySignature, firstAddress, timestamp };
+    await addToWalletTable(mysql, [{
+      id: walletId, xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY, status: 'error', maxGap: 5, createdAt: 10000, readyAt: 10001,
+    }]);
+
+    const result = await walletLoad(makeGatewayEvent({}, JSON.stringify(body)), null, null) as APIGatewayProxyResult;
+    expect(result.statusCode).toBe(200);
+    expect(combined).toHaveBeenCalledTimes(1);
+    const w = await Db.getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.CREATING); // CAS flipped it before the invoke
+  }, SHIELDED_TEST_TIMEOUT_MS);
+
+  test('a lost legacy CAS race skips the duplicate invoke', async () => {
+    await cleanDatabase(mysql);
+    const walletId = getWalletId(XPUBKEY);
+    const { combined } = spyInvokes();
+    const now = Math.floor(Date.now() / 1000);
+    const { xpubkey, xpubkeySignature, authXpubkey, authXpubkeySignature, firstAddress, timestamp } = getAuthData(now);
+    const body = { xpubkey, xpubkeySignature, authXpubkey, authXpubkeySignature, firstAddress, timestamp };
+    await addToWalletTable(mysql, [{
+      id: walletId, xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY, status: 'error', maxGap: 5, createdAt: 10000, readyAt: 10001,
+    }]);
+    jest.spyOn(Db, 'casWalletErrorToCreating').mockResolvedValueOnce(false); // another request won
+
+    const result = await walletLoad(makeGatewayEvent({}, JSON.stringify(body)), null, null) as APIGatewayProxyResult;
+    expect(result.statusCode).toBe(200);
+    expect(combined).not.toHaveBeenCalled();
+  }, SHIELDED_TEST_TIMEOUT_MS);
+
+  test('an upgrade of a max-retries wallet resets retry_count and loads', async () => {
+    await cleanDatabase(mysql);
+    const walletId = getWalletId(XPUBKEY);
+    const { combined } = spyInvokes();
+    const now = Math.floor(Date.now() / 1000);
+    const body = buildShieldedLoadBody(now);
+    // Legacy wallet bricked at the retry cap, no ct keys yet -> a first-time upgrade.
+    await addToWalletTable(mysql, [{
+      id: walletId, xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY, status: 'error', maxGap: 5, createdAt: 10000, readyAt: 10001,
+    }]);
+    await mysql.query('UPDATE `wallet` SET `retry_count` = 5 WHERE `id` = ?', [walletId]); // MAX in the test env
+
+    const result = await walletLoad(makeGatewayEvent({}, JSON.stringify(body)), null, null) as APIGatewayProxyResult;
+    // Honored, not rejected as WALLET_MAX_RETRIES: the attach reset the counter.
+    expect(result.statusCode).toBe(200);
+    expect(combined).toHaveBeenCalledTimes(1);
+    const w = await Db.getWallet(mysql, walletId);
+    expect(w.retryCount).toBe(0);
+    expect(w.ctStatus).toBe(WalletStatus.CREATING);
+    expect(w.scanXpriv).toBe(body.scanXpriv);
+  }, SHIELDED_TEST_TIMEOUT_MS);
 });

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -1478,6 +1478,38 @@ test('loadWalletFailed pins both sides for a fresh shielded wallet crash', async
   expect(w.retryCount).toBe(5);
 });
 
+test('loadWalletFailed does not demote a shielded wallet that already recovered', async () => {
+  expect.hasAssertions();
+  await cleanDatabase(mysql);
+  const walletId = getWalletId(XPUBKEY);
+  await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, 5);
+  await Db.registerWalletShieldedKeys(mysql, walletId, 'scanx', 'spendx', 20);
+  // A later attempt already recovered both sides; the DLQ event for the earlier
+  // crashed attempt is only now being delivered.
+  await Db.markWalletCombinedReady(mysql, walletId, true);
+
+  await loadWalletFailed(makeLoadWalletFailedSNSEvent(1, XPUBKEY), null, null);
+
+  const w = await Db.getWallet(mysql, walletId);
+  expect(w.status).toBe(WalletStatus.READY);
+  expect(w.ctStatus).toBe(WalletStatus.READY);
+  expect(w.retryCount).toBe(0); // not pinned at the cap -> not bricked
+});
+
+test('loadWalletFailed does not demote a transparent wallet that already recovered', async () => {
+  expect.hasAssertions();
+  await cleanDatabase(mysql);
+  const walletId = getWalletId(XPUBKEY);
+  await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, 5);
+  await Db.updateWalletStatus(mysql, walletId, WalletStatus.READY);
+
+  await loadWalletFailed(makeLoadWalletFailedSNSEvent(1, XPUBKEY), null, null);
+
+  const w = await Db.getWallet(mysql, walletId);
+  expect(w.status).toBe(WalletStatus.READY);
+  expect(w.retryCount).toBe(0);
+});
+
 test('GET /wallet/tokens', async () => {
   expect.hasAssertions();
 
@@ -2809,6 +2841,49 @@ describe('shielded wallet registration', () => {
     const w = await Db.getWallet(mysql, walletId);
     expect(w.status).toBe(WalletStatus.CREATING);   // CAS flipped it before the invoke
     expect(w.ctStatus).toBe(WalletStatus.CREATING);
+  }, SHIELDED_TEST_TIMEOUT_MS);
+
+  /**
+   * Simulate losing the upgrade race: a concurrent request attaches `keys` to the
+   * wallet just before ours, so our guarded write matches no rows and reports false.
+   */
+  const loseUpgradeRaceTo = (walletId: string, keys: { scanXpriv: string; spendXpub: string }) => {
+    jest.spyOn(Db, 'registerWalletShieldedKeys').mockImplementationOnce(async () => {
+      await mysql.query(
+        'UPDATE `wallet` SET `scan_xpriv` = ?, `spend_xpub` = ?, `ct_status` = ? WHERE `id` = ?',
+        [Buffer.from(keys.scanXpriv, 'utf8'), keys.spendXpub, WalletStatus.CREATING, walletId],
+      );
+      return false;
+    });
+  };
+
+  test('a lost upgrade race skips the duplicate invoke', async () => {
+    await cleanDatabase(mysql);
+    await seedReadyWallet();
+    const { combined } = spyInvokes();
+    const now = Math.floor(Date.now() / 1000);
+    const body = buildShieldedLoadBody(now);
+    loseUpgradeRaceTo(getWalletId(XPUBKEY), body); // winner attached the same keys
+
+    const result = await walletLoad(makeGatewayEvent({}, JSON.stringify(body)), null, null) as APIGatewayProxyResult;
+    expect(result.statusCode).toBe(200);
+    // The winner is already driving the load; this request must not spawn a second.
+    expect(combined).not.toHaveBeenCalled();
+  }, SHIELDED_TEST_TIMEOUT_MS);
+
+  test('a lost upgrade race against a different key set is a 409', async () => {
+    await cleanDatabase(mysql);
+    await seedReadyWallet();
+    const { combined } = spyInvokes();
+    const now = Math.floor(Date.now() / 1000);
+    const body = buildShieldedLoadBody(now);
+    const stored = buildShieldedFields(getWalletId(XPUBKEY), now, { seedHex: '02'.repeat(32) });
+    loseUpgradeRaceTo(getWalletId(XPUBKEY), stored); // winner attached a different set
+
+    const result = await walletLoad(makeGatewayEvent({}, JSON.stringify(body)), null, null) as APIGatewayProxyResult;
+    expect(result.statusCode).toBe(409);
+    expect(JSON.parse(result.body as string).error).toBe(ApiError.SHIELDED_KEYS_CONFLICT);
+    expect(combined).not.toHaveBeenCalled();
   }, SHIELDED_TEST_TIMEOUT_MS);
 
   test('a lost CAS race skips the duplicate invoke', async () => {

--- a/packages/wallet-service/tests/db.shielded.test.ts
+++ b/packages/wallet-service/tests/db.shielded.test.ts
@@ -7,6 +7,7 @@
 
 import { ServerlessMysql } from 'serverless-mysql';
 import { Bip32Account } from '@wallet-service/common';
+import { DbSelectResult } from '@src/types';
 import { getDbConnection, closeDbConnection } from '@src/utils';
 import { cleanDatabase, addToWalletTable, addToAddressTable } from '@tests/utils';
 import {
@@ -15,6 +16,9 @@ import {
   markShieldedTxOutputRecovered,
   markShieldedTxOutputRecoveryFailed,
   getShieldedOutputsToRecover,
+  upsertShieldedAddressOwnership,
+  getWalletCtSpendAddresses,
+  markShieldedCatchupDone,
 } from '@src/db/shielded';
 
 const mysql: ServerlessMysql = getDbConnection();
@@ -235,5 +239,77 @@ describe('shielded db: outputs to recover', () => {
     expect(first.map((o) => [o.txId, o.index])).toEqual([['multi', 0], ['multi', 1]]);
     const next = await getShieldedOutputsToRecover(mysql, 'w1', 2, { txId: 'multi', index: 1 });
     expect(next.map((o) => [o.txId, o.index])).toEqual([['multi', 2]]);
+  });
+});
+
+describe('upsertShieldedAddressOwnership', () => {
+  const rows = [
+    { index: 0, spendAddress: 'WSpend0', ctAddress: 'ct0', scanPrivkey: Buffer.alloc(32, 1) },
+    { index: 1, spendAddress: 'WSpend1', ctAddress: 'ct1', scanPrivkey: Buffer.alloc(32, 2) },
+  ];
+
+  it('claims fresh rows with pending catch-up state', async () => {
+    await upsertShieldedAddressOwnership(mysql, 'w1', rows);
+    const res = await mysql.query(
+      'SELECT `address`, `index`, `wallet_id`, `transactions`, `bip32_account`, `catchup_state`, `ct_address`, `scan_privkey` FROM `address` ORDER BY `index`',
+    );
+    expect(res).toHaveLength(2);
+    expect(res[0].wallet_id).toBe('w1');
+    expect(Number(res[0].bip32_account)).toBe(2);
+    expect(res[0].catchup_state).toBe('pending');
+    expect(res[0].ct_address).toBe('ct0');
+    expect(Buffer.from(res[0].scan_privkey).equals(Buffer.alloc(32, 1))).toBe(true);
+    expect(Number(res[0].transactions)).toBe(0);
+  });
+
+  it('claims a daemon observation row without touching its transactions counter', async () => {
+    // daemon observation shape: bare row, involvement already counted
+    await mysql.query('INSERT INTO `address` (`address`, `transactions`) VALUES (?, 3)', ['WSpend0']);
+    await upsertShieldedAddressOwnership(mysql, 'w1', rows);
+    const r = (await mysql.query('SELECT * FROM `address` WHERE `address` = ?', ['WSpend0']))[0];
+    expect(r.wallet_id).toBe('w1');
+    expect(Number(r.transactions)).toBe(3); // preserved — never in the ON DUPLICATE clause
+    expect(r.catchup_state).toBe('pending');
+  });
+
+  it('does not reset a done catch-up state on re-claim', async () => {
+    await upsertShieldedAddressOwnership(mysql, 'w1', rows);
+    await mysql.query('UPDATE `address` SET `catchup_state` = ? WHERE `address` = ?', ['done', 'WSpend0']);
+    await upsertShieldedAddressOwnership(mysql, 'w1', rows);
+    const r = (await mysql.query('SELECT `catchup_state` FROM `address` WHERE `address` = ?', ['WSpend0']))[0];
+    expect(r.catchup_state).toBe('done'); // COALESCE keeps it
+  });
+
+  it('is a no-op for an empty row list', async () => {
+    await upsertShieldedAddressOwnership(mysql, 'w1', []);
+    expect(Number((await mysql.query('SELECT COUNT(*) AS c FROM `address`'))[0].c)).toBe(0);
+  });
+});
+
+describe('getWalletCtSpendAddresses', () => {
+  it('returns only the wallet CTSpend addresses, ordered by index', async () => {
+    await upsertShieldedAddressOwnership(mysql, 'w1', [
+      { index: 1, spendAddress: 'WSpend1', ctAddress: 'ct1', scanPrivkey: Buffer.alloc(32, 2) },
+      { index: 0, spendAddress: 'WSpend0', ctAddress: 'ct0', scanPrivkey: Buffer.alloc(32, 1) },
+    ]);
+    await upsertShieldedAddressOwnership(mysql, 'w2', [
+      { index: 0, spendAddress: 'WOther0', ctAddress: 'ctX', scanPrivkey: Buffer.alloc(32, 9) },
+    ]);
+    // transparent-claimed row of w1 must be excluded
+    await mysql.query('INSERT INTO `address` (`address`, `index`, `wallet_id`, `transactions`) VALUES (?, 0, ?, 0)', ['WTransp0', 'w1']);
+    expect(await getWalletCtSpendAddresses(mysql, 'w1')).toStrictEqual(['WSpend0', 'WSpend1']);
+  });
+});
+
+describe('markShieldedCatchupDone', () => {
+  it('marks only the wallet CTSpend rows up to maxIndex', async () => {
+    await upsertShieldedAddressOwnership(mysql, 'w1', [
+      { index: 0, spendAddress: 'WSpend0', ctAddress: 'ct0', scanPrivkey: Buffer.alloc(32, 1) },
+      { index: 1, spendAddress: 'WSpend1', ctAddress: 'ct1', scanPrivkey: Buffer.alloc(32, 2) },
+      { index: 2, spendAddress: 'WSpend2', ctAddress: 'ct2', scanPrivkey: Buffer.alloc(32, 3) },
+    ]);
+    await markShieldedCatchupDone(mysql, 'w1', 1);
+    const res: DbSelectResult = await mysql.query('SELECT `index`, `catchup_state` FROM `address` ORDER BY `index`');
+    expect(res.map((r) => r.catchup_state)).toStrictEqual(['done', 'done', 'pending']);
   });
 });

--- a/packages/wallet-service/tests/db.shielded.test.ts
+++ b/packages/wallet-service/tests/db.shielded.test.ts
@@ -336,7 +336,7 @@ describe('generateShieldedAddresses', () => {
   );
 
   it('derives exactly maxGap addresses when nothing was ever used', async () => {
-    const res = await generateShieldedAddresses(mysql, gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    const res = await generateShieldedAddresses(mysql, 'gap-w', gapScanXpriv, gapSpendXpub, 5, gapNetwork);
     expect(res.rows).toHaveLength(5);
     expect(res.lastUsedShieldedIndex).toBeNull();
     expect(res.rows[0]).toStrictEqual({
@@ -354,7 +354,7 @@ describe('generateShieldedAddresses', () => {
     // violate the gap rule itself and is correctly out of reach.
     await seedOutputAt(derivedAt(3).spendAddress, 'gap-tx0');
     await seedOutputAt(derivedAt(7).spendAddress, 'gap-tx1');
-    const res = await generateShieldedAddresses(mysql, gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    const res = await generateShieldedAddresses(mysql, 'gap-w', gapScanXpriv, gapSpendXpub, 5, gapNetwork);
     expect(res.lastUsedShieldedIndex).toBe(7);
     expect(res.rows).toHaveLength(13); // 0..12 = lastUsed + maxGap
     expect(res.rows[12].index).toBe(12);
@@ -362,15 +362,52 @@ describe('generateShieldedAddresses', () => {
 
   it('counts a transparent (mode 0) output to a shielded spend address as usage', async () => {
     await seedOutputAt(derivedAt(2).spendAddress, 'gap-tx2', 0);
-    const res = await generateShieldedAddresses(mysql, gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    const res = await generateShieldedAddresses(mysql, 'gap-w', gapScanXpriv, gapSpendXpub, 5, gapNetwork);
     expect(res.lastUsedShieldedIndex).toBe(2);
     expect(res.rows).toHaveLength(8); // 0..7
   });
 
   it('ignores voided outputs', async () => {
     await seedOutputAt(derivedAt(3).spendAddress, 'gap-tx3', 1, true);
-    const res = await generateShieldedAddresses(mysql, gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    const res = await generateShieldedAddresses(mysql, 'gap-w', gapScanXpriv, gapSpendXpub, 5, gapNetwork);
     expect(res.lastUsedShieldedIndex).toBeNull();
     expect(res.rows).toHaveLength(5);
+  });
+
+  it('reuses already-claimed rows instead of re-deriving them', async () => {
+    // Sentinel values distinct from any real derivation: if these come back,
+    // the loop trusted storage (keys are immutable per wallet, so stored
+    // derivations are authoritative) and skipped the expensive derivation.
+    const sentinels = [0, 1, 2, 3, 4].map((i) => ({
+      index: i, spendAddress: `stored-${i}`, ctAddress: `stored-ct-${i}`, scanPrivkey: Buffer.alloc(32, 0xf0 + i),
+    }));
+    await upsertShieldedAddressOwnership(mysql, 'gap-w', sentinels);
+
+    const res = await generateShieldedAddresses(mysql, 'gap-w', gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    expect(res.rows).toHaveLength(5);
+    expect(res.rows.map((r) => r.spendAddress)).toStrictEqual(sentinels.map((s) => s.spendAddress));
+    expect(res.rows[0].scanPrivkey.equals(Buffer.alloc(32, 0xf0))).toBe(true);
+    expect(res.newRows).toHaveLength(0); // nothing to claim on a retry
+  });
+
+  it('derives only the indices beyond the stored window', async () => {
+    const sentinels = [0, 1, 2].map((i) => ({
+      index: i, spendAddress: `stored-${i}`, ctAddress: `stored-ct-${i}`, scanPrivkey: Buffer.alloc(32, 0xf0 + i),
+    }));
+    await upsertShieldedAddressOwnership(mysql, 'gap-w', sentinels);
+    // usage at the stored index 1 pulls the window to 0..6
+    await seedOutputAt('stored-1', 'gap-tx4');
+
+    const res = await generateShieldedAddresses(mysql, 'gap-w', gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    expect(res.lastUsedShieldedIndex).toBe(1);
+    expect(res.rows).toHaveLength(7); // 0..6
+    expect(res.rows[1].spendAddress).toBe('stored-1');       // reused
+    expect(res.rows[3]).toStrictEqual({                       // freshly derived
+      index: 3,
+      spendAddress: derivedAt(3).spendAddress,
+      ctAddress: derivedAt(3).ctAddress,
+      scanPrivkey: derivedAt(3).scanPrivkey,
+    });
+    expect(res.newRows.map((r) => r.index)).toStrictEqual([3, 4, 5, 6]);
   });
 });

--- a/packages/wallet-service/tests/db.shielded.test.ts
+++ b/packages/wallet-service/tests/db.shielded.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { ServerlessMysql } from 'serverless-mysql';
+import BIP32Factory from 'bip32';
+import * as ecc from 'tiny-secp256k1';
+import { Network } from '@hathor/wallet-lib';
 import { Bip32Account } from '@wallet-service/common';
+import { deriveCtAddress } from '@wallet-service/common/src/crypto/shieldedAddress';
 import { DbSelectResult } from '@src/types';
 import { getDbConnection, closeDbConnection } from '@src/utils';
 import { cleanDatabase, addToWalletTable, addToAddressTable } from '@tests/utils';
@@ -19,6 +23,7 @@ import {
   upsertShieldedAddressOwnership,
   getWalletCtSpendAddresses,
   markShieldedCatchupDone,
+  generateShieldedAddresses,
 } from '@src/db/shielded';
 
 const mysql: ServerlessMysql = getDbConnection();
@@ -311,5 +316,61 @@ describe('markShieldedCatchupDone', () => {
     await markShieldedCatchupDone(mysql, 'w1', 1);
     const res: DbSelectResult = await mysql.query('SELECT `index`, `catchup_state` FROM `address` ORDER BY `index`');
     expect(res.map((r) => r.catchup_state)).toStrictEqual(['done', 'done', 'pending']);
+  });
+});
+
+describe('generateShieldedAddresses', () => {
+  const bip32lib = BIP32Factory(ecc);
+  const gapRoot = bip32lib.fromSeed(Buffer.from('02'.repeat(32), 'hex'));
+  const gapScanXpriv = gapRoot.derivePath("m/44'/280'/1'/0").toBase58();
+  const gapSpendXpub = gapRoot.derivePath("m/44'/280'/2'/0").neutered().toBase58();
+  const gapNetwork = new Network(process.env.NETWORK as string);
+  const derivedAt = (i: number) => deriveCtAddress(gapScanXpriv, gapSpendXpub, i, gapNetwork);
+
+  const seedOutputAt = (address: string, txId: string, mode = 1, voided = false) => mysql.query(
+    `INSERT INTO \`tx_output\`
+       (\`tx_id\`, \`index\`, \`address\`, \`value\`, \`token_id\`, \`authorities\`,
+        \`timelock\`, \`heightlock\`, \`locked\`, \`voided\`, \`mode\`, \`recovery_state\`)
+     VALUES (?, 0, ?, NULL, NULL, 0, NULL, NULL, FALSE, ?, ?, 'unowned')`,
+    [txId, address, voided, mode],
+  );
+
+  it('derives exactly maxGap addresses when nothing was ever used', async () => {
+    const res = await generateShieldedAddresses(mysql, gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    expect(res.rows).toHaveLength(5);
+    expect(res.lastUsedShieldedIndex).toBeNull();
+    expect(res.rows[0]).toStrictEqual({
+      index: 0,
+      spendAddress: derivedAt(0).spendAddress,
+      ctAddress: derivedAt(0).ctAddress,
+      scanPrivkey: derivedAt(0).scanPrivkey,
+    });
+    expect(res.addresses).toStrictEqual(res.rows.map((r) => r.spendAddress));
+  });
+
+  it('extends the window past chained usage into a later block', async () => {
+    // usage at 3 pulls the window to 0..8; usage at 7 (found in the second
+    // block) pulls it to 0..12. An isolated use at 7 with 0..6 unused would
+    // violate the gap rule itself and is correctly out of reach.
+    await seedOutputAt(derivedAt(3).spendAddress, 'gap-tx0');
+    await seedOutputAt(derivedAt(7).spendAddress, 'gap-tx1');
+    const res = await generateShieldedAddresses(mysql, gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    expect(res.lastUsedShieldedIndex).toBe(7);
+    expect(res.rows).toHaveLength(13); // 0..12 = lastUsed + maxGap
+    expect(res.rows[12].index).toBe(12);
+  });
+
+  it('counts a transparent (mode 0) output to a shielded spend address as usage', async () => {
+    await seedOutputAt(derivedAt(2).spendAddress, 'gap-tx2', 0);
+    const res = await generateShieldedAddresses(mysql, gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    expect(res.lastUsedShieldedIndex).toBe(2);
+    expect(res.rows).toHaveLength(8); // 0..7
+  });
+
+  it('ignores voided outputs', async () => {
+    await seedOutputAt(derivedAt(3).spendAddress, 'gap-tx3', 1, true);
+    const res = await generateShieldedAddresses(mysql, gapScanXpriv, gapSpendXpub, 5, gapNetwork);
+    expect(res.lastUsedShieldedIndex).toBeNull();
+    expect(res.rows).toHaveLength(5);
   });
 });

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -2,14 +2,13 @@ import { logger } from '@tests/winston.mock';
 import { mockedAddAlert } from '@tests/utils/alerting.utils.mock';
 import { v4 as uuidv4 } from 'uuid';
 import {
-  addNewAddresses,
   addUtxos,
   advanceLastUsedShieldedIndex,
   casWalletErrorToCreating,
   createTxProposal,
   createWallet,
-  markWalletCombinedError,
-  markWalletCombinedReady,
+  markWalletLoadError,
+  markWalletLoadReady,
   upsertNewAddresses,
   generateAddresses,
   getAddressWalletInfo,
@@ -35,8 +34,6 @@ import {
   getTransactionsById,
   getTxsAfterHeight,
   getAddressAtIndex,
-  initWalletBalance,
-  initWalletTxHistory,
   markUtxosWithProposalId,
   updateTxOutputSpentBy,
   storeTokenInformation,
@@ -357,21 +354,6 @@ test('getWallet, createWallet and updateWalletStatus', async () => {
   expect(ret.readyAt).toBeGreaterThanOrEqual(timestamp);
 });
 
-test('addNewAddresses', async () => {
-  expect.hasAssertions();
-  const walletId = 'walletId';
-
-  // test adding empty dict
-  await addNewAddresses(mysql, walletId, {}, -1);
-  await expect(checkAddressTable(mysql, 0)).resolves.toBe(true);
-
-  // add some addresses
-  await addNewAddresses(mysql, walletId, addrMap, -1);
-  for (const [index, address] of ADDRESSES.entries()) {
-    await expect(checkAddressTable(mysql, ADDRESSES.length, address, index, walletId, 0)).resolves.toBe(true);
-  }
-});
-
 test('updateExistingAddresses', async () => {
   expect.hasAssertions();
   const walletId = 'walletId';
@@ -381,11 +363,10 @@ test('updateExistingAddresses', async () => {
   await expect(checkAddressTable(mysql, 0)).resolves.toBe(true);
 
   // first add some addresses to database, without walletId and index
-  const newAddrMap = {};
-  for (const address of ADDRESSES) {
-    newAddrMap[address] = null;
-  }
-  await addNewAddresses(mysql, null, newAddrMap, -1);
+  await mysql.query(
+    'INSERT INTO `address`(`address`, `transactions`) VALUES ?',
+    [ADDRESSES.map((address) => [address, 0])],
+  );
   for (const address of ADDRESSES) {
     await expect(checkAddressTable(mysql, ADDRESSES.length, address, null, null, 0)).resolves.toBe(true);
   }
@@ -395,120 +376,6 @@ test('updateExistingAddresses', async () => {
   for (const [index, address] of ADDRESSES.entries()) {
     await expect(checkAddressTable(mysql, ADDRESSES.length, address, index, walletId, 0)).resolves.toBe(true);
   }
-});
-
-test('initWalletTxHistory', async () => {
-  expect.hasAssertions();
-  const walletId = 'walletId';
-  const addr1 = 'addr1';
-  const addr2 = 'addr2';
-  const addr3 = 'addr3';
-  const token1 = 'token1';
-  const token2 = 'token2';
-  const token3 = 'token3';
-  const txId1 = 'txId1';
-  const txId2 = 'txId2';
-  const timestamp1 = 10;
-  const timestamp2 = 20;
-
-  /*
-   * addr1 and addr2 belong to our wallet, while addr3 does not. We are adding this last
-   * address to make sure the wallet history will only get the balance from its own addresses
-   *
-   * These transactions are not valid under network rules, but here we only want to test the
-   * database updates and final values
-   *
-   * tx1:
-   *  . addr1: receive 10 token1 and 7 token2 (+10 token1, +7 token2);
-   *  . addr2: receive 5 token2 (+5 token2);
-   *  . addr3: receive 3 token1 (+3 token1);
-   * tx2:
-   *  . addr1: send 1 token1 and receive 3 token3 (-1 token1, +3 token3);
-   *  . addr2: send 5 token2 (-5 token2);
-   *  . addr3: receive 3 token1 (+3 token1);
-   *
-   *  Final entries for wallet_tx_history will be:
-   *    . txId1 token1 +10
-   *    . txId1 token2 +12
-   *    . txId2 token1 -1
-   *    . txId2 token2 -5
-   *    . txId2 token3 +3
-   */
-
-  // with empty addresses it shouldn't add anything
-  await initWalletTxHistory(mysql, walletId, []);
-  await expect(checkWalletTxHistoryTable(mysql, 0)).resolves.toBe(true);
-
-  const entries = [
-    { address: addr1, txId: txId1, tokenId: token1, balance: 10n, timestamp: timestamp1 },
-    { address: addr1, txId: txId1, tokenId: token2, balance: 7n, timestamp: timestamp1 },
-    { address: addr2, txId: txId1, tokenId: token2, balance: 5n, timestamp: timestamp1 },
-    { address: addr3, txId: txId1, tokenId: token1, balance: 3n, timestamp: timestamp1 },
-    { address: addr1, txId: txId2, tokenId: token1, balance: -1n, timestamp: timestamp2 },
-    { address: addr1, txId: txId2, tokenId: token3, balance: 3n, timestamp: timestamp2 },
-    { address: addr2, txId: txId2, tokenId: token2, balance: -5n, timestamp: timestamp2 },
-    { address: addr3, txId: txId2, tokenId: token1, balance: 3n, timestamp: timestamp2 },
-  ];
-  await addToAddressTxHistoryTable(mysql, entries);
-
-  await initWalletTxHistory(mysql, walletId, [addr1, addr2]);
-
-  // check wallet_tx_history entries
-  await expect(checkWalletTxHistoryTable(mysql, 5, walletId, token1, txId1, 10, timestamp1)).resolves.toBe(true);
-  await expect(checkWalletTxHistoryTable(mysql, 5, walletId, token2, txId1, 12, timestamp1)).resolves.toBe(true);
-  await expect(checkWalletTxHistoryTable(mysql, 5, walletId, token1, txId2, -1, timestamp2)).resolves.toBe(true);
-  await expect(checkWalletTxHistoryTable(mysql, 5, walletId, token2, txId2, -5, timestamp2)).resolves.toBe(true);
-  await expect(checkWalletTxHistoryTable(mysql, 5, walletId, token3, txId2, 3, timestamp2)).resolves.toBe(true);
-});
-
-test('initWalletBalance', async () => {
-  expect.hasAssertions();
-  const walletId = 'walletId';
-  const addr1 = 'addr1';
-  const addr2 = 'addr2';
-  const addr3 = 'addr3';
-  const token1 = 'token1';
-  const token2 = 'token2';
-  const tx1 = 'tx1';
-  const tx2 = 'tx2';
-  const tx3 = 'tx3';
-  const ts1 = 0;
-  const ts2 = 10;
-  const ts3 = 20;
-  const timelock = 500;
-
-  /*
-   * addr1 and addr2 belong to our wallet, while addr3 does not. We are adding this last
-   * address to make sure the wallet will only get the balance from its own addresses
-   */
-  const historyEntries = [
-    { address: addr1, txId: tx1, tokenId: token1, balance: 10n, timestamp: ts1 },
-    { address: addr1, txId: tx2, tokenId: token1, balance: -8n, timestamp: ts2 },
-    { address: addr1, txId: tx1, tokenId: token2, balance: 5n, timestamp: ts1 },
-    { address: addr2, txId: tx1, tokenId: token1, balance: 3n, timestamp: ts1 },
-    { address: addr2, txId: tx3, tokenId: token1, balance: 4n, timestamp: ts3 },
-    { address: addr2, txId: tx2, tokenId: token2, balance: 2n, timestamp: ts2 },
-    { address: addr3, txId: tx1, tokenId: token1, balance: 1n, timestamp: ts1 },
-    { address: addr3, txId: tx3, tokenId: token2, balance: 11n, timestamp: ts3 },
-  ];
-  const addressEntries = [
-    // address, tokenId, unlocked, locked, lockExpires, transactions, unlocked_authorities, locked_authorities, total_received
-    [addr1, token1, 2, 0, null, 2, 1, 0, 4],
-    [addr1, token2, 1, 4, timelock, 1, 2, 0, 5],
-    [addr2, token1, 5, 2, null, 2, 2, 0, 20],
-    [addr2, token2, 0, 2, null, 1, 0, 0, 2],
-    [addr3, token1, 0, 1, null, 1, 0, 0, 1],
-    [addr3, token2, 10, 1, null, 1, 0, 0, 11],
-  ];
-
-  await addToAddressTxHistoryTable(mysql, historyEntries);
-  await addToAddressBalanceTable(mysql, addressEntries);
-
-  await initWalletBalance(mysql, walletId, [addr1, addr2]);
-
-  // check balance entries
-  await expect(checkWalletBalanceTable(mysql, 2, walletId, token1, 7n, 2n, null, 3, 3)).resolves.toBe(true);
-  await expect(checkWalletBalanceTable(mysql, 2, walletId, token2, 1n, 6n, timelock, 2, 2)).resolves.toBe(true);
 });
 
 test('updateWalletTablesWithTx', async () => {
@@ -3311,7 +3178,10 @@ describe('getTransactionById', () => {
       { address: addr1, txId: txId1, tokenId: token2.id, balance: 7n, timestamp: timestamp1 },
     ];
     await addToAddressTxHistoryTable(mysql, entries);
-    await initWalletTxHistory(mysql, walletId1, [addr1]);
+    await addToWalletTxHistoryTable(mysql, [
+      [walletId1, txId1, token1.id, 10n, timestamp1, false],
+      [walletId1, txId1, token2.id, 7n, timestamp1, false],
+    ]);
 
     const txTokens = await getTransactionById(mysql, txId1, walletId1);
 
@@ -4172,9 +4042,9 @@ describe('combined-load wallet helpers', () => {
     expect((await getWallet(mysql, wid)).lastUsedShieldedIndex).toBe(5);
   });
 
-  it('markWalletCombinedReady flips statuses and resets retry_count', async () => {
+  it('markWalletLoadReady flips statuses and resets retry_count', async () => {
     await mysql.query('UPDATE `wallet` SET `retry_count` = 3, `ct_status` = ? WHERE `id` = ?', ['creating', wid]);
-    await markWalletCombinedReady(mysql, wid, true);
+    await markWalletLoadReady(mysql, wid, true);
     let w = await getWallet(mysql, wid);
     expect(w.status).toBe(WalletStatus.READY);
     expect(w.ctStatus).toBe(WalletStatus.READY);
@@ -4182,20 +4052,20 @@ describe('combined-load wallet helpers', () => {
 
     // upgrade variant: transparent already ready and left alone
     await mysql.query('UPDATE `wallet` SET `retry_count` = 2, `ct_status` = ?, `ready_at` = 123 WHERE `id` = ?', ['creating', wid]);
-    await markWalletCombinedReady(mysql, wid, false);
+    await markWalletLoadReady(mysql, wid, false);
     w = await getWallet(mysql, wid);
     expect(w.ctStatus).toBe(WalletStatus.READY);
     expect(w.retryCount).toBe(0);
     expect(w.readyAt).toBe(123); // untouched
   });
 
-  it('markWalletCombinedError sets error states with an atomic retry bump', async () => {
-    await markWalletCombinedError(mysql, wid, true);
+  it('markWalletLoadError sets error states with an atomic retry bump', async () => {
+    await markWalletLoadError(mysql, wid, true);
     let w = await getWallet(mysql, wid);
     expect(w.status).toBe(WalletStatus.ERROR);
     expect(w.ctStatus).toBe(WalletStatus.ERROR);
     expect(w.retryCount).toBe(1);
-    await markWalletCombinedError(mysql, wid, false); // upgrade variant: transparent untouched
+    await markWalletLoadError(mysql, wid, false); // upgrade variant: transparent untouched
     w = await getWallet(mysql, wid);
     expect(w.retryCount).toBe(2);
   });

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -4,8 +4,13 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   addNewAddresses,
   addUtxos,
+  advanceLastUsedShieldedIndex,
+  casWalletErrorToCreating,
   createTxProposal,
   createWallet,
+  markWalletCombinedError,
+  markWalletCombinedReady,
+  upsertNewAddresses,
   generateAddresses,
   getAddressWalletInfo,
   getBlockByHeight,
@@ -4123,5 +4128,72 @@ describe('createWallet with shielded keys', () => {
 
     // the in-memory result matches what a subsequent getWallet reads back.
     expect(await getWallet(mysql, walletId)).toStrictEqual(ret);
+  });
+});
+
+describe('combined-load wallet helpers', () => {
+  const wid = 'combined-w';
+  beforeEach(async () => { await createWallet(mysql, wid, 'xpub', 'authxpub', 5); });
+
+  it('upsertNewAddresses tolerates pre-existing rows and never regresses last_used_address_index', async () => {
+    // daemon raced us: the row already exists, claimed, and the frontier moved to 7
+    await mysql.query('INSERT INTO `address` (`address`, `index`, `wallet_id`, `transactions`) VALUES (?, 1, ?, 2)', ['addr1', wid]);
+    await mysql.query('UPDATE `wallet` SET `last_used_address_index` = 7 WHERE `id` = ?', [wid]);
+    await upsertNewAddresses(mysql, wid, { addr0: 0, addr1: 1 }, 3); // stale frontier 3
+    const rows = await mysql.query('SELECT `address`, `transactions` FROM `address` ORDER BY `index`');
+    expect(rows).toHaveLength(2); // no dup-key crash
+    expect(Number(rows[1].transactions)).toBe(2); // untouched on duplicate
+    const w = await getWallet(mysql, wid);
+    expect(w.lastUsedAddressIndex).toBe(7); // GREATEST kept the newer frontier
+  });
+
+  it('advanceLastUsedShieldedIndex distinguishes NULL from 0 and never regresses', async () => {
+    expect((await getWallet(mysql, wid)).lastUsedShieldedIndex).toBeNull();
+    await advanceLastUsedShieldedIndex(mysql, wid, 0);
+    expect((await getWallet(mysql, wid)).lastUsedShieldedIndex).toBe(0);
+    await advanceLastUsedShieldedIndex(mysql, wid, 5);
+    await advanceLastUsedShieldedIndex(mysql, wid, 2); // stale write
+    expect((await getWallet(mysql, wid)).lastUsedShieldedIndex).toBe(5);
+  });
+
+  it('markWalletCombinedReady flips statuses and resets retry_count', async () => {
+    await mysql.query('UPDATE `wallet` SET `retry_count` = 3, `ct_status` = ? WHERE `id` = ?', ['creating', wid]);
+    await markWalletCombinedReady(mysql, wid, true);
+    let w = await getWallet(mysql, wid);
+    expect(w.status).toBe(WalletStatus.READY);
+    expect(w.ctStatus).toBe(WalletStatus.READY);
+    expect(w.retryCount).toBe(0);
+
+    // upgrade variant: transparent already ready and left alone
+    await mysql.query('UPDATE `wallet` SET `retry_count` = 2, `ct_status` = ?, `ready_at` = 123 WHERE `id` = ?', ['creating', wid]);
+    await markWalletCombinedReady(mysql, wid, false);
+    w = await getWallet(mysql, wid);
+    expect(w.ctStatus).toBe(WalletStatus.READY);
+    expect(w.retryCount).toBe(0);
+    expect(w.readyAt).toBe(123); // untouched
+  });
+
+  it('markWalletCombinedError sets error states with an atomic retry bump', async () => {
+    await markWalletCombinedError(mysql, wid, true);
+    let w = await getWallet(mysql, wid);
+    expect(w.status).toBe(WalletStatus.ERROR);
+    expect(w.ctStatus).toBe(WalletStatus.ERROR);
+    expect(w.retryCount).toBe(1);
+    await markWalletCombinedError(mysql, wid, false); // upgrade variant: transparent untouched
+    w = await getWallet(mysql, wid);
+    expect(w.retryCount).toBe(2);
+  });
+
+  it('casWalletErrorToCreating wins only from an error state', async () => {
+    expect(await casWalletErrorToCreating(mysql, wid)).toBe(false); // creating/none — nothing to flip
+    await mysql.query('UPDATE `wallet` SET `status` = ?, `ct_status` = ? WHERE `id` = ?', ['error', 'error', wid]);
+    expect(await casWalletErrorToCreating(mysql, wid)).toBe(true);
+    const w = await getWallet(mysql, wid);
+    expect(w.status).toBe(WalletStatus.CREATING);
+    expect(w.ctStatus).toBe(WalletStatus.CREATING);
+    // ct-only error also flips
+    await mysql.query('UPDATE `wallet` SET `status` = ?, `ct_status` = ? WHERE `id` = ?', ['ready', 'error', wid]);
+    expect(await casWalletErrorToCreating(mysql, wid)).toBe(true);
+    expect((await getWallet(mysql, wid)).status).toBe(WalletStatus.READY); // untouched
   });
 });

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -4104,13 +4104,29 @@ describe('registerWalletShieldedKeys', () => {
     const walletId = 'wsk-wallet';
     await createWallet(mysql, walletId, 'xpub', 'authxpub', 20);
 
-    await Db.registerWalletShieldedKeys(mysql, walletId, 'scanxprivstr', 'spendxpubstr', 15);
+    const attached = await Db.registerWalletShieldedKeys(mysql, walletId, 'scanxprivstr', 'spendxpubstr', 15);
 
+    expect(attached).toBe(true);
     const wallet = await getWallet(mysql, walletId);
     expect(wallet.scanXpriv).toBe('scanxprivstr');
     expect(wallet.spendXpub).toBe('spendxpubstr');
     expect(wallet.shieldedMaxGap).toBe(15);
     expect(wallet.ctStatus).toBe('creating');
+  });
+
+  it('does not overwrite keys that are already attached', async () => {
+    const walletId = 'wsk-wallet-cas';
+    await createWallet(mysql, walletId, 'xpub', 'authxpub', 20);
+    await Db.registerWalletShieldedKeys(mysql, walletId, 'firstscan', 'firstspend', 15);
+
+    const attached = await Db.registerWalletShieldedKeys(mysql, walletId, 'secondscan', 'secondspend', 20);
+
+    // The loser of the race reports false and leaves the winner's keys intact.
+    expect(attached).toBe(false);
+    const wallet = await getWallet(mysql, walletId);
+    expect(wallet.scanXpriv).toBe('firstscan');
+    expect(wallet.spendXpub).toBe('firstspend');
+    expect(wallet.shieldedMaxGap).toBe(15);
   });
 });
 

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -9,6 +9,7 @@ import {
   createWallet,
   markWalletLoadError,
   markWalletLoadReady,
+  markLegacyLoadError,
   upsertNewAddresses,
   generateAddresses,
   getAddressWalletInfo,
@@ -4043,12 +4044,13 @@ describe('combined-load wallet helpers', () => {
   });
 
   it('markWalletLoadReady flips statuses and resets retry_count', async () => {
-    await mysql.query('UPDATE `wallet` SET `retry_count` = 3, `ct_status` = ? WHERE `id` = ?', ['creating', wid]);
+    await mysql.query('UPDATE `wallet` SET `retry_count` = 3, `ct_status` = ?, `ready_at` = NULL WHERE `id` = ?', ['creating', wid]);
     await markWalletLoadReady(mysql, wid, true);
     let w = await getWallet(mysql, wid);
     expect(w.status).toBe(WalletStatus.READY);
     expect(w.ctStatus).toBe(WalletStatus.READY);
     expect(w.retryCount).toBe(0);
+    expect(w.readyAt).toEqual(expect.any(Number)); // fresh load stamps ready_at
 
     // upgrade variant: transparent already ready and left alone
     await mysql.query('UPDATE `wallet` SET `retry_count` = 2, `ct_status` = ?, `ready_at` = 123 WHERE `id` = ?', ['creating', wid]);
@@ -4060,13 +4062,64 @@ describe('combined-load wallet helpers', () => {
   });
 
   it('markWalletLoadError sets error states with an atomic retry bump', async () => {
+    // A shielded load is mid-flight on both sides — the state this helper runs in.
+    await mysql.query('UPDATE `wallet` SET `ct_status` = ? WHERE `id` = ?', ['creating', wid]);
     await markWalletLoadError(mysql, wid, true);
     let w = await getWallet(mysql, wid);
     expect(w.status).toBe(WalletStatus.ERROR);
     expect(w.ctStatus).toBe(WalletStatus.ERROR);
     expect(w.retryCount).toBe(1);
-    await markWalletLoadError(mysql, wid, false); // upgrade variant: transparent untouched
+    await markWalletLoadError(mysql, wid, false); // upgrade variant: legacy untouched
     w = await getWallet(mysql, wid);
+    expect(w.retryCount).toBe(2);
+  });
+
+  it('markWalletLoadError leaves an already-recovered wallet alone', async () => {
+    // A stale worker reports failure after a later attempt already succeeded:
+    // neither side may be demoted and the retry counter must not move.
+    await mysql.query(
+      'UPDATE `wallet` SET `status` = ?, `ct_status` = ?, `retry_count` = 0 WHERE `id` = ?',
+      ['ready', 'ready', wid],
+    );
+
+    await markWalletLoadError(mysql, wid, true);
+
+    const w = await getWallet(mysql, wid);
+    expect(w.status).toBe(WalletStatus.READY);
+    expect(w.ctStatus).toBe(WalletStatus.READY);
+    expect(w.retryCount).toBe(0);
+  });
+
+  it('markWalletLoadError pins only the shielded side when legacy already errored', async () => {
+    // status='error' / ct_status='ready' — the two legs move independently.
+    await mysql.query(
+      'UPDATE `wallet` SET `status` = ?, `ct_status` = ?, `retry_count` = 0 WHERE `id` = ?',
+      ['error', 'ready', wid],
+    );
+
+    await markWalletLoadError(mysql, wid, false);
+
+    const w = await getWallet(mysql, wid);
+    expect(w.status).toBe(WalletStatus.ERROR); // untouched
+    expect(w.ctStatus).toBe(WalletStatus.READY); // already ready -> not demoted
+    expect(w.retryCount).toBe(0); // guarded write matched nothing
+  });
+
+  it('markLegacyLoadError bumps retry atomically and never demotes a ready wallet', async () => {
+    await markLegacyLoadError(mysql, wid); // status='creating'
+    let w = await getWallet(mysql, wid);
+    expect(w.status).toBe(WalletStatus.ERROR);
+    expect(w.retryCount).toBe(1);
+
+    await markLegacyLoadError(mysql, wid); // retry of an errored wallet still counts
+    w = await getWallet(mysql, wid);
+    expect(w.retryCount).toBe(2);
+
+    // a stale attempt after recovery must not demote or bump
+    await mysql.query('UPDATE `wallet` SET `status` = ? WHERE `id` = ?', ['ready', wid]);
+    await markLegacyLoadError(mysql, wid);
+    w = await getWallet(mysql, wid);
+    expect(w.status).toBe(WalletStatus.READY);
     expect(w.retryCount).toBe(2);
   });
 

--- a/packages/wallet-service/tests/loadWallet.test.ts
+++ b/packages/wallet-service/tests/loadWallet.test.ts
@@ -203,6 +203,26 @@ describe('loadWallet', () => {
     spy.mockRestore();
   }, COMBINED_TEST_TIMEOUT_MS);
 
+  it('rolls the settle back when the ready flip fails', async () => {
+    // The rebuild and the ready flip share one transaction so the daemon never
+    // sees totals without READY (or READY without totals). If the flip throws,
+    // the rebuild it was grouped with must roll back too.
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP, { scanXpriv, spendXpub, shieldedMaxGap: SHIELDED_GAP });
+    await seedShieldedOutputAt(0, 'ctxS', 0xaa, 500n);
+    const spy = jest.spyOn(Db, 'markWalletLoadReady').mockRejectedValueOnce(new Error('ready boom'));
+
+    const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result).toMatchObject({ success: false });
+
+    // No wallet totals survived the rollback...
+    const wb = await mysql.query('SELECT COUNT(*) AS c FROM `wallet_balance` WHERE `wallet_id` = ?', [walletId]);
+    expect(Number((wb as { c: number }[])[0].c)).toBe(0);
+    // ...and the wallet is not left looking loaded.
+    const w = await getWallet(mysql, walletId);
+    expect(w.status).not.toBe(WalletStatus.READY);
+    spy.mockRestore();
+  }, COMBINED_TEST_TIMEOUT_MS);
+
   it('the settle drain recovers an output that lands between the two sweeps', async () => {
     // Pins the second findAndRewindShielded: simulate a daemon ingest that writes
     // an unowned output for a claimed CTSpend address AFTER the first sweep. Only

--- a/packages/wallet-service/tests/loadWallet.test.ts
+++ b/packages/wallet-service/tests/loadWallet.test.ts
@@ -21,6 +21,8 @@ import {
 } from '@tests/utils';
 import { resetCtCryptoMock, primeAmountRewind } from '@tests/utils/ct-crypto-mock';
 import { loadWallet } from '@src/api/wallet';
+import * as ShieldedRecovery from '@src/shieldedRecovery';
+import * as ShieldedDb from '@src/db/shielded';
 import * as Db from '@src/db';
 import { createWallet, getWallet, updateWalletStatus } from '@src/db';
 import { DbSelectResult, WalletStatus } from '@src/types';
@@ -122,15 +124,20 @@ describe('loadWallet', () => {
   it('is idempotent: a second run converges without double-crediting', async () => {
     await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP, { scanXpriv, spendXpub, shieldedMaxGap: SHIELDED_GAP });
     await seedShieldedOutputAt(0, 'ctx2', 0xb2, 700n);
+    // A transparent receive on a legacy address, so the re-load also can't
+    // double-credit the transparent side.
+    await addToAddressTxHistoryTable(mysql, [{ address: ADDRESSES[0], txId: 'ptx2', tokenId: '00', balance: 250n, timestamp: 10 }]);
+    await addToAddressBalanceTable(mysql, [[ADDRESSES[0], '00', 250, 0, null, 1, 0, 0, 250]]);
 
     await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
     const result2 = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
     expect(result2).toMatchObject({ success: true });
 
     const wb = (await mysql.query(
-      "SELECT `unlocked_shielded_balance` AS usb FROM `wallet_balance` WHERE `wallet_id` = ? AND `token_id` = '00'", [walletId],
+      "SELECT `unlocked_balance` AS ub, `unlocked_shielded_balance` AS usb FROM `wallet_balance` WHERE `wallet_id` = ? AND `token_id` = '00'", [walletId],
     ))[0];
-    expect(String(wb.usb)).toBe('700'); // not 1400
+    expect(String(wb.usb)).toBe('700'); // shielded not 1400
+    expect(String(wb.ub)).toBe('250'); // transparent not 500
 
     const w = await getWallet(mysql, walletId);
     expect(w.status).toBe(WalletStatus.READY);
@@ -165,6 +172,52 @@ describe('loadWallet', () => {
     expect(w.status).toBe(WalletStatus.ERROR);
     expect(w.ctStatus).toBe(WalletStatus.ERROR);
     expect(w.retryCount).toBe(1);
+  }, COMBINED_TEST_TIMEOUT_MS);
+
+  it('rolls the claim back and marks error when ownership upsert fails', async () => {
+    // The failure lands inside the claim transaction (after the transparent
+    // upsert), exercising the rollback branch — not the pre-transaction path the
+    // other failure test hits.
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP, { scanXpriv, spendXpub, shieldedMaxGap: SHIELDED_GAP });
+    await seedShieldedOutputAt(0, 'ctx3', 0xc3, 500n);
+    const spy = jest.spyOn(ShieldedDb, 'upsertShieldedAddressOwnership').mockRejectedValueOnce(new Error('claim boom'));
+
+    const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result).toMatchObject({ success: false });
+
+    // Nothing from the claim survived: no CTSpend rows were committed.
+    const ctRows = await mysql.query(
+      'SELECT COUNT(*) AS c FROM `address` WHERE `wallet_id` = ? AND `bip32_account` = ?', [walletId, Bip32Account.CTSpend],
+    );
+    expect(Number(ctRows[0].c)).toBe(0);
+    const w = await getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.ERROR);
+    expect(w.ctStatus).toBe(WalletStatus.ERROR);
+    spy.mockRestore();
+  }, COMBINED_TEST_TIMEOUT_MS);
+
+  it('the settle drain recovers an output that lands between the two sweeps', async () => {
+    // Pins the second findAndRewindShielded: simulate a daemon ingest that writes
+    // an unowned output for a claimed CTSpend address AFTER the first sweep. Only
+    // the second sweep can recover it — deleting that sweep would drop it.
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP, { scanXpriv, spendXpub, shieldedMaxGap: SHIELDED_GAP });
+    const realRewind = ShieldedRecovery.findAndRewindShielded;
+    let calls = 0;
+    const spy = jest.spyOn(ShieldedRecovery, 'findAndRewindShielded').mockImplementation(async (...args) => {
+      calls += 1;
+      if (calls === 1) {
+        await seedShieldedOutputAt(1, 'ctxLate', 0xd4, 900n); // lands after the claim, before sweep 2
+      }
+      return realRewind(...args);
+    });
+
+    const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result).toMatchObject({ success: true });
+    expect(spy).toHaveBeenCalledTimes(2);
+    const out = (await mysql.query("SELECT `recovery_state`, `value` FROM `tx_output` WHERE `tx_id` = 'ctxLate'"))[0];
+    expect(out.recovery_state).toBe('recovered'); // only the second sweep could have done this
+    expect(String(out.value)).toBe('900');
+    spy.mockRestore();
   }, COMBINED_TEST_TIMEOUT_MS);
 
   it('behaves as a transparent-only load for a wallet without shielded keys', async () => {

--- a/packages/wallet-service/tests/loadWallet.test.ts
+++ b/packages/wallet-service/tests/loadWallet.test.ts
@@ -185,11 +185,18 @@ describe('loadWallet', () => {
     const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
     expect(result).toMatchObject({ success: false });
 
-    // Nothing from the claim survived: no CTSpend rows were committed.
+    // Nothing from the claim survived. The CTSpend upsert threw, so proving
+    // rollback means checking the *legacy* upsert that ran before it in the same
+    // transaction left no claimed rows.
     const ctRows = await mysql.query(
       'SELECT COUNT(*) AS c FROM `address` WHERE `wallet_id` = ? AND `bip32_account` = ?', [walletId, Bip32Account.CTSpend],
     );
     expect(Number(ctRows[0].c)).toBe(0);
+    const legacyRows = await mysql.query(
+      'SELECT COUNT(*) AS c FROM `address` WHERE `wallet_id` = ? AND (`bip32_account` IS NULL OR `bip32_account` = ?)',
+      [walletId, Bip32Account.Legacy],
+    );
+    expect(Number(legacyRows[0].c)).toBe(0); // legacy claim rolled back too
     const w = await getWallet(mysql, walletId);
     expect(w.status).toBe(WalletStatus.ERROR);
     expect(w.ctStatus).toBe(WalletStatus.ERROR);
@@ -205,10 +212,12 @@ describe('loadWallet', () => {
     let calls = 0;
     const spy = jest.spyOn(ShieldedRecovery, 'findAndRewindShielded').mockImplementation(async (...args) => {
       calls += 1;
+      const result = await realRewind(...args); // run the real sweep first...
       if (calls === 1) {
-        await seedShieldedOutputAt(1, 'ctxLate', 0xd4, 900n); // lands after the claim, before sweep 2
+        // ...then land the raced output, so only the second sweep can see it.
+        await seedShieldedOutputAt(1, 'ctxLate', 0xd4, 900n);
       }
-      return realRewind(...args);
+      return result;
     });
 
     const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });

--- a/packages/wallet-service/tests/loadWallet.test.ts
+++ b/packages/wallet-service/tests/loadWallet.test.ts
@@ -15,9 +15,13 @@ import { mockedAddAlert } from '@tests/utils/alerting.utils.mock';
 import { Bip32Account } from '@wallet-service/common';
 import { deriveCtAddress } from '@wallet-service/common/src/crypto/shieldedAddress';
 import { getDbConnection, getWalletId, closeDbConnection } from '@src/utils';
-import { cleanDatabase, XPUBKEY, AUTH_XPUBKEY } from '@tests/utils';
+import {
+  cleanDatabase, XPUBKEY, AUTH_XPUBKEY, ADDRESSES,
+  addToAddressTxHistoryTable, addToAddressBalanceTable, checkWalletBalanceTable,
+} from '@tests/utils';
 import { resetCtCryptoMock, primeAmountRewind } from '@tests/utils/ct-crypto-mock';
-import { loadWalletCombined } from '@src/api/wallet';
+import { loadWallet } from '@src/api/wallet';
+import * as Db from '@src/db';
 import { createWallet, getWallet, updateWalletStatus } from '@src/db';
 import { DbSelectResult, WalletStatus } from '@src/types';
 
@@ -62,7 +66,7 @@ const seedShieldedOutputAt = async (index: number, txId: string, marker: number,
 };
 
 const runWorker = (event: Record<string, unknown>) => (
-  loadWalletCombined(event as never, null as never, null as never)
+  loadWallet(event as never, null as never, null as never)
 );
 
 beforeEach(async () => {
@@ -75,7 +79,7 @@ afterAll(async () => {
   await closeDbConnection(mysql);
 });
 
-describe('loadWalletCombined', () => {
+describe('loadWallet', () => {
   it('loads a fresh shielded wallet end-to-end: claims, recovers, credits, flips ready', async () => {
     await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP, { scanXpriv, spendXpub, shieldedMaxGap: SHIELDED_GAP });
     await seedShieldedOutputAt(2, 'ctx1', 0xa1, 1500n);
@@ -175,6 +179,72 @@ describe('loadWalletCombined', () => {
       'SELECT COUNT(*) AS c FROM `address` WHERE `wallet_id` = ? AND `bip32_account` = ?', [walletId, Bip32Account.CTSpend],
     ))[0];
     expect(Number(ctCount.c)).toBe(0);
+  }, COMBINED_TEST_TIMEOUT_MS);
+
+  it('reconstructs transparent balance and history for a wallet without shielded keys', async () => {
+    // Golden parity check for the transparent-only path, standing in for the
+    // deleted deprecated load: seed real derived addresses with multi-token,
+    // voided, and cross-address-shared-tx activity, then assert exact
+    // wallet_balance / wallet_tx_history output.
+    const T_HTR = '00';
+    const T_B = 'aa';
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP);
+
+    await addToAddressTxHistoryTable(mysql, [
+      // ptxA is shared across two of the wallet's addresses (same token) — the
+      // wallet-level row must SUM them and count the tx once.
+      { address: ADDRESSES[0], txId: 'ptxA', tokenId: T_HTR, balance: 100n, timestamp: 10 },
+      { address: ADDRESSES[1], txId: 'ptxA', tokenId: T_HTR, balance: 50n, timestamp: 10 },
+      { address: ADDRESSES[0], txId: 'ptxB', tokenId: T_HTR, balance: -30n, timestamp: 20 },
+      // ptxC is voided — must be excluded from balance, tx count, and history.
+      { address: ADDRESSES[0], txId: 'ptxC', tokenId: T_HTR, balance: 999n, timestamp: 25, voided: true },
+      { address: ADDRESSES[1], txId: 'ptxD', tokenId: T_B, balance: 7n, timestamp: 40 },
+    ]);
+    await addToAddressBalanceTable(mysql, [
+      // address, token, unlocked, locked, timelock, transactions, uAuth, lAuth, total_received
+      [ADDRESSES[0], T_HTR, 70, 0, null, 2, 0, 0, 100],
+      [ADDRESSES[1], T_HTR, 50, 0, null, 1, 0, 0, 50],
+      [ADDRESSES[1], T_B, 7, 0, null, 1, 0, 0, 7],
+    ]);
+
+    const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result).toMatchObject({ success: true, walletId });
+
+    const w = await getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.READY);
+    expect(w.ctStatus).toBe('none');
+
+    // wallet_balance: summed per token across the wallet's addresses; tx count is
+    // DISTINCT non-voided tx_id from history (ptxC excluded).
+    expect(await checkWalletBalanceTable(mysql, 2, walletId, T_HTR, 120n, 0n, null, 2)).toBe(true);
+    expect(await checkWalletBalanceTable(mysql, 2, walletId, T_B, 7n, 0n, null, 1)).toBe(true);
+    const balances: DbSelectResult = await mysql.query(
+      'SELECT `token_id`, `total_received` FROM `wallet_balance` WHERE `wallet_id` = ? ORDER BY `token_id`', [walletId],
+    );
+    expect(balances.map((r) => [r.token_id, String(r.total_received)])).toEqual([[T_HTR, '150'], [T_B, '7']]);
+
+    // wallet_tx_history: one row per (tx_id, token); voided tx absent.
+    const history: DbSelectResult = await mysql.query(
+      'SELECT `tx_id`, `token_id`, `balance`, `timestamp` FROM `wallet_tx_history` WHERE `wallet_id` = ? ORDER BY `timestamp`, `token_id`',
+      [walletId],
+    );
+    expect(history.map((r) => [r.tx_id, r.token_id, String(r.balance), Number(r.timestamp)])).toEqual([
+      ['ptxA', T_HTR, '150', 10],
+      ['ptxB', T_HTR, '-30', 20],
+      ['ptxD', T_B, '7', 40],
+    ]);
+  }, COMBINED_TEST_TIMEOUT_MS);
+
+  it('marks a transparent-only wallet error and bumps retryCount on load failure', async () => {
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP);
+    const spy = jest.spyOn(Db, 'generateAddresses').mockRejectedValueOnce(new Error('derivation boom'));
+
+    const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result).toMatchObject({ success: false });
+    const w = await getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.ERROR);
+    expect(w.retryCount).toBe(1);
+    spy.mockRestore();
   }, COMBINED_TEST_TIMEOUT_MS);
 
   it('short-circuits warmup events', async () => {

--- a/packages/wallet-service/tests/loadWalletCombined.test.ts
+++ b/packages/wallet-service/tests/loadWalletCombined.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { ServerlessMysql } from 'serverless-mysql';
+import BIP32Factory from 'bip32';
+import * as ecc from 'tiny-secp256k1';
+import { Network } from '@hathor/wallet-lib';
+// Mocks the alerting module by resolved file, so both the worker's subpath
+// import and the recovery engine's barrel import land on the same stub.
+import { mockedAddAlert } from '@tests/utils/alerting.utils.mock';
+import { Bip32Account } from '@wallet-service/common';
+import { deriveCtAddress } from '@wallet-service/common/src/crypto/shieldedAddress';
+import { getDbConnection, getWalletId, closeDbConnection } from '@src/utils';
+import { cleanDatabase, XPUBKEY, AUTH_XPUBKEY } from '@tests/utils';
+import { resetCtCryptoMock, primeAmountRewind } from '@tests/utils/ct-crypto-mock';
+import { loadWalletCombined } from '@src/api/wallet';
+import { createWallet, getWallet, updateWalletStatus } from '@src/db';
+import { DbSelectResult, WalletStatus } from '@src/types';
+
+const mysql: ServerlessMysql = getDbConnection();
+const COMBINED_TEST_TIMEOUT_MS = 30000; // real BIP32 derivation across gap blocks is slow
+
+const bip32lib = BIP32Factory(ecc);
+const root = bip32lib.fromSeed(Buffer.from('03'.repeat(32), 'hex'));
+const scanXpriv = root.derivePath("m/44'/280'/1'/0").toBase58();
+const spendXpub = root.derivePath("m/44'/280'/2'/0").neutered().toBase58();
+const net = new Network(process.env.NETWORK as string);
+const derivedAt = (i: number) => deriveCtAddress(scanXpriv, spendXpub, i, net);
+
+const walletId = getWalletId(XPUBKEY);
+const MAX_GAP = 5;      // transparent gap for the test event
+const SHIELDED_GAP = 5; // wallet.shielded_max_gap
+
+const seedShieldedOutputAt = async (index: number, txId: string, marker: number, value: bigint) => {
+  const { spendAddress } = derivedAt(index);
+  await mysql.query(
+    `INSERT INTO \`tx_output\`
+       (\`tx_id\`, \`index\`, \`address\`, \`value\`, \`token_id\`, \`authorities\`,
+        \`timelock\`, \`heightlock\`, \`locked\`, \`voided\`, \`mode\`, \`recovery_state\`)
+     VALUES (?, 0, ?, NULL, '00', 0, NULL, NULL, FALSE, FALSE, 1, 'unowned')`,
+    [txId, spendAddress],
+  );
+  await mysql.query(
+    `INSERT INTO \`shielded_tx_output_data\`
+       (\`tx_id\`, \`index\`, \`commitment\`, \`range_proof\`, \`script\`, \`ephemeral_pubkey\`, \`asset_commitment\`)
+     VALUES (?, 0, ?, ?, ?, ?, NULL)`,
+    [txId, Buffer.alloc(33, marker), Buffer.alloc(8), Buffer.alloc(1), Buffer.alloc(33, marker)],
+  );
+  await mysql.query(
+    'INSERT INTO `transaction` (`tx_id`, `timestamp`, `version`, `voided`) VALUES (?, 1000, 1, FALSE)', [txId],
+  );
+  primeAmountRewind({
+    commitment: Buffer.alloc(33, marker),
+    ephemeralPubkey: Buffer.alloc(33, marker),
+    value,
+    tokenUid: Buffer.from('00', 'hex'),
+  });
+};
+
+const runWorker = (event: Record<string, unknown>) => (
+  loadWalletCombined(event as never, null as never, null as never)
+);
+
+beforeEach(async () => {
+  await cleanDatabase(mysql);
+  resetCtCryptoMock();
+  mockedAddAlert.mockClear();
+});
+
+afterAll(async () => {
+  await closeDbConnection(mysql);
+});
+
+describe('loadWalletCombined', () => {
+  it('loads a fresh shielded wallet end-to-end: claims, recovers, credits, flips ready', async () => {
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP, { scanXpriv, spendXpub, shieldedMaxGap: SHIELDED_GAP });
+    await seedShieldedOutputAt(2, 'ctx1', 0xa1, 1500n);
+
+    const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result).toMatchObject({ success: true, walletId });
+
+    // shielded window claimed: usage at 2 -> rows 0..7, all done, real keys stored
+    const ctRows: DbSelectResult = await mysql.query(
+      'SELECT `index`, `catchup_state`, `ct_address`, `scan_privkey` FROM `address` WHERE `wallet_id` = ? AND `bip32_account` = ? ORDER BY `index`',
+      [walletId, Bip32Account.CTSpend],
+    );
+    expect(ctRows).toHaveLength(2 + SHIELDED_GAP + 1);
+    expect(ctRows.every((r) => r.catchup_state === 'done')).toBe(true);
+    expect(ctRows[2].ct_address).toBe(derivedAt(2).ctAddress);
+    expect(Buffer.from(ctRows[2].scan_privkey as Buffer).equals(derivedAt(2).scanPrivkey)).toBe(true);
+
+    // output recovered and credited to the wallet's shielded balance
+    const out = (await mysql.query('SELECT `recovery_state`, `value` FROM `tx_output` WHERE `tx_id` = ?', ['ctx1']))[0];
+    expect(out.recovery_state).toBe('recovered');
+    expect(String(out.value)).toBe('1500');
+    const wb = (await mysql.query(
+      "SELECT `unlocked_shielded_balance` AS usb FROM `wallet_balance` WHERE `wallet_id` = ? AND `token_id` = '00'", [walletId],
+    ))[0];
+    expect(String(wb.usb)).toBe('1500');
+
+    // wallet finalized
+    const w = await getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.READY);
+    expect(w.ctStatus).toBe(WalletStatus.READY);
+    expect(w.retryCount).toBe(0);
+    expect(w.lastUsedShieldedIndex).toBe(2);
+    // transparent window claimed too (no transparent usage -> maxGap rows)
+    const tCount = (await mysql.query(
+      'SELECT COUNT(*) AS c FROM `address` WHERE `wallet_id` = ? AND (`bip32_account` IS NULL OR `bip32_account` = 0)', [walletId],
+    ))[0];
+    expect(Number(tCount.c)).toBe(MAX_GAP);
+  }, COMBINED_TEST_TIMEOUT_MS);
+
+  it('is idempotent: a second run converges without double-crediting', async () => {
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP, { scanXpriv, spendXpub, shieldedMaxGap: SHIELDED_GAP });
+    await seedShieldedOutputAt(0, 'ctx2', 0xb2, 700n);
+
+    await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    const result2 = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result2).toMatchObject({ success: true });
+
+    const wb = (await mysql.query(
+      "SELECT `unlocked_shielded_balance` AS usb FROM `wallet_balance` WHERE `wallet_id` = ? AND `token_id` = '00'", [walletId],
+    ))[0];
+    expect(String(wb.usb)).toBe('700'); // not 1400
+
+    const w = await getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.READY);
+    expect(w.ctStatus).toBe(WalletStatus.READY);
+  }, COMBINED_TEST_TIMEOUT_MS);
+
+  it('keeps the transparent side untouched when a shielded upgrade fails', async () => {
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP);
+    await updateWalletStatus(mysql, walletId, WalletStatus.READY);
+    // register keys, then corrupt the stored scan xpriv so derivation throws
+    await mysql.query(
+      'UPDATE `wallet` SET `scan_xpriv` = ?, `spend_xpub` = ?, `shielded_max_gap` = ?, `ct_status` = ? WHERE `id` = ?',
+      [Buffer.from('not-a-valid-xpriv', 'utf8'), spendXpub, SHIELDED_GAP, 'creating', walletId],
+    );
+
+    const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result).toMatchObject({ success: false });
+
+    const w = await getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.READY);   // upgrade: untouched
+    expect(w.ctStatus).toBe(WalletStatus.ERROR);
+    expect(w.retryCount).toBe(1);
+    expect(mockedAddAlert).toHaveBeenCalled();   // caught failures alert
+  }, COMBINED_TEST_TIMEOUT_MS);
+
+  it('marks both sides on a fresh-load failure', async () => {
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP, { scanXpriv: 'garbage', spendXpub, shieldedMaxGap: SHIELDED_GAP });
+
+    const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result).toMatchObject({ success: false });
+    const w = await getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.ERROR);
+    expect(w.ctStatus).toBe(WalletStatus.ERROR);
+    expect(w.retryCount).toBe(1);
+  }, COMBINED_TEST_TIMEOUT_MS);
+
+  it('behaves as a transparent-only load for a wallet without shielded keys', async () => {
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, MAX_GAP);
+
+    const result = await runWorker({ xpubkey: XPUBKEY, maxGap: MAX_GAP });
+    expect(result).toMatchObject({ success: true });
+    const w = await getWallet(mysql, walletId);
+    expect(w.status).toBe(WalletStatus.READY);
+    expect(w.ctStatus).toBe('none'); // no fabricated shielded lifecycle
+    const ctCount = (await mysql.query(
+      'SELECT COUNT(*) AS c FROM `address` WHERE `wallet_id` = ? AND `bip32_account` = ?', [walletId, Bip32Account.CTSpend],
+    ))[0];
+    expect(Number(ctCount.c)).toBe(0);
+  }, COMBINED_TEST_TIMEOUT_MS);
+
+  it('short-circuits warmup events', async () => {
+    const r = await runWorker({ source: 'serverless-plugin-warmup' });
+    expect(r).toMatchObject({ success: true, walletId: '' });
+  });
+});

--- a/packages/wallet-service/tests/reconstructWallet.test.ts
+++ b/packages/wallet-service/tests/reconstructWallet.test.ts
@@ -225,4 +225,28 @@ describe('reconstructWallet', () => {
     ))[0];
     expect(String(wbB.usb)).toBe('42'); // recovered token -> second GROUP BY token_id row
   });
+
+  it('folds a fully-shielded HTR output onto the canonical "00" token row', async () => {
+    await seedWallet('w1');
+    await seedCtSpendAddress('ca', 'w1', 0);
+    await insertTx('h1', 800);
+    await insertTx('h2', 810);
+    // A transparent/amount-shielded HTR receive and a fully-shielded HTR receive
+    // must land on the SAME token_id '00' row, not a separate all-zero-uid row.
+    await insertUnownedOutput('h1', 'ca', '00', 1); // mode-1 HTR
+    await insertSatellite('h1', Buffer.alloc(33, 0xe1), Buffer.alloc(33, 0xe1));
+    await insertUnownedOutput('h2', 'ca', null, 2); // mode-2 HTR — token from the rewind
+    await insertSatellite('h2', Buffer.alloc(33, 0xe2), Buffer.alloc(33, 0xe2), Buffer.alloc(33, 0xf2));
+    primeAmountRewind({ commitment: Buffer.alloc(33, 0xe1), ephemeralPubkey: Buffer.alloc(33, 0xe1), value: 100n, tokenUid: Buffer.from('00', 'hex') });
+    // The native token's raw on-chain uid is 32 zero bytes.
+    primeFullyRewind({ commitment: Buffer.alloc(33, 0xe2), ephemeralPubkey: Buffer.alloc(33, 0xe2), value: 42n, tokenUid: Buffer.alloc(32, 0), assetCommitment: Buffer.alloc(33, 0xf2) });
+
+    expect(await reconstructWallet(mysql, 'w1', [], ['ca'], logger)).toEqual({ recovered: 2, failed: 0 });
+
+    // Both receives fold onto the single '00' row: 100 + 42 = 142.
+    expect(String((await readWalletBalance('w1')).usb)).toBe('142');
+    const rows = await mysql.query("SELECT `token_id` FROM `wallet_balance` WHERE `wallet_id` = 'w1'");
+    expect(rows).toHaveLength(1); // no stray all-zero-uid token row
+    expect((rows as { token_id: string }[])[0].token_id).toBe('00');
+  });
 });

--- a/packages/wallet-service/tests/txById.test.ts
+++ b/packages/wallet-service/tests/txById.test.ts
@@ -3,13 +3,14 @@ import {
 } from '@src/api/txById';
 import { TokenVersion } from '@hathor/wallet-lib';
 import { closeDbConnection, getDbConnection } from '@src/utils';
-import { addOrUpdateTx, createWallet, initWalletTxHistory } from '@src/db';
+import { addOrUpdateTx, createWallet } from '@src/db';
 import {
   makeGatewayEventWithAuthorizer,
   cleanDatabase,
   XPUBKEY,
   AUTH_XPUBKEY,
   addToAddressTxHistoryTable,
+  addToWalletTxHistoryTable,
   addToTokenTable,
 } from '@tests/utils';
 import { APIGatewayProxyResult } from 'aws-lambda';
@@ -49,7 +50,10 @@ test('get a transaction given its ID', async () => {
     { address: addr1, txId: txId1, tokenId: token2.id, balance: 7n, timestamp: timestamp1 },
   ];
   await addToAddressTxHistoryTable(mysql, entries);
-  await initWalletTxHistory(mysql, walletId1, [addr1]);
+  await addToWalletTxHistoryTable(mysql, [
+    [walletId1, txId1, token1.id, 10n, timestamp1, false],
+    [walletId1, txId1, token2.id, 7n, timestamp1, false],
+  ]);
 
   const event = makeGatewayEventWithAuthorizer(walletId1, {
     txId: txId1,


### PR DESCRIPTION
## Summary

Implements `loadWalletCombined` — the canonical async wallet-load Lambda — replacing the stub PR #474 left behind. It derives both the transparent and shielded (CTSpend) address paths, claims ownership rows, runs `reconstructWallet` to rebuild both balances, and flips the wallet to ready.

The worker mirrors the transparent `loadWallet` template:

1. **Read-only derivation** — transparent `generateAddresses` plus a new shielded gap loop that infers usage from observed `tx_output` rows (no rewinding). Already-claimed rows are reused from storage, so a retry re-derives nothing.
2. **One short claim transaction** — upsert address ownership + advance the frontier indices.
3. **`reconstructWallet` outside any transaction** — it internally rewinds owned outputs and rebuilds the balance/history tables; idempotent by recompute, and must not hold locks while doing crypto + paged UPDATEs.
4. **A settle rewind pass** — closes the claim-visibility race against in-flight daemon ingests.
5. **Status flips.**



## Acceptance criteria

- **Fresh load** — a new shielded wallet claims rows, recovers, credits balances, and flips both sides ready.
- **Upgrade** — a shielded upgrade to an already-READY transparent wallet leaves the transparent side untouched.
- **Idempotent retry** — a second run converges without double-crediting.
- **Error handling** — a fresh-load failure marks both sides; an upgrade failure pins only the shielded side.
- **Transparent-only** — a wallet without shielded keys behaves exactly as before.
- **Gap invariant** — the derivation window extends past chained usage; a transparent (mode 0) output to a shielded spend address counts as usage; voided outputs do not.
- **Daemon partition** — transparent gap math ignores CTSpend rows. The CT index pair the unified query now returns is intentionally unconsumed (daemon-side shielded gap extension is a follow-up).

## Follow-ups (explicit non-goals)

- Daemon live shielded gap-extension — will consume the CT index pair (`maxCtWalletIndex`/`maxCtAmongAddresses`) this PR's unified query already returns, plus `last_used_shielded_index` advancement on recovery and a daemon-side claim upsert.
- The post-`ready` re-drive sweep — must key on `tx_output.recovery_state` joined to claimed CTSpend rows, **not** on `catchup_state`.
- `shielded-catchup-complete` realtime event.
- Real ct-crypto provider wiring — blocked on a `@hathor/ct-crypto-node` release that bundles a provider.
- Spend-side history for pre-registration spends — accepted-wrong; balances remain correct.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet loading now follows a single unified async flow to rebuild both transparent (legacy) and shielded (CTSpend) balances, address windows, and transaction history.
  * Added CTSpend address discovery with per-index ownership tracking and catch-up completion.

* **Bug Fixes**
  * Transparent gap-extension now derives strictly from legacy index tracking (CTSpend progress no longer affects it).
  * Wallet “max index” calculations are partitioned by legacy vs CTSpend, preventing cross-impact.
  * Improved concurrency-safe load retries/state transitions to avoid demotion and double-crediting, including clearer legacy vs shielded error pinning.
  * Canonicalized shielded token IDs to prevent duplicate “all-zero” token rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->