### PR TITLE
feat(shielded-outputs): shielded balances, history, utxos and addresses on wallet API

### DIFF
--- a/packages/daemon/__tests__/db/index.test.ts
+++ b/packages/daemon/__tests__/db/index.test.ts
@@ -74,7 +74,7 @@ import {
   createOutput,
   XPUBKEY,
 } from '../utils';
-import { isAuthority } from '@wallet-service/common';
+import { isAuthority, Bip32Account } from '@wallet-service/common';
 import { DbTxOutput, StringMap, TokenInfo, WalletStatus } from '../../src/types';
 import { Authorities, TokenBalanceMap } from '@wallet-service/common';
 import { constants, TokenVersion } from '@hathor/wallet-lib';
@@ -976,6 +976,10 @@ describe('address and wallet related tests', () => {
     for (const [index, address] of ADDRESSES.entries()) {
       await expect(checkAddressTable(mysql, ADDRESSES.length, address, index, walletId, 0)).resolves.toBe(true);
     }
+
+    // claimed legacy addresses carry an explicit account (never NULL)
+    const [accountRows] = await mysql.query('SELECT DISTINCT `bip32_account` FROM `address`');
+    expect((accountRows as Array<{ bip32_account: number }>).map((row) => Number(row.bip32_account))).toStrictEqual([Bip32Account.Legacy]);
   });
 
   test('updateWalletTablesWithTx', async () => {

--- a/packages/daemon/src/db/index.ts
+++ b/packages/daemon/src/db/index.ts
@@ -1867,11 +1867,13 @@ export const addNewAddresses = async (
   if (Object.keys(addresses).length === 0) return;
   const entries = [];
   for (const [address, index] of Object.entries(addresses)) {
-    entries.push([address, index, walletId, 0]);
+    // Claimed legacy addresses carry an explicit account: an owned address never
+    // has a NULL bip32_account.
+    entries.push([address, index, walletId, 0, Bip32Account.Legacy]);
   }
   await mysql.query(
     `INSERT INTO \`address\`(\`address\`, \`index\`,
-                             \`wallet_id\`, \`transactions\`)
+                             \`wallet_id\`, \`transactions\`, \`bip32_account\`)
      VALUES ?`,
     [entries],
   );

--- a/packages/wallet-service/src/api/addresses.ts
+++ b/packages/wallet-service/src/api/addresses.ts
@@ -22,6 +22,7 @@ import { walletIdProxyHandler } from '@src/commons';
 import middy from '@middy/core';
 import cors from '@middy/http-cors';
 import errorHandler from '@src/api/middlewares/errorHandler';
+import { Bip32Account } from '@wallet-service/common';
 
 const mysql = getDbConnection();
 
@@ -32,11 +33,13 @@ const checkMineBodySchema = Joi.object({
     .min(1)
     .max(512) // max number of addresses in a tx (256 outputs and 256 inputs)
     .required(),
+  legacy: Joi.boolean().default(true),
 });
 
 class AddressAtIndexValidator {
   static readonly bodySchema = Joi.object({
     index: Joi.number().min(0).optional(),
+    legacy: Joi.boolean().default(true),
   });
 
   static validate(payload: unknown): { value: AddressAtIndexRequest, error: ValidationError } {
@@ -87,7 +90,8 @@ export const checkMine: APIGatewayProxyHandler = middy(walletIdProxyHandler(asyn
   }
 
   const sentAddresses = value.addresses;
-  const dbWalletAddresses: AddressInfo[] = await getWalletAddresses(mysql, walletId, sentAddresses);
+  const account = value.legacy ? Bip32Account.Legacy : Bip32Account.CTSpend;
+  const dbWalletAddresses: AddressInfo[] = await getWalletAddresses(mysql, walletId, sentAddresses, account);
   const walletAddresses: Set<string> = dbWalletAddresses.reduce((acc, { address }) => acc.add(address), new Set([]));
 
   await closeDbConnection(mysql);
@@ -107,6 +111,18 @@ export const checkMine: APIGatewayProxyHandler = middy(walletIdProxyHandler(asyn
   };
 })).use(cors())
   .use(errorHandler());
+
+// The default (legacy) response shape must stay byte-identical to what the
+// API returned before the shielded columns existed, so we build entries
+// explicitly instead of returning the internal AddressInfo shape as-is.
+// `ct_address` is only surfaced on CTSpend (legacy=false) entries.
+const toAddressResponse = (address: AddressInfo, legacy: boolean): Record<string, unknown> => ({
+  address: address.address,
+  index: address.index,
+  transactions: address.transactions,
+  seqnum: address.seqnum,
+  ...(legacy ? {} : { ct_address: address.ctAddress }),
+});
 
 /**
  * Get the addresses of a wallet, allowing an index filter
@@ -138,10 +154,12 @@ export const get: APIGatewayProxyHandler = middy(
       return closeDbAndGetError(mysql, ApiError.INVALID_PAYLOAD, { details });
     }
 
+    const account = body.legacy ? Bip32Account.Legacy : Bip32Account.CTSpend;
+
     let response = null;
 
     if ('index' in body) {
-      const address: AddressInfo | null = await dbGetAddressAtIndex(mysql, walletId, body.index);
+      const address: AddressInfo | null = await dbGetAddressAtIndex(mysql, walletId, body.index, account);
 
       if (!address) {
         return closeDbAndGetError(mysql, ApiError.ADDRESS_NOT_FOUND);
@@ -151,17 +169,17 @@ export const get: APIGatewayProxyHandler = middy(
         statusCode: 200,
         body: JSON.stringify({
           success: true,
-          addresses: [address],
+          addresses: [toAddressResponse(address, body.legacy)],
         }),
       };
     } else {
       // Searching for multiple addresses
-      const addresses = await getWalletAddresses(mysql, walletId);
+      const addresses = await getWalletAddresses(mysql, walletId, null, account);
       response = {
         statusCode: 200,
         body: JSON.stringify({
           success: true,
-          addresses,
+          addresses: addresses.map((address) => toAddressResponse(address, body.legacy)),
         }),
       };
     }

--- a/packages/wallet-service/src/api/addresses.ts
+++ b/packages/wallet-service/src/api/addresses.ts
@@ -117,13 +117,26 @@ export const checkMine: APIGatewayProxyHandler = middy(walletIdProxyHandler(asyn
 // before the shielded columns existed, so we build entries explicitly instead of
 // returning the internal AddressInfo shape as-is.
 // `ct_address` is only surfaced on CTSpend (legacy=false) entries.
-const toAddressResponse = (address: AddressInfo, legacy: boolean): Record<string, unknown> => ({
-  address: address.address,
-  index: address.index,
-  transactions: address.transactions,
-  seqnum: address.seqnum,
-  ...(legacy ? {} : { ct_address: address.ctAddress }),
-});
+const toAddressResponse = (address: AddressInfo, legacy: boolean): Record<string, unknown> => {
+  // Legacy: the on-chain address is the address. CTSpend (legacy=false): the
+  // user-facing CT address is the address, and the on-chain spend address is
+  // surfaced under `spendAddress`.
+  if (legacy) {
+    return {
+      address: address.address,
+      index: address.index,
+      transactions: address.transactions,
+      seqnum: address.seqnum,
+    };
+  }
+  return {
+    address: address.ctAddress,
+    spendAddress: address.address,
+    index: address.index,
+    transactions: address.transactions,
+    seqnum: address.seqnum,
+  };
+};
 
 /**
  * Get the addresses of a wallet, allowing an index filter

--- a/packages/wallet-service/src/api/addresses.ts
+++ b/packages/wallet-service/src/api/addresses.ts
@@ -33,7 +33,6 @@ const checkMineBodySchema = Joi.object({
     .min(1)
     .max(512) // max number of addresses in a tx (256 outputs and 256 inputs)
     .required(),
-  legacy: Joi.boolean().default(true),
 });
 
 class AddressAtIndexValidator {
@@ -90,8 +89,10 @@ export const checkMine: APIGatewayProxyHandler = middy(walletIdProxyHandler(asyn
   }
 
   const sentAddresses = value.addresses;
-  const account = value.legacy ? Bip32Account.Legacy : Bip32Account.CTSpend;
-  const dbWalletAddresses: AddressInfo[] = await getWalletAddresses(mysql, walletId, sentAddresses, account);
+  // Membership is account-agnostic: an address is "mine" if the wallet owns it,
+  // whether it is a Legacy or a CTSpend address. The response is a boolean map
+  // with no account-specific fields, so there is nothing to scope by account.
+  const dbWalletAddresses: AddressInfo[] = await getWalletAddresses(mysql, walletId, sentAddresses);
   const walletAddresses: Set<string> = dbWalletAddresses.reduce((acc, { address }) => acc.add(address), new Set([]));
 
   await closeDbConnection(mysql);

--- a/packages/wallet-service/src/api/addresses.ts
+++ b/packages/wallet-service/src/api/addresses.ts
@@ -113,9 +113,9 @@ export const checkMine: APIGatewayProxyHandler = middy(walletIdProxyHandler(asyn
 })).use(cors())
   .use(errorHandler());
 
-// The default (legacy) response shape must stay byte-identical to what the
-// API returned before the shielded columns existed, so we build entries
-// explicitly instead of returning the internal AddressInfo shape as-is.
+// The default (legacy) response must keep the same field set the API returned
+// before the shielded columns existed, so we build entries explicitly instead of
+// returning the internal AddressInfo shape as-is.
 // `ct_address` is only surfaced on CTSpend (legacy=false) entries.
 const toAddressResponse = (address: AddressInfo, legacy: boolean): Record<string, unknown> => ({
   address: address.address,

--- a/packages/wallet-service/src/api/balances.ts
+++ b/packages/wallet-service/src/api/balances.ts
@@ -15,6 +15,7 @@ import {
   getWallet,
   getTokenInformation,
 } from '@src/db';
+import { computeUnifiedStatus } from '@src/db/utils';
 import {
   closeDbConnection,
   getDbConnection,
@@ -33,6 +34,8 @@ const paramsSchema = Joi.object({
   token_id: Joi.string()
     .alphanum()
     .optional(),
+  split: Joi.boolean()
+    .default(false),
 });
 
 /*
@@ -49,7 +52,7 @@ export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (wal
 
   const { value, error } = paramsSchema.validate(params, {
     abortEarly: false,
-    convert: false,
+    convert: true, // query-string params always arrive as strings
   });
 
   if (error) {
@@ -90,7 +93,11 @@ export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (wal
 
   return {
     statusCode: 200,
-    body: bigIntUtils.JSONBigInt.stringify({ success: true, balances }),
+    body: bigIntUtils.JSONBigInt.stringify({
+      success: true,
+      balances: value.split ? balances.map((balance) => balance.toSplitJSON()) : balances,
+      status: computeUnifiedStatus(status.status, status.ctStatus ?? 'none'),
+    }),
   };
 })).use(cors())
   .use(warmupMiddleware())

--- a/packages/wallet-service/src/api/newAddresses.ts
+++ b/packages/wallet-service/src/api/newAddresses.ts
@@ -7,7 +7,9 @@
 
 import 'source-map-support/register';
 
+import Joi from 'joi';
 import { APIGatewayProxyHandler } from 'aws-lambda';
+import { Bip32Account } from '@wallet-service/common';
 import { ApiError } from '@src/api/errors';
 import { closeDbAndGetError, warmupMiddleware } from '@src/api/utils';
 import {
@@ -23,13 +25,37 @@ import errorHandler from '@src/api/middlewares/errorHandler';
 
 const mysql = getDbConnection();
 
+const paramsSchema = Joi.object({
+  legacy: Joi.boolean().default(true),
+});
+
 /*
  * Get the addresses of a wallet to be used in new transactions
  * It returns the empty addresses after the last used one
  *
+ * By default it returns the Legacy (account 0) unused addresses. With
+ * `?legacy=false` it returns the CTSpend (account 2) unused addresses under
+ * `addresses` and keeps the Legacy ones under `legacyAddresses`.
+ *
  * This lambda is called by API Gateway on GET /addresses/new
  */
-export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId) => {
+export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId, event) => {
+  const params = event.queryStringParameters || {};
+
+  const { value, error } = paramsSchema.validate(params, {
+    abortEarly: false,
+    convert: true, // query-string params always arrive as strings
+  });
+
+  if (error) {
+    const details = error.details.map((err) => ({
+      message: err.message,
+      path: err.path,
+    }));
+
+    return closeDbAndGetError(mysql, ApiError.INVALID_PAYLOAD, { details });
+  }
+
   const wallet = await getWallet(mysql, walletId);
 
   if (!wallet) {
@@ -39,13 +65,23 @@ export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (wal
     return closeDbAndGetError(mysql, ApiError.WALLET_NOT_READY);
   }
 
-  const addresses = await getNewAddresses(mysql, wallet);
+  if (value.legacy) {
+    const addresses = await getNewAddresses(mysql, wallet, Bip32Account.Legacy);
+    await closeDbConnection(mysql);
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true, addresses }),
+    };
+  }
+
+  const addresses = await getNewAddresses(mysql, wallet, Bip32Account.CTSpend);
+  const legacyAddresses = await getNewAddresses(mysql, wallet, Bip32Account.Legacy);
 
   await closeDbConnection(mysql);
 
   return {
     statusCode: 200,
-    body: JSON.stringify({ success: true, addresses }),
+    body: JSON.stringify({ success: true, addresses, legacyAddresses }),
   };
 })).use(cors())
   .use(warmupMiddleware())

--- a/packages/wallet-service/src/api/newAddresses.ts
+++ b/packages/wallet-service/src/api/newAddresses.ts
@@ -17,6 +17,7 @@ import {
   getNewAddresses,
 } from '@src/db';
 import { closeDbConnection, getDbConnection } from '@src/utils';
+import { ShortAddressInfo } from '@src/types';
 
 import { walletIdProxyHandler } from '@src/commons';
 import middy from '@middy/core';
@@ -65,23 +66,42 @@ export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (wal
     return closeDbAndGetError(mysql, ApiError.WALLET_NOT_READY);
   }
 
+  // The short-info shape the endpoint returns; the internal `ctAddress` field is
+  // never surfaced directly (it is remapped into its own list below).
+  const toShortInfo = (entry: ShortAddressInfo) => ({
+    address: entry.address,
+    index: entry.index,
+    addressPath: entry.addressPath,
+  });
+
   if (value.legacy) {
-    const addresses = await getNewAddresses(mysql, wallet, Bip32Account.Legacy);
+    const legacyRows = await getNewAddresses(mysql, wallet, Bip32Account.Legacy);
     await closeDbConnection(mysql);
     return {
       statusCode: 200,
-      body: JSON.stringify({ success: true, addresses }),
+      body: JSON.stringify({ success: true, addresses: legacyRows.map(toShortInfo) }),
     };
   }
 
-  const addresses = await getNewAddresses(mysql, wallet, Bip32Account.CTSpend);
-  const legacyAddresses = await getNewAddresses(mysql, wallet, Bip32Account.Legacy);
+  const ctSpendRows = await getNewAddresses(mysql, wallet, Bip32Account.CTSpend);
+  const legacyRows = await getNewAddresses(mysql, wallet, Bip32Account.Legacy);
 
   await closeDbConnection(mysql);
 
+  // For the CTSpend account we surface two parallel lists: `addresses` carries the
+  // user-facing CT address, `spendAddresses` carries the on-chain spend address;
+  // both share the same index and derivation path.
+  const addresses = ctSpendRows.map((entry) => ({
+    address: entry.ctAddress,
+    index: entry.index,
+    addressPath: entry.addressPath,
+  }));
+  const spendAddresses = ctSpendRows.map(toShortInfo);
+  const legacyAddresses = legacyRows.map(toShortInfo);
+
   return {
     statusCode: 200,
-    body: JSON.stringify({ success: true, addresses, legacyAddresses }),
+    body: JSON.stringify({ success: true, addresses, spendAddresses, legacyAddresses }),
   };
 })).use(cors())
   .use(warmupMiddleware())

--- a/packages/wallet-service/src/api/txOutputs.ts
+++ b/packages/wallet-service/src/api/txOutputs.ts
@@ -26,9 +26,12 @@ import {
   ShieldedTxOutputData,
   ShieldedAddressApiInfo,
 } from '@src/db/shielded';
-import { Bip32Account, RecoveryState, ShieldedOutputMode, isShieldedMode } from '@wallet-service/common';
+import { Bip32Account, RecoveryState, Severity, ShieldedOutputMode, isShieldedMode } from '@wallet-service/common';
+import { addAlert } from '@wallet-service/common/src/utils/alerting.utils';
+import createDefaultLogger from '@src/logger';
 
 const mysql = getDbConnection();
+const logger = createDefaultLogger();
 
 const positiveBigInt = Joi.custom(value => {
   const newVal = BigInt(value);
@@ -184,7 +187,7 @@ const hydrateAndFormat = async (
     walletId,
     [...new Set(shielded.map((output) => output.address))],
   );
-  return formatTxOutputEntries(withPath, satellite, shieldedAddresses);
+  return await formatTxOutputEntries(withPath, satellite, shieldedAddresses);
 };
 
 const _getFilteredTxOutputs = async (walletId: string, filters: IFilterTxOutput) => {
@@ -310,39 +313,67 @@ export const mapTxOutputsWithPath = (walletAddresses: AddressInfo[], txOutputs: 
 
 /**
  * Attach the `kind` discriminator and, for shielded entries, the satellite
- * crypto bytes (hex) and CTSpend ownership metadata. The recovered-only
- * filtering upstream guarantees every shielded row here has a satellite row
- * and a claimed CTSpend address row — a miss is a data-integrity bug.
+ * crypto bytes (hex) and CTSpend ownership metadata.
+ *
+ * The recovered-only filtering upstream means every shielded row here is
+ * expected to have a satellite row and a claimed CTSpend address row, but a
+ * miss can still happen (e.g. a partially-written recovery). When that
+ * happens the offending entry is skipped and a MAJOR alert is raised instead
+ * of failing the whole request — one invisible UTXO is a far smaller blast
+ * radius than a 500 on the entire /utxos or /tx_outputs response, which
+ * would otherwise also hide the wallet's unrelated transparent funds.
  */
-export const formatTxOutputEntries = (
+export const formatTxOutputEntries = async (
   txOutputs: DbTxOutputWithPath[],
   satellite: Map<string, ShieldedTxOutputData>,
   shieldedAddresses: Map<string, ShieldedAddressApiInfo>,
-): Record<string, unknown>[] => txOutputs.map((txOutput) => {
-  if (!isShieldedMode(txOutput.mode ?? 0)) {
-    return { ...txOutput, kind: 'transparent' };
+): Promise<Record<string, unknown>[]> => {
+  const entries: Record<string, unknown>[] = [];
+
+  for (const txOutput of txOutputs) {
+    if (!isShieldedMode(txOutput.mode ?? 0)) {
+      entries.push({ ...txOutput, kind: 'transparent' });
+      continue;
+    }
+
+    const data = satellite.get(`${txOutput.txId}:${txOutput.index}`);
+    const addressInfo = shieldedAddresses.get(txOutput.address);
+
+    if (!data || !addressInfo) {
+      const missing = [
+        ...(!data ? ['satellite'] : []),
+        ...(!addressInfo ? ['ownership'] : []),
+      ];
+
+      await addAlert(
+        'Shielded tx output missing satellite/ownership data',
+        `tx_output ${txOutput.txId}:${txOutput.index} is missing its ${missing.join(' and ')} row and was skipped.`,
+        Severity.MAJOR,
+        { txId: txOutput.txId, index: txOutput.index, missing },
+        logger,
+      );
+      continue;
+    }
+
+    entries.push({
+      ...txOutput,
+      kind: 'shielded',
+      ctAddress: addressInfo.ctAddress,
+      shieldedIndex: addressInfo.shieldedIndex,
+      commitment: data.commitment.toString('hex'),
+      ephemeralPubkey: data.ephemeralPubkey.toString('hex'),
+      rangeProof: data.rangeProof.toString('hex'),
+      script: data.script.toString('hex'),
+      ...(txOutput.mode === ShieldedOutputMode.AmountShielded ? { tokenData: data.tokenData } : {}),
+      ...(txOutput.mode === ShieldedOutputMode.FullyShielded ? {
+        assetCommitment: data.assetCommitment.toString('hex'),
+        surjectionProof: data.surjectionProof.toString('hex'),
+      } : {}),
+    });
   }
-  const data = satellite.get(`${txOutput.txId}:${txOutput.index}`);
-  const addressInfo = shieldedAddresses.get(txOutput.address);
-  if (!data || !addressInfo) {
-    throw new Error(`Missing shielded data for tx output ${txOutput.txId}:${txOutput.index}`);
-  }
-  return {
-    ...txOutput,
-    kind: 'shielded',
-    ctAddress: addressInfo.ctAddress,
-    shieldedIndex: addressInfo.shieldedIndex,
-    commitment: data.commitment.toString('hex'),
-    ephemeralPubkey: data.ephemeralPubkey.toString('hex'),
-    rangeProof: data.rangeProof.toString('hex'),
-    script: data.script.toString('hex'),
-    ...(txOutput.mode === ShieldedOutputMode.AmountShielded ? { tokenData: data.tokenData } : {}),
-    ...(txOutput.mode === ShieldedOutputMode.FullyShielded ? {
-      assetCommitment: data.assetCommitment.toString('hex'),
-      surjectionProof: data.surjectionProof.toString('hex'),
-    } : {}),
-  };
-});
+
+  return entries;
+};
 
 /**
  * Confirm that the requested addresses belongs to the user's wallet

--- a/packages/wallet-service/src/api/txOutputs.ts
+++ b/packages/wallet-service/src/api/txOutputs.ts
@@ -20,6 +20,13 @@ import { constants, bigIntUtils, transactionUtils } from '@hathor/wallet-lib';
 import middy from '@middy/core';
 import cors from '@middy/http-cors';
 import errorHandler from '@src/api/middlewares/errorHandler';
+import {
+  getShieldedTxOutputDataByIds,
+  getShieldedAddressInfoByAddresses,
+  ShieldedTxOutputData,
+  ShieldedAddressApiInfo,
+} from '@src/db/shielded';
+import { Bip32Account, RecoveryState, ShieldedOutputMode, isShieldedMode } from '@wallet-service/common';
 
 const mysql = getDbConnection();
 
@@ -50,6 +57,7 @@ const bodySchema = Joi.object({
   skipSpent: Joi.boolean().optional().default(true),
   txId: Joi.string().optional(),
   index: Joi.number().optional().min(0),
+  kind: Joi.string().valid('transparent', 'shielded').optional(),
 }).and('txId', 'index')
   .nand('totalAmount', 'maxAmount');
 
@@ -80,6 +88,7 @@ export const getFilteredUtxos = middy(walletIdProxyHandler(async (walletId, even
     totalAmount: queryString.totalAmount,
     maxAmount: queryString.maxAmount,
     maxOutputs: queryString.maxOutputs,
+    kind: queryString.kind,
   };
 
   const { value, error } = bodySchema.validate(eventBody, {
@@ -135,6 +144,7 @@ export const getFilteredTxOutputs = middy(walletIdProxyHandler(async (walletId, 
     totalAmount: queryString.totalAmount,
     maxAmount: queryString.maxAmount,
     maxOutputs: queryString.maxOutputs,
+    kind: queryString.kind,
   };
 
   const { value, error } = bodySchema.validate(eventBody, {
@@ -155,12 +165,34 @@ export const getFilteredTxOutputs = middy(walletIdProxyHandler(async (walletId, 
 })).use(cors())
   .use(errorHandler());
 
+const hydrateAndFormat = async (
+  walletId: string,
+  walletAddresses: AddressInfo[],
+  txOutputs: DbTxOutput[],
+): Promise<Record<string, unknown>[]> => {
+  const withPath = mapTxOutputsWithPath(walletAddresses, txOutputs);
+  const shielded = withPath.filter((output) => isShieldedMode(output.mode ?? 0));
+  if (shielded.length === 0) {
+    return formatTxOutputEntries(withPath, new Map(), new Map());
+  }
+  const satellite = await getShieldedTxOutputDataByIds(
+    mysql,
+    shielded.map((output) => ({ txId: output.txId, index: output.index })),
+  );
+  const shieldedAddresses = await getShieldedAddressInfoByAddresses(
+    mysql,
+    walletId,
+    [...new Set(shielded.map((output) => output.address))],
+  );
+  return formatTxOutputEntries(withPath, satellite, shieldedAddresses);
+};
+
 const _getFilteredTxOutputs = async (walletId: string, filters: IFilterTxOutput) => {
   const walletAddresses = await getWalletAddresses(mysql, walletId);
 
   // txId will only be on the body when the user is searching for specific tx outputs
   if (filters.txId !== undefined) {
-    let txOutputList: DbTxOutputWithPath[] = [];
+    let txOutputList: Record<string, unknown>[] = [];
     const txOutput: DbTxOutput = await getTxOutput(mysql, filters.txId, filters.index, filters.skipSpent);
 
     if (txOutput) {
@@ -172,7 +204,12 @@ const _getFilteredTxOutputs = async (walletId: string, filters: IFilterTxOutput)
         return closeDbAndGetError(mysql, ApiError.TX_OUTPUT_NOT_IN_WALLET);
       }
 
-      txOutputList = mapTxOutputsWithPath(walletAddresses, [txOutput]);
+      const isUnrecoveredShielded = isShieldedMode(txOutput.mode ?? 0)
+        && txOutput.recoveryState !== RecoveryState.Recovered;
+
+      if (!isUnrecoveredShielded) {
+        txOutputList = await hydrateAndFormat(walletId, walletAddresses, [txOutput]);
+      }
     }
 
     return {
@@ -242,7 +279,7 @@ const _getFilteredTxOutputs = async (walletId: string, filters: IFilterTxOutput)
     finalTxOutputs = selectedTxOutputs;
   }
 
-  const txOutputsWithPath: DbTxOutputWithPath[] = mapTxOutputsWithPath(walletAddresses, finalTxOutputs);
+  const txOutputsWithPath = await hydrateAndFormat(walletId, walletAddresses, finalTxOutputs);
 
   return {
     statusCode: 200,
@@ -266,8 +303,45 @@ export const mapTxOutputsWithPath = (walletAddresses: AddressInfo[], txOutputs: 
     // this should never happen, so we will throw here
     throw new Error('Tx output address not in user\'s wallet');
   }
-  const addressPath = `m/44'/${constants.HATHOR_BIP44_CODE}'/0'/0/${addressDetail.index}`;
+  const account = addressDetail.bip32Account === Bip32Account.CTSpend ? Bip32Account.CTSpend : Bip32Account.Legacy;
+  const addressPath = `m/44'/${constants.HATHOR_BIP44_CODE}'/${account}'/0/${addressDetail.index}`;
   return { ...txOutput, addressPath };
+});
+
+/**
+ * Attach the `kind` discriminator and, for shielded entries, the satellite
+ * crypto bytes (hex) and CTSpend ownership metadata. The recovered-only
+ * filtering upstream guarantees every shielded row here has a satellite row
+ * and a claimed CTSpend address row — a miss is a data-integrity bug.
+ */
+export const formatTxOutputEntries = (
+  txOutputs: DbTxOutputWithPath[],
+  satellite: Map<string, ShieldedTxOutputData>,
+  shieldedAddresses: Map<string, ShieldedAddressApiInfo>,
+): Record<string, unknown>[] => txOutputs.map((txOutput) => {
+  if (!isShieldedMode(txOutput.mode ?? 0)) {
+    return { ...txOutput, kind: 'transparent' };
+  }
+  const data = satellite.get(`${txOutput.txId}:${txOutput.index}`);
+  const addressInfo = shieldedAddresses.get(txOutput.address);
+  if (!data || !addressInfo) {
+    throw new Error(`Missing shielded data for tx output ${txOutput.txId}:${txOutput.index}`);
+  }
+  return {
+    ...txOutput,
+    kind: 'shielded',
+    ctAddress: addressInfo.ctAddress,
+    shieldedIndex: addressInfo.shieldedIndex,
+    commitment: data.commitment.toString('hex'),
+    ephemeralPubkey: data.ephemeralPubkey.toString('hex'),
+    rangeProof: data.rangeProof.toString('hex'),
+    script: data.script.toString('hex'),
+    ...(txOutput.mode === ShieldedOutputMode.AmountShielded ? { tokenData: data.tokenData } : {}),
+    ...(txOutput.mode === ShieldedOutputMode.FullyShielded ? {
+      assetCommitment: data.assetCommitment.toString('hex'),
+      surjectionProof: data.surjectionProof.toString('hex'),
+    } : {}),
+  };
 });
 
 /**

--- a/packages/wallet-service/src/api/txOutputs.ts
+++ b/packages/wallet-service/src/api/txOutputs.ts
@@ -210,7 +210,10 @@ const _getFilteredTxOutputs = async (walletId: string, filters: IFilterTxOutput)
       const isUnrecoveredShielded = isShieldedMode(txOutput.mode ?? 0)
         && txOutput.recoveryState !== RecoveryState.Recovered;
 
-      if (!isUnrecoveredShielded) {
+      const kindMismatch = (filters.kind === 'transparent' && isShieldedMode(txOutput.mode ?? 0))
+        || (filters.kind === 'shielded' && !isShieldedMode(txOutput.mode ?? 0));
+
+      if (!isUnrecoveredShielded && !kindMismatch) {
         txOutputList = await hydrateAndFormat(walletId, walletAddresses, [txOutput]);
       }
     }

--- a/packages/wallet-service/src/api/txOutputs.ts
+++ b/packages/wallet-service/src/api/txOutputs.ts
@@ -13,6 +13,7 @@ import {
   DbTxOutputWithPath,
   IFilterTxOutput,
   AddressInfo,
+  TxOutputEntry,
 } from '@src/types';
 import { closeDbAndGetError } from '@src/api/utils';
 import { getDbConnection } from '@src/utils';
@@ -172,7 +173,7 @@ const hydrateAndFormat = async (
   walletId: string,
   walletAddresses: AddressInfo[],
   txOutputs: DbTxOutput[],
-): Promise<Record<string, unknown>[]> => {
+): Promise<TxOutputEntry[]> => {
   const withPath = mapTxOutputsWithPath(walletAddresses, txOutputs);
   const shielded = withPath.filter((output) => isShieldedMode(output.mode ?? 0));
   if (shielded.length === 0) {
@@ -195,7 +196,7 @@ const _getFilteredTxOutputs = async (walletId: string, filters: IFilterTxOutput)
 
   // txId will only be on the body when the user is searching for specific tx outputs
   if (filters.txId !== undefined) {
-    let txOutputList: Record<string, unknown>[] = [];
+    let txOutputList: TxOutputEntry[] = [];
     const txOutput: DbTxOutput = await getTxOutput(mysql, filters.txId, filters.index, filters.skipSpent);
 
     if (txOutput) {
@@ -230,6 +231,15 @@ const _getFilteredTxOutputs = async (walletId: string, filters: IFilterTxOutput)
   const newFilters = {
     ...filters,
   };
+
+  // The amount-selection path exists to be spent: selectUtxos treats every row as
+  // fungible-by-value, but a shielded output carries a shielded script a
+  // transparent input can't consume. When the caller asks for an amount without an
+  // explicit kind, restrict selection to transparent; an explicit kind=shielded is
+  // still honored.
+  if ((newFilters.totalAmount || newFilters.maxAmount) && !newFilters.kind) {
+    newFilters.kind = 'transparent';
+  }
 
   if (newFilters.addresses) {
     const denied = validateAddresses(walletAddresses, newFilters.addresses);
@@ -330,8 +340,8 @@ export const formatTxOutputEntries = async (
   txOutputs: DbTxOutputWithPath[],
   satellite: Map<string, ShieldedTxOutputData>,
   shieldedAddresses: Map<string, ShieldedAddressApiInfo>,
-): Promise<Record<string, unknown>[]> => {
-  const entries: Record<string, unknown>[] = [];
+): Promise<TxOutputEntry[]> => {
+  const entries: TxOutputEntry[] = [];
 
   for (const txOutput of txOutputs) {
     if (!isShieldedMode(txOutput.mode ?? 0)) {

--- a/packages/wallet-service/src/api/txOutputs.ts
+++ b/packages/wallet-service/src/api/txOutputs.ts
@@ -342,15 +342,22 @@ export const formatTxOutputEntries = async (
     const data = satellite.get(`${txOutput.txId}:${txOutput.index}`);
     const addressInfo = shieldedAddresses.get(txOutput.address);
 
-    if (!data || !addressInfo) {
-      const missing = [
-        ...(!data ? ['satellite'] : []),
-        ...(!addressInfo ? ['ownership'] : []),
-      ];
+    const missing: string[] = [
+      ...(!data ? ['satellite'] : []),
+      ...(!addressInfo ? ['ownership'] : []),
+    ];
+    // A FullyShielded output requires both asset byte-fields; a present row with a
+    // NULL required field would crash serialization, so it is a data-integrity
+    // miss too and must degrade (skip + alert) rather than 500 the response.
+    if (data && txOutput.mode === ShieldedOutputMode.FullyShielded) {
+      if (data.assetCommitment === null) missing.push('asset_commitment');
+      if (data.surjectionProof === null) missing.push('surjection_proof');
+    }
 
+    if (missing.length > 0) {
       await addAlert(
         'Shielded tx output missing satellite/ownership data',
-        `tx_output ${txOutput.txId}:${txOutput.index} is missing its ${missing.join(' and ')} row and was skipped.`,
+        `tx_output ${txOutput.txId}:${txOutput.index} is missing its ${missing.join(', ')} data and was skipped.`,
         Severity.MAJOR,
         { txId: txOutput.txId, index: txOutput.index, missing },
         logger,

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -53,7 +53,7 @@ import {
 import {
   getWalletFromDbEntry,
   getTxsFromDBResult,
-  deriveOutputKind,
+  deriveTxKind,
 } from '@src/db/utils';
 import { addAlert } from '@wallet-service/common/src/utils/alerting.utils';
 import { TxInput, Severity } from '@wallet-service/common/src/types';
@@ -1537,9 +1537,9 @@ INNER JOIN token ON w.token_id = token.id
 
   const results: DbSelectResult = await mysql.query(query, params);
   for (const result of results) {
-    const totalAmount = BigInt(result.total_received as string);
-    const unlockedBalance = BigInt(result.unlocked_balance as string);
-    const lockedBalance = BigInt(result.locked_balance as string);
+    const totalAmount = dbIntToBigInt(result.total_received);
+    const unlockedBalance = dbIntToBigInt(result.unlocked_balance);
+    const lockedBalance = dbIntToBigInt(result.locked_balance);
     const unlockedShieldedBalance = dbIntToBigInt(result.unlocked_shielded_balance);
     const lockedShieldedBalance = dbIntToBigInt(result.locked_shielded_balance);
     const totalShieldedReceived = dbIntToBigInt(result.total_shielded_received);
@@ -1639,7 +1639,7 @@ LEFT OUTER JOIN transaction ON transaction.tx_id = wallet_tx_history.tx_id
       voided: <boolean>result.voided,
       balance: transparentDelta + shieldedDelta,
       version: <number>result.version,
-      output_kind: deriveOutputKind(transparentDelta, shieldedDelta),
+      tx_kind: deriveTxKind(transparentDelta, shieldedDelta),
       balanceBreakdown: {
         transparent: transparentDelta,
         shielded: shieldedDelta,
@@ -2638,14 +2638,20 @@ export const filterTxOutputs = async (
   const queryParams: any[] = [
     finalFilters.addresses,
     finalFilters.tokenId,
-    ShieldedOutputMode.Transparent,
-    RecoveryState.Recovered,
   ];
 
+  // Mode/recovery filtering is a single mutually-exclusive clause per kind:
+  //  - transparent: only mode 0
+  //  - shielded: only recovered shielded outputs (their value is known)
+  //  - default (no kind): transparent plus recovered shielded
   if (finalFilters.kind === 'transparent') {
     queryParams.push(ShieldedOutputMode.Transparent);
   } else if (finalFilters.kind === 'shielded') {
     queryParams.push([ShieldedOutputMode.AmountShielded, ShieldedOutputMode.FullyShielded]);
+    queryParams.push(RecoveryState.Recovered);
+  } else {
+    queryParams.push(ShieldedOutputMode.Transparent);
+    queryParams.push(RecoveryState.Recovered);
   }
 
   if (finalFilters.authority === 0) {
@@ -2663,9 +2669,9 @@ export const filterTxOutputs = async (
       WHERE \`address\`
          IN (?)
         AND \`token_id\` = ?
-        AND (\`mode\` = ? OR \`recovery_state\` = ?)
         ${finalFilters.kind === 'transparent' ? 'AND `mode` = ?' : ''}
-        ${finalFilters.kind === 'shielded' ? 'AND `mode` IN (?)' : ''}
+        ${finalFilters.kind === 'shielded' ? 'AND `mode` IN (?) AND `recovery_state` = ?' : ''}
+        ${!finalFilters.kind ? 'AND (`mode` = ? OR `recovery_state` = ?)' : ''}
         ${finalFilters.authority !== 0 ? 'AND `authorities` & ? > 0' : 'AND `authorities` = 0'}
         ${finalFilters.ignoreLocked ? 'AND `locked` = FALSE' : ''}
         ${finalFilters.authority === 0 ? 'AND value < ?' : ''}
@@ -3448,7 +3454,6 @@ export const hasTransactionsOnNonFirstAddress = async (
       WHERE \`wallet_id\` = ?
         AND \`index\` > 0
         AND \`transactions\` > 0
-        AND (\`bip32_account\` IS NULL OR \`bip32_account\` <> 2)
       LIMIT 1`,
     [walletId],
   );

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -426,11 +426,14 @@ export const upsertNewAddresses = async (
   lastUsedAddressIndex: number,
 ): Promise<void> => {
   if (Object.keys(addresses).length > 0) {
-    const entries = Object.entries(addresses).map(([address, index]) => [address, index, walletId, 0]);
+    // Claimed legacy addresses carry an explicit account: an owned address never
+    // has a NULL bip32_account. Set it on insert and when an unowned observation
+    // row is claimed (ON DUPLICATE).
+    const entries = Object.entries(addresses).map(([address, index]) => [address, index, walletId, 0, Bip32Account.Legacy]);
     await mysql.query(
-      `INSERT INTO \`address\`(\`address\`, \`index\`, \`wallet_id\`, \`transactions\`)
+      `INSERT INTO \`address\`(\`address\`, \`index\`, \`wallet_id\`, \`transactions\`, \`bip32_account\`)
        VALUES ?
-       ON DUPLICATE KEY UPDATE \`wallet_id\` = VALUES(\`wallet_id\`), \`index\` = VALUES(\`index\`)`,
+       ON DUPLICATE KEY UPDATE \`wallet_id\` = VALUES(\`wallet_id\`), \`index\` = VALUES(\`index\`), \`bip32_account\` = VALUES(\`bip32_account\`)`,
       [entries],
     );
   }
@@ -1470,8 +1473,29 @@ export const getWalletAddresses = async (
  * @param walletId - Wallet id
  * @returns A list of addresses and their indexes
  */
-export const getNewAddresses = async (mysql: ServerlessMysql, wallet: Wallet): Promise<ShortAddressInfo[]> => {
+export const getNewAddresses = async (
+  mysql: ServerlessMysql,
+  wallet: Wallet,
+  account: Bip32Account = Bip32Account.Legacy,
+): Promise<ShortAddressInfo[]> => {
   const addresses: ShortAddressInfo[] = [];
+
+  // Each account has its own frontier (last used index) and gap limit. A wallet
+  // with no shielded keys has no shielded gap and no CTSpend rows, so there is
+  // nothing to return for that account.
+  const isCtSpend = account === Bip32Account.CTSpend;
+  const frontier = isCtSpend ? (wallet.lastUsedShieldedIndex ?? -1) : wallet.lastUsedAddressIndex;
+  const gap = isCtSpend ? wallet.shieldedMaxGap : wallet.maxGap;
+  if (gap == null) {
+    return addresses;
+  }
+  // An owned address always has its account set; a NULL `bip32_account` marks an
+  // unowned observation row whose account is not yet known, so it is never a
+  // candidate here.
+  const accountFilter = isCtSpend
+    ? `AND \`bip32_account\` = ${Bip32Account.CTSpend}`
+    : `AND \`bip32_account\` = ${Bip32Account.Legacy}`;
+
   // Select all addresses that are empty and the index is bigger than the last used address index
   const results: DbSelectResult = await mysql.query(`
     SELECT *
@@ -1479,17 +1503,17 @@ export const getNewAddresses = async (mysql: ServerlessMysql, wallet: Wallet): P
      WHERE \`wallet_id\` = ?
        AND \`transactions\` = 0
        AND \`index\` > ?
-       AND (\`bip32_account\` IS NULL OR \`bip32_account\` <> 2)
+       ${accountFilter}
   ORDER BY \`index\`
        ASC
-  LIMIT ?`, [wallet.walletId, wallet.lastUsedAddressIndex, wallet.maxGap]);
+  LIMIT ?`, [wallet.walletId, frontier, gap]);
 
   for (const result of results) {
     const index = result.index as number;
     const address = {
       address: result.address as string,
       index,
-      addressPath: getAddressPath(index),
+      addressPath: getAddressPath(index, account),
     };
     addresses.push(address);
   }

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -57,6 +57,7 @@ import {
 } from '@src/db/utils';
 import { addAlert } from '@wallet-service/common/src/utils/alerting.utils';
 import { TxInput, Severity } from '@wallet-service/common/src/types';
+import { ShieldedOutputMode, RecoveryState } from '@wallet-service/common';
 import { Logger } from 'winston';
 import createDefaultLogger from '@src/logger';
 import { FullnodeVersionSchema } from '@src/schemas';
@@ -2607,7 +2608,15 @@ export const filterTxOutputs = async (
   const queryParams: any[] = [
     finalFilters.addresses,
     finalFilters.tokenId,
+    ShieldedOutputMode.Transparent,
+    RecoveryState.Recovered,
   ];
+
+  if (finalFilters.kind === 'transparent') {
+    queryParams.push(ShieldedOutputMode.Transparent);
+  } else if (finalFilters.kind === 'shielded') {
+    queryParams.push([ShieldedOutputMode.AmountShielded, ShieldedOutputMode.FullyShielded]);
+  }
 
   if (finalFilters.authority === 0) {
     queryParams.push(finalFilters.smallerThan);
@@ -2624,6 +2633,9 @@ export const filterTxOutputs = async (
       WHERE \`address\`
          IN (?)
         AND \`token_id\` = ?
+        AND (\`mode\` = ? OR \`recovery_state\` = ?)
+        ${finalFilters.kind === 'transparent' ? 'AND `mode` = ?' : ''}
+        ${finalFilters.kind === 'shielded' ? 'AND `mode` IN (?)' : ''}
         ${finalFilters.authority !== 0 ? 'AND `authorities` & ? > 0' : 'AND `authorities` = 0'}
         ${finalFilters.ignoreLocked ? 'AND `locked` = FALSE' : ''}
         ${finalFilters.authority === 0 ? 'AND value < ?' : ''}
@@ -2653,7 +2665,7 @@ export const mapDbResultToDbTxOutput = (result: any): DbTxOutput => ({
   index: result.index as number,
   tokenId: result.token_id as string,
   address: result.address as string,
-  value: BigInt(result.value),
+  value: BigInt(result.value ?? 0),
   authorities: result.authorities as number,
   timelock: result.timelock as number,
   heightlock: result.heightlock as number,
@@ -2661,6 +2673,8 @@ export const mapDbResultToDbTxOutput = (result: any): DbTxOutput => ({
   txProposalId: result.tx_proposal as string,
   txProposalIndex: result.tx_proposal_index as number,
   spentBy: result.spent_by as string,
+  mode: (result.mode ?? 0) as number,
+  recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
 });
 
 /**

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -1489,6 +1489,9 @@ export const getWalletBalances = async (mysql: ServerlessMysql, walletId: string
     SELECT w.total_received AS total_received,
            w.unlocked_balance AS unlocked_balance,
            w.locked_balance AS locked_balance,
+           w.unlocked_shielded_balance AS unlocked_shielded_balance,
+           w.locked_shielded_balance AS locked_shielded_balance,
+           w.total_shielded_received AS total_shielded_received,
            w.unlocked_authorities AS unlocked_authorities,
            w.locked_authorities AS locked_authorities,
            w.timelock_expires AS timelock_expires,
@@ -1506,6 +1509,9 @@ INNER JOIN token ON w.token_id = token.id
     const totalAmount = BigInt(result.total_received as string);
     const unlockedBalance = BigInt(result.unlocked_balance as string);
     const lockedBalance = BigInt(result.locked_balance as string);
+    const unlockedShieldedBalance = dbIntToBigInt(result.unlocked_shielded_balance);
+    const lockedShieldedBalance = dbIntToBigInt(result.locked_shielded_balance);
+    const totalShieldedReceived = dbIntToBigInt(result.total_shielded_received);
     const unlockedAuthorities = new Authorities(result.unlocked_authorities as number);
     const lockedAuthorities = new Authorities(result.locked_authorities as number);
     const timelockExpires = result.timelock_expires as number;
@@ -1517,7 +1523,7 @@ INNER JOIN token ON w.token_id = token.id
         result.symbol as string,
         toTokenVersion(result.token_version as number),
       ),
-      new Balance(totalAmount, unlockedBalance, lockedBalance, timelockExpires, unlockedAuthorities, lockedAuthorities),
+      new Balance(totalAmount, unlockedBalance, lockedBalance, timelockExpires, unlockedAuthorities, lockedAuthorities, unlockedShieldedBalance, lockedShieldedBalance, totalShieldedReceived),
       result.transactions as number,
     );
     balances.push(balance);

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -954,8 +954,9 @@ export const getTxOutput = async (
       WHERE \`tx_id\` = ?
         AND \`index\` = ?
         ${skipSpent ? 'AND `spent_by` IS NULL' : ''}
-        AND \`voided\` = FALSE`,
-    [txId, index],
+        AND \`voided\` = FALSE
+        AND (\`mode\` = ? OR \`recovery_state\` = ?)`,
+    [txId, index, ShieldedOutputMode.Transparent, RecoveryState.Recovered],
   );
 
   if (!results.length || results.length === 0) {
@@ -2721,22 +2722,31 @@ export const filterTxOutputs = async (
  * @param results - The tx_output results from the database
  * @returns A list of tx_outputs mapped to the DbTxOutput type
  */
-export const mapDbResultToDbTxOutput = (result: any): DbTxOutput => ({
-  txId: result.tx_id as string,
-  index: result.index as number,
-  tokenId: result.token_id as string,
-  address: result.address as string,
-  value: BigInt(result.value ?? 0),
-  authorities: result.authorities as number,
-  timelock: result.timelock as number,
-  heightlock: result.heightlock as number,
-  locked: result.locked > 0,
-  txProposalId: result.tx_proposal as string,
-  txProposalIndex: result.tx_proposal_index as number,
-  spentBy: result.spent_by as string,
-  mode: (result.mode ?? 0) as number,
-  recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
-});
+export const mapDbResultToDbTxOutput = (result: any): DbTxOutput => {
+  // `value` is a NOT-NULL money column for transparent and recovered shielded
+  // rows; it is only NULL on an unrecovered shielded row, which every caller must
+  // exclude in SQL. A NULL reaching here is a real integrity violation — fail
+  // loudly rather than silently coerce it into a spendable-looking zero.
+  if (result.value == null) {
+    throw new Error(`tx_output ${result.tx_id}:${result.index} has a NULL value; unrecovered shielded rows must be filtered out before mapping`);
+  }
+  return {
+    txId: result.tx_id as string,
+    index: result.index as number,
+    tokenId: result.token_id as string,
+    address: result.address as string,
+    value: BigInt(result.value),
+    authorities: result.authorities as number,
+    timelock: result.timelock as number,
+    heightlock: result.heightlock as number,
+    locked: result.locked > 0,
+    txProposalId: result.tx_proposal as string,
+    txProposalIndex: result.tx_proposal_index as number,
+    spentBy: result.spent_by as string,
+    mode: (result.mode ?? 0) as ShieldedOutputMode,
+    recoveryState: (result.recovery_state ?? null) as RecoveryState | null,
+  };
+};
 
 /**
  * Get tx proposal inputs.

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -1473,6 +1473,7 @@ export const getNewAddresses = async (mysql: ServerlessMysql, wallet: Wallet): P
      WHERE \`wallet_id\` = ?
        AND \`transactions\` = 0
        AND \`index\` > ?
+       AND (\`bip32_account\` IS NULL OR \`bip32_account\` <> 2)
   ORDER BY \`index\`
        ASC
   LIMIT ?`, [wallet.walletId, wallet.lastUsedAddressIndex, wallet.maxGap]);
@@ -1720,6 +1721,7 @@ export const getWalletUnlockedUtxos = async (
         AND (\`timelock\` <= ?
              OR \`timelock\` is NULL)
         AND \`locked\` = 1
+        AND \`mode\` = 0
         AND \`spent_by\` IS NULL
         AND \`voided\` = FALSE
         AND \`address\` IN (
@@ -2811,12 +2813,15 @@ export const getExpiredTimelocksUtxos = async (
   mysql: ServerlessMysql,
   now: number,
 ): Promise<DbTxOutput[]> => {
+  // Shielded timelock-unlock accounting is daemon-side follow-up work; this
+  // feeds the transparent-only balance rebuild, so shielded rows are excluded.
   const results: DbSelectResult = await mysql.query(`
     SELECT *
       FROM tx_output
      WHERE locked = TRUE
        AND timelock IS NOT NULL
        AND timelock < ?
+       AND mode = 0
   `, [now]);
 
   const lockedUtxos: DbTxOutput[] = results.map(mapDbResultToDbTxOutput);
@@ -3437,6 +3442,7 @@ export const hasTransactionsOnNonFirstAddress = async (
       WHERE \`wallet_id\` = ?
         AND \`index\` > 0
         AND \`transactions\` > 0
+        AND (\`bip32_account\` IS NULL OR \`bip32_account\` <> 2)
       LIMIT 1`,
     [walletId],
   );

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -1008,9 +1008,10 @@ export const getAuthorityUtxo = async (
  * Get the requested UTXOs.
  *
  * @remarks
- * Unrecovered shielded rows are excluded: their `value`/`token_id` are NULL until
- * recovery, and the mapper's `?? 0` fallback would otherwise mask that into a
- * spendable-looking zero-value UTXO. Recovered shielded rows stay selectable.
+ * Unrecovered shielded rows are excluded: their `value` and `token_id` are NULL
+ * until recovery, and the mapper's `?? 0` fallback on `value` would otherwise mask
+ * such a row into a spendable-looking zero-value UTXO. Recovered shielded rows stay
+ * selectable.
  *
  * @param mysql - Database connection
  * @param utxosKeys - Information about the queried UTXOs, including tx_id and index

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -1516,6 +1516,7 @@ export const getNewAddresses = async (
       address: result.address as string,
       index,
       addressPath: getAddressPath(index, account),
+      ctAddress: (result.ct_address ?? null) as string | null,
     };
     addresses.push(address);
   }

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -57,7 +57,7 @@ import {
 } from '@src/db/utils';
 import { addAlert } from '@wallet-service/common/src/utils/alerting.utils';
 import { TxInput, Severity } from '@wallet-service/common/src/types';
-import { ShieldedOutputMode, RecoveryState } from '@wallet-service/common';
+import { ShieldedOutputMode, RecoveryState, Bip32Account } from '@wallet-service/common';
 import { Logger } from 'winston';
 import createDefaultLogger from '@src/logger';
 import { FullnodeVersionSchema } from '@src/schemas';
@@ -1407,21 +1407,41 @@ export const updateWalletLockedBalance = async (
  * @param mysql - Database connection
  * @param walletId - Wallet id
  * @param filterAddresses - Optional parameter to filter addresses from the list
+ * @param account - Optional BIP32 account selector. `undefined` returns addresses from all
+ * accounts (existing behavior); `Legacy` and `CTSpend` restrict to that derivation account.
  * @returns A list of addresses and their info (index and transactions)
  */
-export const getWalletAddresses = async (mysql: ServerlessMysql, walletId: string, filterAddresses?: string[]): Promise<AddressInfo[]> => {
+export const getWalletAddresses = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  filterAddresses?: string[],
+  account?: Bip32Account,
+): Promise<AddressInfo[]> => {
   const addresses: AddressInfo[] = [];
   const subQuery = filterAddresses ? `
     AND \`address\` IN (?)
   ` : '';
+  // Legacy rows created before the shielded columns existed have a NULL
+  // bip32_account, so the legacy selector must be NULL-tolerant.
+  let accountFilter = '';
+  if (account === Bip32Account.Legacy) {
+    accountFilter = 'AND (`bip32_account` IS NULL OR `bip32_account` = 0)';
+  } else if (account !== undefined) {
+    accountFilter = 'AND `bip32_account` = ?';
+  }
+
+  const params: unknown[] = [walletId];
+  if (filterAddresses) params.push(filterAddresses);
+  if (account !== undefined && account !== Bip32Account.Legacy) params.push(account);
 
   const results: DbSelectResult = await mysql.query(`
     SELECT *
       FROM \`address\`
      WHERE \`wallet_id\` = ?
       ${subQuery}
+      ${accountFilter}
   ORDER BY \`index\`
-       ASC`, [walletId, filterAddresses]);
+       ASC`, params);
 
   for (const result of results) {
     const address = {
@@ -1429,6 +1449,8 @@ export const getWalletAddresses = async (mysql: ServerlessMysql, walletId: strin
       index: result.index as number,
       transactions: result.transactions as number,
       seqnum: result.seqnum as number,
+      ctAddress: (result.ct_address ?? null) as string | null,
+      bip32Account: result.bip32_account == null ? null : Number(result.bip32_account),
     };
     addresses.push(address);
   }
@@ -3362,15 +3384,25 @@ export const getAddressAtIndex = async (
   mysql: ServerlessMysql,
   walletId: string,
   index: number,
+  account: Bip32Account = Bip32Account.Legacy,
 ): Promise<AddressInfo | null> => {
+  // Legacy rows created before the shielded columns existed have a NULL
+  // bip32_account, so the legacy selector must be NULL-tolerant.
+  const accountFilter = account === Bip32Account.Legacy
+    ? 'AND (`bip32_account` IS NULL OR `bip32_account` = 0)'
+    : 'AND `bip32_account` = ?';
+  const params: unknown[] = account === Bip32Account.Legacy
+    ? [index, walletId]
+    : [index, walletId, account];
   const addresses = await mysql.query<AddressInfo[]>(
     `
-    SELECT \`address\`, \`index\`, \`transactions\`, \`seqnum\`
+    SELECT \`address\`, \`index\`, \`transactions\`, \`seqnum\`, \`ct_address\`
       FROM \`address\` pd
      WHERE \`index\` = ?
        AND \`wallet_id\` = ?
+       ${accountFilter}
      LIMIT 1`,
-    [index, walletId],
+    params,
   );
 
   if (addresses.length <= 0) {
@@ -3382,7 +3414,9 @@ export const getAddressAtIndex = async (
     index: addresses[0].index,
     transactions: addresses[0].transactions,
     seqnum: addresses[0].seqnum,
-  }
+    // eslint-disable-next-line dot-notation
+    ctAddress: (addresses[0]['ct_address'] ?? null) as string | null,
+  };
 };
 
 /**

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -53,6 +53,7 @@ import {
 import {
   getWalletFromDbEntry,
   getTxsFromDBResult,
+  deriveOutputKind,
 } from '@src/db/utils';
 import { addAlert } from '@wallet-service/common/src/utils/alerting.utils';
 import { TxInput, Severity } from '@wallet-service/common/src/types';
@@ -1583,6 +1584,7 @@ export const getWalletTxHistory = async (
   const history: TxTokenBalance[] = [];
   const results: DbSelectResult = await mysql.query(`
     SELECT wallet_tx_history.balance AS balance,
+           wallet_tx_history.shielded_balance_delta AS shielded_balance_delta,
            wallet_tx_history.timestamp AS timestamp,
            wallet_tx_history.token_id AS token_id,
            wallet_tx_history.tx_id AS tx_id,
@@ -1599,12 +1601,19 @@ LEFT OUTER JOIN transaction ON transaction.tx_id = wallet_tx_history.tx_id
     [walletId, tokenId, skip, count]);
 
   for (const result of results) {
+    const transparentDelta = BigInt(result.balance as string);
+    const shieldedDelta = BigInt((result.shielded_balance_delta ?? 0) as string | number);
     const tx: TxTokenBalance = {
       txId: <string>result.tx_id,
       timestamp: <number>result.timestamp,
       voided: <boolean>result.voided,
-      balance: BigInt(result.balance as string),
+      balance: transparentDelta + shieldedDelta,
       version: <number>result.version,
+      output_kind: deriveOutputKind(transparentDelta, shieldedDelta),
+      balanceBreakdown: {
+        transparent: transparentDelta,
+        shielded: shieldedDelta,
+      },
     };
     history.push(tx);
   }

--- a/packages/wallet-service/src/db/index.ts
+++ b/packages/wallet-service/src/db/index.ts
@@ -1004,6 +1004,11 @@ export const getAuthorityUtxo = async (
 /**
  * Get the requested UTXOs.
  *
+ * @remarks
+ * Unrecovered shielded rows are excluded: their `value`/`token_id` are NULL until
+ * recovery, and the mapper's `?? 0` fallback would otherwise mask that into a
+ * spendable-looking zero-value UTXO. Recovered shielded rows stay selectable.
+ *
  * @param mysql - Database connection
  * @param utxosKeys - Information about the queried UTXOs, including tx_id and index
  * @returns A list of UTXOs with all their properties
@@ -1023,8 +1028,9 @@ export const getUtxos = async (
       WHERE (\`tx_id\`, \`index\`)
          IN (?)
         AND \`spent_by\` IS NULL
-        AND \`voided\` = FALSE`,
-    [entries],
+        AND \`voided\` = FALSE
+        AND (\`mode\` = ? OR \`recovery_state\` = ?)`,
+    [entries, ShieldedOutputMode.Transparent, RecoveryState.Recovered],
   );
 
   const utxos = results.map(mapDbResultToDbTxOutput);

--- a/packages/wallet-service/src/db/shielded.ts
+++ b/packages/wallet-service/src/db/shielded.ts
@@ -121,7 +121,7 @@ export interface ShieldedOutputToRecover {
   index: number;
   address: string;
   /** 1 = AmountShielded (token known), 2 = FullyShielded (token recovered by rewind). */
-  mode: number;
+  mode: ShieldedOutputMode;
   /** Set for AmountShielded at observe time; NULL for FullyShielded until recovered. */
   tokenId: string | null;
   scanPrivkey: Buffer;
@@ -180,7 +180,7 @@ export const getShieldedOutputsToRecover = async (
     txId: row.tx_id as string,
     index: row.index as number,
     address: row.address as string,
-    mode: row.mode as number,
+    mode: row.mode as ShieldedOutputMode,
     tokenId: (row.token_id ?? null) as string | null,
     scanPrivkey: row.scan_privkey as Buffer,
     ephemeralPubkey: row.ephemeral_pubkey as Buffer,

--- a/packages/wallet-service/src/db/shielded.ts
+++ b/packages/wallet-service/src/db/shielded.ts
@@ -341,6 +341,89 @@ export const rebuildWalletTxHistory = async (
   );
 };
 
+export interface ShieldedTxOutputData {
+  txId: string;
+  index: number;
+  commitment: Buffer;
+  ephemeralPubkey: Buffer;
+  rangeProof: Buffer;
+  script: Buffer;
+  tokenData: number | null;
+  assetCommitment: Buffer | null;
+  surjectionProof: Buffer | null;
+}
+
+export interface ShieldedAddressApiInfo {
+  address: string;
+  ctAddress: string;
+  shieldedIndex: number;
+}
+
+/**
+ * Fetch the on-chain crypto bytes for a batch of shielded outputs. One query
+ * regardless of list size; the returned Map is keyed `txId:index`.
+ *
+ * Deliberately separate from the ownership helpers: this returns no key
+ * material, so it is safe to feed straight into API responses.
+ */
+export const getShieldedTxOutputDataByIds = async (
+  mysql: ServerlessMysql,
+  ids: Array<{ txId: string; index: number }>,
+): Promise<Map<string, ShieldedTxOutputData>> => {
+  const dataMap = new Map<string, ShieldedTxOutputData>();
+  if (ids.length === 0) return dataMap;
+  const results: DbSelectResult = await mysql.query(
+    `SELECT \`tx_id\`, \`index\`, \`commitment\`, \`ephemeral_pubkey\`, \`range_proof\`,
+            \`script\`, \`token_data\`, \`asset_commitment\`, \`surjection_proof\`
+       FROM \`shielded_tx_output_data\`
+      WHERE (\`tx_id\`, \`index\`) IN (?)`,
+    [ids.map((id) => [id.txId, id.index])],
+  );
+  for (const row of results) {
+    dataMap.set(`${row.tx_id}:${row.index}`, {
+      txId: row.tx_id as string,
+      index: row.index as number,
+      commitment: row.commitment as Buffer,
+      ephemeralPubkey: row.ephemeral_pubkey as Buffer,
+      rangeProof: row.range_proof as Buffer,
+      script: row.script as Buffer,
+      tokenData: row.token_data == null ? null : Number(row.token_data),
+      assetCommitment: (row.asset_commitment ?? null) as Buffer | null,
+      surjectionProof: (row.surjection_proof ?? null) as Buffer | null,
+    });
+  }
+  return dataMap;
+};
+
+/**
+ * CTSpend display metadata for the caller wallet's shielded addresses.
+ * Returns no key material (unlike the ownership helpers used by recovery).
+ */
+export const getShieldedAddressInfoByAddresses = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  addresses: string[],
+): Promise<Map<string, ShieldedAddressApiInfo>> => {
+  const infoMap = new Map<string, ShieldedAddressApiInfo>();
+  if (addresses.length === 0) return infoMap;
+  const results: DbSelectResult = await mysql.query(
+    `SELECT \`address\`, \`ct_address\`, \`index\`
+       FROM \`address\`
+      WHERE \`wallet_id\` = ?
+        AND \`bip32_account\` = ?
+        AND \`address\` IN (?)`,
+    [walletId, Bip32Account.CTSpend, addresses],
+  );
+  for (const row of results) {
+    infoMap.set(row.address as string, {
+      address: row.address as string,
+      ctAddress: row.ct_address as string,
+      shieldedIndex: row.index as number,
+    });
+  }
+  return infoMap;
+};
+
 export interface ShieldedOwnershipRow {
   index: number;
   spendAddress: string;

--- a/packages/wallet-service/src/db/utils.ts
+++ b/packages/wallet-service/src/db/utils.ts
@@ -11,7 +11,7 @@ import { getWalletId } from '@src/utils';
 import {
   WalletStatus,
   CtStatus,
-  OutputKind,
+  TxKind,
   Wallet,
   Tx,
   DbSelectResult,
@@ -113,7 +113,7 @@ export const computeUnifiedStatus = (status: WalletStatus, ctStatus: CtStatus): 
  * Classify a history row by which balance deltas are non-zero. A row with
  * both deltas zero keeps the transparent reading it always had.
  */
-export const deriveOutputKind = (transparentDelta: bigint, shieldedDelta: bigint): OutputKind => {
+export const deriveTxKind = (transparentDelta: bigint, shieldedDelta: bigint): TxKind => {
   if (shieldedDelta === 0n) return 'transparent';
   if (transparentDelta === 0n) return 'shielded';
   return 'mixed';

--- a/packages/wallet-service/src/db/utils.ts
+++ b/packages/wallet-service/src/db/utils.ts
@@ -11,6 +11,7 @@ import { getWalletId } from '@src/utils';
 import {
   WalletStatus,
   CtStatus,
+  OutputKind,
   Wallet,
   Tx,
   DbSelectResult,
@@ -106,6 +107,16 @@ export const computeUnifiedStatus = (status: WalletStatus, ctStatus: CtStatus): 
   if (status === WalletStatus.ERROR || ctStatus === WalletStatus.ERROR) return WalletStatus.ERROR;
   if (status === WalletStatus.CREATING || ctStatus === WalletStatus.CREATING) return WalletStatus.CREATING;
   return WalletStatus.READY;
+};
+
+/**
+ * Classify a history row by which balance deltas are non-zero. A row with
+ * both deltas zero keeps the transparent reading it always had.
+ */
+export const deriveOutputKind = (transparentDelta: bigint, shieldedDelta: bigint): OutputKind => {
+  if (shieldedDelta === 0n) return 'transparent';
+  if (transparentDelta === 0n) return 'shielded';
+  return 'mixed';
 };
 
 /**

--- a/packages/wallet-service/src/db/utils.ts
+++ b/packages/wallet-service/src/db/utils.ts
@@ -100,7 +100,7 @@ export const getWalletFromDbEntry = (entry: Record<string, unknown>): Wallet => 
  *  - no shielded keys registered (`none`) → the legacy status
  *  - either side errored → error
  *  - either side still creating → creating
- *  - both ready → ready
+ *  - otherwise (neither errored nor creating) → ready
  */
 export const computeUnifiedStatus = (status: WalletStatus, ctStatus: CtStatus): WalletStatus => {
   if (ctStatus === 'none') return status;

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -186,6 +186,8 @@ export interface ShortAddressInfo {
   address: string;
   index: number;
   addressPath: string;
+  // The long-form CT address, populated only for CTSpend (account-2) rows.
+  ctAddress?: string | null;
 }
 
 export interface TokenBalance {

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -178,6 +178,8 @@ export interface AddressInfo {
   index: number;
   transactions: number;
   seqnum: number;
+  ctAddress?: string | null;
+  bip32Account?: number | null;
 }
 
 export interface ShortAddressInfo {
@@ -820,6 +822,7 @@ export interface PushDelete {
 
 export interface AddressAtIndexRequest {
   index?: number,
+  legacy?: boolean,
 }
 
 export interface TxByIdRequest {

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -11,7 +11,7 @@ import { TxInput, TxOutput } from '@wallet-service/common/src/types';
 
 import hathorLib, { TokenVersion } from '@hathor/wallet-lib';
 import { isAuthority } from '@wallet-service/common/src/utils/wallet.utils';
-import { RecoveryState } from '@wallet-service/common';
+import { RecoveryState, ShieldedOutputMode } from '@wallet-service/common';
 
 import {
   APIGatewayProxyEvent,
@@ -743,7 +743,7 @@ export interface DbTxOutput {
   txProposalId?: string;
   txProposalIndex?: number;
   voided?: boolean | null;
-  mode?: number;
+  mode?: ShieldedOutputMode;
   recoveryState?: RecoveryState | null;
 }
 
@@ -790,6 +790,29 @@ export interface IWalletInsufficientFunds {
 export interface DbTxOutputWithPath extends DbTxOutput {
   addressPath: string;
 }
+
+// The `/utxos` + `/tx_outputs` response entry: a discriminated union on `kind`.
+// Transparent entries are the tx_output-with-path shape; shielded entries add the
+// hydrated CT metadata and hex-encoded satellite bytes (mode-specific fields are
+// optional here — `tokenData` for AmountShielded, asset fields for FullyShielded).
+export interface TransparentTxOutputEntry extends DbTxOutputWithPath {
+  kind: 'transparent';
+}
+
+export interface ShieldedTxOutputEntry extends DbTxOutputWithPath {
+  kind: 'shielded';
+  ctAddress: string;
+  shieldedIndex: number;
+  commitment: string;
+  ephemeralPubkey: string;
+  rangeProof: string;
+  script: string;
+  tokenData?: number | null;
+  assetCommitment?: string;
+  surjectionProof?: string;
+}
+
+export type TxOutputEntry = TransparentTxOutputEntry | ShieldedTxOutputEntry;
 
 export interface Miner {
   address: string;

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -359,13 +359,22 @@ export class Balance {
 
   lockExpires: number | null;
 
-  constructor(totalAmountSent = 0n, unlockedAmount = 0n, lockedAmount = 0n, lockExpires = null, unlockedAuthorities = null, lockedAuthorities = null) {
+  unlockedShieldedAmount: bigint;
+
+  lockedShieldedAmount: bigint;
+
+  totalShieldedReceived: bigint;
+
+  constructor(totalAmountSent = 0n, unlockedAmount = 0n, lockedAmount = 0n, lockExpires = null, unlockedAuthorities = null, lockedAuthorities = null, unlockedShieldedAmount = 0n, lockedShieldedAmount = 0n, totalShieldedReceived = 0n) {
     this.totalAmountSent = totalAmountSent;
     this.unlockedAmount = unlockedAmount;
     this.lockedAmount = lockedAmount;
     this.lockExpires = lockExpires;
     this.unlockedAuthorities = unlockedAuthorities || new Authorities();
     this.lockedAuthorities = lockedAuthorities || new Authorities();
+    this.unlockedShieldedAmount = unlockedShieldedAmount;
+    this.lockedShieldedAmount = lockedShieldedAmount;
+    this.totalShieldedReceived = totalShieldedReceived;
   }
 
   /**
@@ -399,6 +408,9 @@ export class Balance {
       this.lockExpires,
       this.unlockedAuthorities.clone(),
       this.lockedAuthorities.clone(),
+      this.unlockedShieldedAmount,
+      this.lockedShieldedAmount,
+      this.totalShieldedReceived,
     );
   }
 
@@ -428,6 +440,9 @@ export class Balance {
       lockExpires,
       Authorities.merge(b1.unlockedAuthorities, b2.unlockedAuthorities),
       Authorities.merge(b1.lockedAuthorities, b2.lockedAuthorities),
+      b1.unlockedShieldedAmount + b2.unlockedShieldedAmount,
+      b1.lockedShieldedAmount + b2.lockedShieldedAmount,
+      b1.totalShieldedReceived + b2.totalShieldedReceived,
     );
   }
 }
@@ -465,8 +480,32 @@ export class WalletTokenBalance {
       token: this.token,
       transactions: this.transactions,
       balance: {
-        unlocked: this.balance.unlockedAmount,
-        locked: this.balance.lockedAmount,
+        unlocked: this.balance.unlockedAmount + this.balance.unlockedShieldedAmount,
+        locked: this.balance.lockedAmount + this.balance.lockedShieldedAmount,
+      },
+      tokenAuthorities: {
+        unlocked: this.balance.unlockedAuthorities,
+        locked: this.balance.lockedAuthorities,
+      },
+      lockExpires: this.balance.lockExpires,
+    };
+  }
+
+  toSplitJSON(): Record<string, unknown> {
+    return {
+      token: this.token,
+      transactions: this.transactions,
+      balance: {
+        unlocked: {
+          transparent: this.balance.unlockedAmount,
+          shielded: this.balance.unlockedShieldedAmount,
+          total: this.balance.unlockedAmount + this.balance.unlockedShieldedAmount,
+        },
+        locked: {
+          transparent: this.balance.lockedAmount,
+          shielded: this.balance.lockedShieldedAmount,
+          total: this.balance.lockedAmount + this.balance.lockedShieldedAmount,
+        },
       },
       tokenAuthorities: {
         unlocked: this.balance.unlockedAuthorities,

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -516,12 +516,19 @@ export class WalletTokenBalance {
   }
 }
 
+export type OutputKind = 'transparent' | 'shielded' | 'mixed';
+
 export interface TxTokenBalance {
   txId: string;
   timestamp: number;
   voided: boolean;
   balance: bigint;
   version: number;
+  output_kind: OutputKind;
+  balanceBreakdown: {
+    transparent: bigint;
+    shielded: bigint;
+  };
 }
 
 export class TokenBalanceMap {

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -519,7 +519,7 @@ export class WalletTokenBalance {
   }
 }
 
-export type OutputKind = 'transparent' | 'shielded' | 'mixed';
+export type TxKind = 'transparent' | 'shielded' | 'mixed';
 
 export interface TxTokenBalance {
   txId: string;
@@ -527,7 +527,7 @@ export interface TxTokenBalance {
   voided: boolean;
   balance: bigint;
   version: number;
-  output_kind: OutputKind;
+  tx_kind: TxKind;
   balanceBreakdown: {
     transparent: bigint;
     shielded: bigint;

--- a/packages/wallet-service/src/types.ts
+++ b/packages/wallet-service/src/types.ts
@@ -11,6 +11,7 @@ import { TxInput, TxOutput } from '@wallet-service/common/src/types';
 
 import hathorLib, { TokenVersion } from '@hathor/wallet-lib';
 import { isAuthority } from '@wallet-service/common/src/utils/wallet.utils';
+import { RecoveryState } from '@wallet-service/common';
 
 import {
   APIGatewayProxyEvent,
@@ -740,6 +741,8 @@ export interface DbTxOutput {
   txProposalId?: string;
   txProposalIndex?: number;
   voided?: boolean | null;
+  mode?: number;
+  recoveryState?: RecoveryState | null;
 }
 
 export interface Block {
@@ -769,6 +772,7 @@ export interface IFilterTxOutput {
   index?: number;
   totalAmount?: bigint;
   maxAmount?: bigint;
+  kind?: 'transparent' | 'shielded';
 }
 
 export enum InputSelectionAlgo {

--- a/packages/wallet-service/src/utils.ts
+++ b/packages/wallet-service/src/utils.ts
@@ -16,6 +16,7 @@ import * as bitcoinMessage from 'bitcoinjs-message';
 import * as ecc from 'tiny-secp256k1';
 import BIP32Factory from 'bip32';
 import config from '@src/config';
+import { Bip32Account } from '@wallet-service/common';
 
 const bip32 = BIP32Factory(ecc);
 
@@ -170,12 +171,12 @@ export const fetchBlockHeight = async (txId: string, logger: Logger): Promise<[n
 };
 
 /**
- * Creates default address path from address index
+ * Creates an address derivation path from an address index and its bip32 account.
  *
  * @returns {string} The address path
  */
-export const getAddressPath = (index: number): string => (
-  `m/44'/${hathorLib.constants.HATHOR_BIP44_CODE}'/0'/0/${index}`
+export const getAddressPath = (index: number, account: Bip32Account = Bip32Account.Legacy): string => (
+  `m/44'/${hathorLib.constants.HATHOR_BIP44_CODE}'/${account}'/0/${index}`
 );
 
 /**

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -374,7 +374,7 @@ test('GET /addresses legacy param selects the derivation account', async () => {
   expect(result.statusCode).toBe(404);
 });
 
-test('POST /addresses/check_mine resolves membership within the selected account', async () => {
+test('POST /addresses/check_mine resolves membership across all accounts', async () => {
   expect.hasAssertions();
 
   await addToWalletTable(mysql, [{
@@ -392,29 +392,18 @@ test('POST /addresses/check_mine resolves membership within the selected account
     { address: ADDRESSES[1], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
   ]);
 
-  // default: legacy account only
-  let event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
-    addresses: [ADDRESSES[0], ADDRESSES[1]],
+  // A wallet owns both its Legacy and its CTSpend addresses; a foreign address is not mine.
+  // check_mine returns only a boolean membership map, so it never filters by account.
+  const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
+    addresses: [ADDRESSES[0], ADDRESSES[1], ADDRESSES[2]],
   }));
-  let result = await checkMine(event, null, null) as APIGatewayProxyResult;
-  let returnBody = JSON.parse(result.body as string);
+  const result = await checkMine(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
   expect(result.statusCode).toBe(200);
   expect(returnBody.addresses).toStrictEqual({
     [ADDRESSES[0]]: true,
-    [ADDRESSES[1]]: false,
-  });
-
-  // legacy=false: CTSpend account only
-  event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
-    addresses: [ADDRESSES[0], ADDRESSES[1]],
-    legacy: false,
-  }));
-  result = await checkMine(event, null, null) as APIGatewayProxyResult;
-  returnBody = JSON.parse(result.body as string);
-  expect(result.statusCode).toBe(200);
-  expect(returnBody.addresses).toStrictEqual({
-    [ADDRESSES[0]]: false,
     [ADDRESSES[1]]: true,
+    [ADDRESSES[2]]: false,
   });
 });
 

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -908,8 +908,8 @@ test('GET /txhistory', async () => {
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody.history).toHaveLength(2);
-  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 5, voided: 0, version: 2, output_kind: 'transparent', balanceBreakdown: { transparent: 5, shielded: 0 } });
-  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 0, version: 3, output_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
+  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 5, voided: 0, version: 2, tx_kind: 'transparent', balanceBreakdown: { transparent: 5, shielded: 0 } });
+  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 0, version: 3, tx_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
 
   // with count just 1, return only the most recent tx
   event = makeGatewayEventWithAuthorizer('my-wallet', { count: '1' });
@@ -919,7 +919,7 @@ test('GET /txhistory', async () => {
   expect(returnBody.success).toBe(true);
   expect(returnBody.count).toBe(1);
   expect(returnBody.history).toHaveLength(1);
-  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 0, version: 3, output_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
+  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 0, version: 3, tx_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
 
   // skip first item
   event = makeGatewayEventWithAuthorizer('my-wallet', { skip: '1' });
@@ -929,7 +929,7 @@ test('GET /txhistory', async () => {
   expect(returnBody.success).toBe(true);
   expect(returnBody.skip).toBe(1);
   expect(returnBody.history).toHaveLength(1);
-  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 5, voided: 0, version: 2, output_kind: 'transparent', balanceBreakdown: { transparent: 5, shielded: 0 } });
+  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 5, voided: 0, version: 2, tx_kind: 'transparent', balanceBreakdown: { transparent: 5, shielded: 0 } });
 
   // use other token id
   event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: 'token2' });
@@ -938,7 +938,7 @@ test('GET /txhistory', async () => {
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody.history).toHaveLength(1);
-  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 7, voided: 0, version: 2, output_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
+  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 7, voided: 0, version: 2, tx_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
 
   // it should also return voided transactions
   event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: 'token3' });
@@ -947,10 +947,10 @@ test('GET /txhistory', async () => {
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody.history).toHaveLength(1);
-  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 1, version: 3, output_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
+  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 1, version: 3, tx_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
 });
 
-test('GET /txhistory carries output_kind and balanceBreakdown', async () => {
+test('GET /txhistory carries tx_kind and balanceBreakdown', async () => {
   expect.hasAssertions();
 
   await addToWalletTable(mysql, [{
@@ -975,13 +975,13 @@ test('GET /txhistory carries output_kind and balanceBreakdown', async () => {
   expect(returnBody.success).toBe(true);
 
   const byTx = Object.fromEntries(returnBody.history.map((h) => [h.txId, h]));
-  expect(byTx.stx1.output_kind === 'transparent').toBe(true);
+  expect(byTx.stx1.tx_kind === 'transparent').toBe(true);
   expect(byTx.stx1.balance).toBe(150);
   expect(byTx.stx1.balanceBreakdown).toStrictEqual({ transparent: 150, shielded: 0 });
-  expect(byTx.stx2.output_kind === 'shielded').toBe(true);
+  expect(byTx.stx2.tx_kind === 'shielded').toBe(true);
   expect(byTx.stx2.balance).toBe(150);
   expect(byTx.stx2.balanceBreakdown).toStrictEqual({ transparent: 0, shielded: 150 });
-  expect(byTx.stx3.output_kind === 'mixed').toBe(true);
+  expect(byTx.stx3.tx_kind === 'mixed').toBe(true);
   expect(byTx.stx3.balance).toBe(50);
   expect(byTx.stx3.balanceBreakdown).toStrictEqual({ transparent: -50, shielded: 100 });
 });

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -673,6 +673,111 @@ test('GET /balances', async () => {
   expect(returnBody.balances).toHaveLength(0);
 });
 
+test('GET /balances shielded: merged default, split breakdown and unified status', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'shielded-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+    ctStatus: 'ready',
+  }]);
+  const token1 = { id: 'token1', name: 'MyToken1', symbol: 'MT1', version: TokenVersion.DEPOSIT };
+  await addToTokenTable(mysql, [{ ...token1, transactions: 0 }]);
+  await addToWalletBalanceTable(mysql, [{
+    walletId: 'shielded-wallet',
+    tokenId: 'token1',
+    unlockedBalance: 1000n,
+    lockedBalance: 0n,
+    unlockedAuthorities: 0,
+    lockedAuthorities: 0,
+    timelockExpires: null,
+    transactions: 50,
+    unlockedShieldedBalance: 2500n,
+    lockedShieldedBalance: 0n,
+    totalShieldedReceived: 2500n,
+  }]);
+
+  // default: merged totals, same field shapes as today
+  let event = makeGatewayEventWithAuthorizer('shielded-wallet', null);
+  let result = await balancesGet(event, null, null) as APIGatewayProxyResult;
+  let returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.success).toBe(true);
+  expect(returnBody.status).toBe('ready');
+  expect(returnBody.balances).toContainEqual({
+    token: token1,
+    transactions: 50,
+    balance: { unlocked: 3500, locked: 0 },
+    lockExpires: null,
+    tokenAuthorities: { unlocked: { mint: false, melt: false }, locked: { mint: false, melt: false } },
+  });
+
+  // split=true: breakdown objects
+  event = makeGatewayEventWithAuthorizer('shielded-wallet', { split: 'true' });
+  result = await balancesGet(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.balances).toContainEqual({
+    token: token1,
+    transactions: 50,
+    balance: {
+      unlocked: { transparent: 1000, shielded: 2500, total: 3500 },
+      locked: { transparent: 0, shielded: 0, total: 0 },
+    },
+    lockExpires: null,
+    tokenAuthorities: { unlocked: { mint: false, melt: false }, locked: { mint: false, melt: false } },
+  });
+});
+
+test('GET /balances surfaces creating unified status during shielded catch-up', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'catching-up-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+    ctStatus: 'creating',
+  }]);
+
+  const event = makeGatewayEventWithAuthorizer('catching-up-wallet', null);
+  const result = await balancesGet(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.success).toBe(true);
+  expect(returnBody.status).toBe('creating');
+});
+
+test('GET /balances split=true renders zero backfill for unheld token', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'empty-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
+  await addToTokenTable(mysql, [{ id: 'token9', name: 'T9', symbol: 'T9', version: TokenVersion.DEPOSIT, transactions: 0 }]);
+
+  const event = makeGatewayEventWithAuthorizer('empty-wallet', { token_id: 'token9', split: 'true' });
+  const result = await balancesGet(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.balances).toHaveLength(1);
+  expect(returnBody.balances[0].balance).toStrictEqual({
+    unlocked: { transparent: 0, shielded: 0, total: 0 },
+    locked: { transparent: 0, shielded: 0, total: 0 },
+  });
+});
+
 test('GET /txhistory', async () => {
   expect.hasAssertions();
 

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -823,8 +823,8 @@ test('GET /txhistory', async () => {
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody.history).toHaveLength(2);
-  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 5, voided: 0, version: 2 });
-  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 0, version: 3 });
+  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 5, voided: 0, version: 2, output_kind: 'transparent', balanceBreakdown: { transparent: 5, shielded: 0 } });
+  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 0, version: 3, output_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
 
   // with count just 1, return only the most recent tx
   event = makeGatewayEventWithAuthorizer('my-wallet', { count: '1' });
@@ -834,7 +834,7 @@ test('GET /txhistory', async () => {
   expect(returnBody.success).toBe(true);
   expect(returnBody.count).toBe(1);
   expect(returnBody.history).toHaveLength(1);
-  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 0, version: 3 });
+  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 0, version: 3, output_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
 
   // skip first item
   event = makeGatewayEventWithAuthorizer('my-wallet', { skip: '1' });
@@ -844,7 +844,7 @@ test('GET /txhistory', async () => {
   expect(returnBody.success).toBe(true);
   expect(returnBody.skip).toBe(1);
   expect(returnBody.history).toHaveLength(1);
-  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 5, voided: 0, version: 2 });
+  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 5, voided: 0, version: 2, output_kind: 'transparent', balanceBreakdown: { transparent: 5, shielded: 0 } });
 
   // use other token id
   event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: 'token2' });
@@ -853,7 +853,7 @@ test('GET /txhistory', async () => {
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody.history).toHaveLength(1);
-  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 7, voided: 0, version: 2 });
+  expect(returnBody.history).toContainEqual({ txId: 'tx1', timestamp: 1000, balance: 7, voided: 0, version: 2, output_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
 
   // it should also return voided transactions
   event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: 'token3' });
@@ -862,7 +862,43 @@ test('GET /txhistory', async () => {
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody.history).toHaveLength(1);
-  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 1, version: 3 });
+  expect(returnBody.history).toContainEqual({ txId: 'tx2', timestamp: 1001, balance: 7, voided: 1, version: 3, output_kind: 'transparent', balanceBreakdown: { transparent: 7, shielded: 0 } });
+});
+
+test('GET /txhistory carries output_kind and balanceBreakdown', async () => {
+  expect.hasAssertions();
+
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
+  await addToWalletTxHistoryTable(mysql, [
+    ['my-wallet', 'stx1', '00', 150n, 2000, false],            // transparent-only
+    ['my-wallet', 'stx2', '00', 0n, 2001, false, 150n],        // shielded-only
+    ['my-wallet', 'stx3', '00', -50n, 2002, false, 100n],      // mixed
+  ]);
+
+  const event = makeGatewayEventWithAuthorizer('my-wallet', null);
+  const result = await txHistoryGet(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.success).toBe(true);
+
+  const byTx = Object.fromEntries(returnBody.history.map((h) => [h.txId, h]));
+  expect(byTx.stx1.output_kind === 'transparent').toBe(true);
+  expect(byTx.stx1.balance).toBe(150);
+  expect(byTx.stx1.balanceBreakdown).toStrictEqual({ transparent: 150, shielded: 0 });
+  expect(byTx.stx2.output_kind === 'shielded').toBe(true);
+  expect(byTx.stx2.balance).toBe(150);
+  expect(byTx.stx2.balanceBreakdown).toStrictEqual({ transparent: 0, shielded: 150 });
+  expect(byTx.stx3.output_kind === 'mixed').toBe(true);
+  expect(byTx.stx3.balance).toBe(50);
+  expect(byTx.stx3.balanceBreakdown).toStrictEqual({ transparent: -50, shielded: 100 });
 });
 
 test('GET /wallet', async () => {

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -453,6 +453,55 @@ test('GET /addresses/new', async () => {
   expect(returnBody.addresses).toContainEqual({ address: ADDRESSES[6], index: 6, addressPath: "m/44'/280'/0'/0/6" });
   expect(returnBody.addresses).toContainEqual({ address: ADDRESSES[7], index: 7, addressPath: "m/44'/280'/0'/0/7" });
   expect(returnBody.addresses).toContainEqual({ address: ADDRESSES[8], index: 8, addressPath: "m/44'/280'/0'/0/8" });
+
+  // legacy is not present in the default response
+  expect(returnBody.legacyAddresses).toBeUndefined();
+});
+
+test('GET /addresses/new legacy=false returns shielded and legacy unused addresses', async () => {
+  expect.hasAssertions();
+
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    highestUsedIndex: 4,
+    createdAt: 10000,
+    readyAt: 10001,
+    ctStatus: 'ready',
+    shieldedMaxGap: 3,
+    lastUsedShieldedIndex: 1,
+  }]);
+  await addToAddressTable(mysql, [
+    // Legacy account (0): unused addresses after the transparent frontier (index > 4)
+    { address: ADDRESSES[0], index: 5, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 6, walletId: 'my-wallet', transactions: 0, bip32_account: 0 },
+    // CTSpend account (2): used up to the shielded frontier (index <= 1), unused after it
+    { address: ADDRESSES[2], index: 1, walletId: 'my-wallet', transactions: 2, bip32_account: 2, ct_address: 'Hsh1' },
+    { address: ADDRESSES[3], index: 2, walletId: 'my-wallet', transactions: 0, bip32_account: 2, ct_address: 'Hsh2' },
+    { address: ADDRESSES[4], index: 3, walletId: 'my-wallet', transactions: 0, bip32_account: 2, ct_address: 'Hsh3' },
+    { address: ADDRESSES[5], index: 4, walletId: 'my-wallet', transactions: 0, bip32_account: 2, ct_address: 'Hsh4' },
+  ]);
+
+  const event = makeGatewayEventWithAuthorizer('my-wallet', { legacy: 'false' });
+  const result = await newAddressesGet(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.success).toBe(true);
+
+  // `addresses` are the CTSpend unused addresses within the shielded gap (3), on the account-2 path
+  expect(returnBody.addresses).toStrictEqual([
+    { address: ADDRESSES[3], index: 2, addressPath: "m/44'/280'/2'/0/2" },
+    { address: ADDRESSES[4], index: 3, addressPath: "m/44'/280'/2'/0/3" },
+    { address: ADDRESSES[5], index: 4, addressPath: "m/44'/280'/2'/0/4" },
+  ]);
+  // `legacyAddresses` carry today's legacy shape
+  expect(returnBody.legacyAddresses).toStrictEqual([
+    { address: ADDRESSES[0], index: 5, addressPath: "m/44'/280'/0'/0/5" },
+    { address: ADDRESSES[1], index: 6, addressPath: "m/44'/280'/0'/0/6" },
+  ]);
 });
 
 test('GET /addresses/new with no transactions', async () => {

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -357,7 +357,7 @@ test('GET /addresses legacy param selects the derivation account', async () => {
   returnBody = JSON.parse(result.body as string);
   expect(result.statusCode).toBe(200);
   expect(returnBody.addresses).toStrictEqual([
-    { address: ADDRESSES[2], index: 7, transactions: 3, seqnum: 0, ct_address: 'HshLongCtAddress1' },
+    { address: 'HshLongCtAddress1', spendAddress: ADDRESSES[2], index: 7, transactions: 3, seqnum: 0 },
   ]);
 
   // index lookup honours the account selector
@@ -366,7 +366,7 @@ test('GET /addresses legacy param selects the derivation account', async () => {
   returnBody = JSON.parse(result.body as string);
   expect(result.statusCode).toBe(200);
   expect(returnBody.addresses).toStrictEqual([
-    { address: ADDRESSES[2], index: 7, transactions: 3, seqnum: 0, ct_address: 'HshLongCtAddress1' },
+    { address: 'HshLongCtAddress1', spendAddress: ADDRESSES[2], index: 7, transactions: 3, seqnum: 0 },
   ]);
   // ...and defaults to legacy: index 7 does not exist in the legacy account
   event = makeGatewayEventWithAuthorizer('my-wallet', { index: '7' });
@@ -491,8 +491,14 @@ test('GET /addresses/new legacy=false returns shielded and legacy unused address
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
 
-  // `addresses` are the CTSpend unused addresses within the shielded gap (3), on the account-2 path
+  // `addresses` carry the user-facing CT address within the shielded gap (3), on the account-2 path
   expect(returnBody.addresses).toStrictEqual([
+    { address: 'Hsh2', index: 2, addressPath: "m/44'/280'/2'/0/2" },
+    { address: 'Hsh3', index: 3, addressPath: "m/44'/280'/2'/0/3" },
+    { address: 'Hsh4', index: 4, addressPath: "m/44'/280'/2'/0/4" },
+  ]);
+  // `spendAddresses` carry the parallel on-chain spend addresses
+  expect(returnBody.spendAddresses).toStrictEqual([
     { address: ADDRESSES[3], index: 2, addressPath: "m/44'/280'/2'/0/2" },
     { address: ADDRESSES[4], index: 3, addressPath: "m/44'/280'/2'/0/3" },
     { address: ADDRESSES[5], index: 4, addressPath: "m/44'/280'/2'/0/4" },

--- a/packages/wallet-service/tests/api.test.ts
+++ b/packages/wallet-service/tests/api.test.ts
@@ -322,6 +322,102 @@ test('GET /addresses/check_mine', async () => {
   expect(returnBody.details[1].message).toStrictEqual('"addresses[0]" length must be at least 34 characters long');
 });
 
+test('GET /addresses legacy param selects the derivation account', async () => {
+  expect.hasAssertions();
+
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
+
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 12, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 1, bip32_account: null as any },
+    { address: ADDRESSES[2], index: 7, walletId: 'my-wallet', transactions: 3, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+
+  // default: legacy only, exact historical shape (no ct_address / account keys)
+  let event = makeGatewayEventWithAuthorizer('my-wallet', null);
+  let result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  let returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.addresses).toStrictEqual([
+    { address: ADDRESSES[0], index: 0, transactions: 12, seqnum: 0 },
+    { address: ADDRESSES[1], index: 1, transactions: 1, seqnum: 0 },
+  ]);
+
+  // legacy=false: CTSpend rows with ct_address
+  event = makeGatewayEventWithAuthorizer('my-wallet', { legacy: 'false' });
+  result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.addresses).toStrictEqual([
+    { address: ADDRESSES[2], index: 7, transactions: 3, seqnum: 0, ct_address: 'HshLongCtAddress1' },
+  ]);
+
+  // index lookup honours the account selector
+  event = makeGatewayEventWithAuthorizer('my-wallet', { index: '7', legacy: 'false' });
+  result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.addresses).toStrictEqual([
+    { address: ADDRESSES[2], index: 7, transactions: 3, seqnum: 0, ct_address: 'HshLongCtAddress1' },
+  ]);
+  // ...and defaults to legacy: index 7 does not exist in the legacy account
+  event = makeGatewayEventWithAuthorizer('my-wallet', { index: '7' });
+  result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  expect(result.statusCode).toBe(404);
+});
+
+test('POST /addresses/check_mine resolves membership within the selected account', async () => {
+  expect.hasAssertions();
+
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
+
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+
+  // default: legacy account only
+  let event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
+    addresses: [ADDRESSES[0], ADDRESSES[1]],
+  }));
+  let result = await checkMine(event, null, null) as APIGatewayProxyResult;
+  let returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.addresses).toStrictEqual({
+    [ADDRESSES[0]]: true,
+    [ADDRESSES[1]]: false,
+  });
+
+  // legacy=false: CTSpend account only
+  event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
+    addresses: [ADDRESSES[0], ADDRESSES[1]],
+    legacy: false,
+  }));
+  result = await checkMine(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.addresses).toStrictEqual({
+    [ADDRESSES[0]]: false,
+    [ADDRESSES[1]]: true,
+  });
+});
+
 test('GET /addresses/new', async () => {
   expect.hasAssertions();
 

--- a/packages/wallet-service/tests/db.shielded.test.ts
+++ b/packages/wallet-service/tests/db.shielded.test.ts
@@ -13,7 +13,7 @@ import { Bip32Account } from '@wallet-service/common';
 import { deriveCtAddress } from '@wallet-service/common/src/crypto/shieldedAddress';
 import { DbSelectResult } from '@src/types';
 import { getDbConnection, closeDbConnection } from '@src/utils';
-import { cleanDatabase, addToWalletTable, addToAddressTable } from '@tests/utils';
+import { cleanDatabase, addToWalletTable, addToAddressTable, addToShieldedTxOutputDataTable } from '@tests/utils';
 import {
   findShieldedAddressOwnership,
   findShieldedAddressOwnershipBatch,
@@ -24,6 +24,8 @@ import {
   getWalletCtSpendAddresses,
   markShieldedCatchupDone,
   generateShieldedAddresses,
+  getShieldedTxOutputDataByIds,
+  getShieldedAddressInfoByAddresses,
 } from '@src/db/shielded';
 
 const mysql: ServerlessMysql = getDbConnection();
@@ -409,5 +411,59 @@ describe('generateShieldedAddresses', () => {
       scanPrivkey: derivedAt(3).scanPrivkey,
     });
     expect(res.newRows.map((r) => r.index)).toStrictEqual([3, 4, 5, 6]);
+  });
+});
+
+describe('shielded db: API hydration helpers', () => {
+  it('getShieldedTxOutputDataByIds returns satellite rows keyed by txId:index', async () => {
+    // shielded_tx_output_data FKs onto tx_output(tx_id, index) -> seed the parent rows first.
+    await insertShieldedOutput('tx1', 5, 'a1', 1, 'unowned', null, '00');
+    await insertShieldedOutput('tx2', 0, 'a1', 2, 'unowned', null, null);
+
+    await addToShieldedTxOutputDataTable(mysql, [{
+      txId: 'tx1', index: 5,
+      commitment: Buffer.alloc(33, 1), rangeProof: Buffer.alloc(64, 2),
+      script: Buffer.alloc(4, 3), ephemeralPubkey: Buffer.alloc(33, 4),
+      tokenData: 1,
+    }, {
+      txId: 'tx2', index: 0,
+      commitment: Buffer.alloc(33, 5), rangeProof: Buffer.alloc(64, 6),
+      script: Buffer.alloc(4, 7), ephemeralPubkey: Buffer.alloc(33, 8),
+      assetCommitment: Buffer.alloc(33, 9), surjectionProof: Buffer.alloc(64, 10),
+    }]);
+
+    const map = await getShieldedTxOutputDataByIds(mysql, [
+      { txId: 'tx1', index: 5 },
+      { txId: 'tx2', index: 0 },
+    ]);
+    expect(map.size).toBe(2);
+    expect(map.get('tx1:5')).toStrictEqual({
+      txId: 'tx1', index: 5,
+      commitment: Buffer.alloc(33, 1), ephemeralPubkey: Buffer.alloc(33, 4),
+      rangeProof: Buffer.alloc(64, 2), script: Buffer.alloc(4, 3),
+      tokenData: 1, assetCommitment: null, surjectionProof: null,
+    });
+    expect(map.get('tx2:0').tokenData).toBeNull();
+    expect(map.get('tx2:0').assetCommitment).toStrictEqual(Buffer.alloc(33, 9));
+    expect(map.get('tx2:0').surjectionProof).toStrictEqual(Buffer.alloc(64, 10));
+  });
+
+  it('getShieldedTxOutputDataByIds returns empty map without querying on empty input', async () => {
+    const map = await getShieldedTxOutputDataByIds(mysql, []);
+    expect(map.size).toBe(0);
+  });
+
+  it('getShieldedAddressInfoByAddresses only matches CTSpend rows of the wallet', async () => {
+    await addToAddressTable(mysql, [
+      { address: 'legacyAddr', index: 0, walletId: 'w1', transactions: 1, bip32_account: 0 },
+      { address: 'ctAddr', index: 7, walletId: 'w1', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+      { address: 'ctAddrOther', index: 1, walletId: 'w2', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress2' },
+    ]);
+
+    const map = await getShieldedAddressInfoByAddresses(mysql, 'w1', ['legacyAddr', 'ctAddr', 'ctAddrOther']);
+    expect(map.size).toBe(1);
+    expect(map.get('ctAddr')).toStrictEqual({
+      address: 'ctAddr', ctAddress: 'HshLongCtAddress1', shieldedIndex: 7,
+    });
   });
 });

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -65,6 +65,8 @@ import {
   addMiner,
   getMinersList,
   getExpiredTimelocksUtxos,
+  getNewAddresses,
+  getWalletUnlockedUtxos,
   getTotalTransactions,
   getAvailableAuthorities,
   getAffectedAddressTxCountFromTxList,
@@ -1442,6 +1444,22 @@ test('getUnusedAddresses', async () => {
   expect(addresses).toHaveLength(0);
 });
 
+test('getNewAddresses skips CTSpend rows', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'w1', xpubkey: 'xpub', authXpubkey: 'auth', status: 'ready',
+    maxGap: 10, createdAt: 1, readyAt: 2, highestUsedIndex: -1,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: 'legacyEmpty', index: 0, walletId: 'w1', transactions: 0, bip32_account: 0 },
+    { address: 'ctEmpty', index: 1, walletId: 'w1', transactions: 0, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+
+  const wallet = await getWallet(mysql, 'w1');
+  const newAddresses = await getNewAddresses(mysql, wallet);
+  expect(newAddresses.map((a) => a.address)).toStrictEqual(['legacyEmpty']);
+});
+
 test('markUtxosWithProposalId and getTxProposalInputs', async () => {
   expect.hasAssertions();
 
@@ -2706,6 +2724,42 @@ test('getExpiredTimelocksUtxos', async () => {
   expect(unlockedUtxos3).toHaveLength(3);
   // last one is an authority utxo
   expect(unlockedUtxos3[2].authorities).toStrictEqual(Number(outputs[4].value));
+});
+
+test('getExpiredTimelocksUtxos ignores shielded outputs', async () => {
+  expect.hasAssertions();
+  const now = getUnixTimestamp();
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 0, tokenId: '00', address: ADDRESSES[0], value: 10n,
+    authorities: 0, timelock: now - 100, heightlock: null, locked: true, spentBy: null,
+  }, {
+    txId: 'txS', index: 1, tokenId: '00', address: ADDRESSES[1], value: 20n,
+    authorities: 0, timelock: now - 100, heightlock: null, locked: true, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }]);
+
+  const utxos = await getExpiredTimelocksUtxos(mysql, now);
+  expect(utxos.map((u) => u.txId)).toStrictEqual(['txT']);
+});
+
+test('getWalletUnlockedUtxos ignores shielded outputs', async () => {
+  expect.hasAssertions();
+  const now = getUnixTimestamp();
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'w1', transactions: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'w1', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 0, tokenId: '00', address: ADDRESSES[0], value: 10n,
+    authorities: 0, timelock: now - 100, heightlock: null, locked: true, spentBy: null,
+  }, {
+    txId: 'txS', index: 1, tokenId: '00', address: ADDRESSES[1], value: 20n,
+    authorities: 0, timelock: now - 100, heightlock: null, locked: true, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }]);
+
+  const utxos = await getWalletUnlockedUtxos(mysql, 'w1', now, 100000);
+  expect(utxos.map((u) => u.txId)).toStrictEqual(['txT']);
 });
 
 test('getTotalTransactions', async () => {
@@ -4125,6 +4179,19 @@ describe('hasTransactionsOnNonFirstAddress', () => {
 
     expect(result1).toBe(false);
     expect(result2).toBe(true);
+  });
+
+  it('ignores CTSpend usage', async () => {
+    expect.hasAssertions();
+
+    const walletId = 'test-wallet';
+    await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, 5);
+    await addToAddressTable(mysql, [
+      { address: ADDRESSES[0], index: 0, walletId, transactions: 3, bip32_account: 0 },
+      { address: ADDRESSES[1], index: 5, walletId, transactions: 2, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+    ]);
+
+    expect(await Db.hasTransactionsOnNonFirstAddress(mysql, walletId)).toBe(false);
   });
 });
 

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -61,6 +61,7 @@ import {
   markUtxosAsVoided,
   unspendUtxos,
   filterTxOutputs,
+  mapDbResultToDbTxOutput,
   getTxProposalInputs,
   addMiner,
   getMinersList,
@@ -1519,7 +1520,7 @@ test('markUtxosWithProposalId and getTxProposalInputs', async () => {
   const address = 'address';
   const txProposalId = 'txProposalId';
 
-  const utxos = [{
+  const utxos: DbTxOutput[] = [{
     txId,
     index: 0,
     tokenId,
@@ -1988,7 +1989,7 @@ test('cleanupVoidedTx', async () => {
     [txId2, 0, 1, false, 0, 0],
   ]);
 
-  const utxo2 = {
+  const utxo2: DbTxOutput = {
     txId: txId2,
     index: 0,
     tokenId,
@@ -2775,6 +2776,15 @@ test('getExpiredTimelocksUtxos', async () => {
   expect(unlockedUtxos3).toHaveLength(3);
   // last one is an authority utxo
   expect(unlockedUtxos3[2].authorities).toStrictEqual(Number(outputs[4].value));
+});
+
+test('mapDbResultToDbTxOutput throws loudly on a NULL value', () => {
+  expect.hasAssertions();
+  // An unrecovered shielded row (value NULL) must be filtered out before mapping;
+  // a NULL reaching the mapper is an integrity violation and must not be coerced
+  // into a spendable-looking zero.
+  expect(() => mapDbResultToDbTxOutput({ tx_id: 'txU', index: 4, value: null, mode: 2 }))
+    .toThrow('tx_output txU:4 has a NULL value');
 });
 
 test('getExpiredTimelocksUtxos ignores shielded outputs', async () => {

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -115,7 +115,7 @@ import {
 } from '@src/types';
 import { Severity } from '@wallet-service/common/src/types';
 import { isAuthority } from '@wallet-service/common/src/utils/wallet.utils';
-import { Bip32Account } from '@wallet-service/common';
+import { Bip32Account, ShieldedOutputMode, RecoveryState } from '@wallet-service/common';
 import {
   closeDbConnection,
   getDbConnection,
@@ -602,6 +602,57 @@ test('addUtxos, getUtxos, unlockUtxos, updateTxOutputSpentBy, unspendUtxos, getT
 
   const countAfterDelete = await countTxOutputTable(mysql);
   expect(countAfterDelete).toStrictEqual(0);
+});
+
+test('getUtxos excludes unrecovered shielded outputs', async () => {
+  expect.hasAssertions();
+
+  await addToUtxoTable(mysql, [{
+    txId: 'txTransparent',
+    index: 0,
+    tokenId: 'token1',
+    address: 'address1',
+    value: 5n,
+    authorities: 0,
+    timelock: null,
+    heightlock: null,
+    locked: false,
+  }, {
+    txId: 'txRecoveredShielded',
+    index: 0,
+    tokenId: 'token1',
+    address: 'address2',
+    value: 10n,
+    authorities: 0,
+    timelock: null,
+    heightlock: null,
+    locked: false,
+    mode: ShieldedOutputMode.AmountShielded,
+    recoveryState: RecoveryState.Recovered,
+  }, {
+    txId: 'txUnrecoveredShielded',
+    index: 0,
+    tokenId: null,
+    address: 'address3',
+    value: null,
+    authorities: 0,
+    timelock: null,
+    heightlock: null,
+    locked: false,
+    mode: ShieldedOutputMode.FullyShielded,
+    recoveryState: RecoveryState.Unowned,
+  } as unknown as DbTxOutput]);
+
+  const results = await getUtxos(mysql, [
+    { txId: 'txTransparent', index: 0 },
+    { txId: 'txRecoveredShielded', index: 0 },
+    { txId: 'txUnrecoveredShielded', index: 0 },
+  ]);
+
+  const returnedKeys = results.map((utxo) => `${utxo.txId}:${utxo.index}`);
+  expect(returnedKeys).toHaveLength(2);
+  expect(returnedKeys).toStrictEqual(expect.arrayContaining(['txTransparent:0', 'txRecoveredShielded:0']));
+  expect(returnedKeys).not.toContain('txUnrecoveredShielded:0');
 });
 
 test('getLockedUtxoFromInputs', async () => {

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -96,6 +96,7 @@ import {
   rollbackTransaction,
   commitTransaction,
   computeUnifiedStatus,
+  deriveOutputKind,
 } from '@src/db/utils';
 import {
   Authorities,
@@ -4017,6 +4018,17 @@ describe('computeUnifiedStatus', () => {
 
   it('is ready only when both sides are ready', () => {
     expect(computeUnifiedStatus(WalletStatus.READY, WalletStatus.READY)).toBe(WalletStatus.READY);
+  });
+});
+
+describe('deriveOutputKind', () => {
+  it('classifies by which deltas are non-zero', () => {
+    expect(deriveOutputKind(150n, 0n)).toBe('transparent');
+    expect(deriveOutputKind(0n, 150n)).toBe('shielded');
+    expect(deriveOutputKind(-50n, 100n)).toBe('mixed');
+    expect(deriveOutputKind(0n, -25n)).toBe('shielded');
+    // a net-zero row keeps its historical transparent reading
+    expect(deriveOutputKind(0n, 0n)).toBe('transparent');
   });
 });
 

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -113,6 +113,7 @@ import {
 } from '@src/types';
 import { Severity } from '@wallet-service/common/src/types';
 import { isAuthority } from '@wallet-service/common/src/utils/wallet.utils';
+import { Bip32Account } from '@wallet-service/common';
 import {
   closeDbConnection,
   getDbConnection,
@@ -783,6 +784,42 @@ test('getWalletAddresses', async () => {
   expect(filteredReturnedAddresses[0].address).toBe(ADDRESSES[0]);
   expect(filteredReturnedAddresses[1].address).toBe(ADDRESSES[2]);
   expect(filteredReturnedAddresses[2].address).toBe(ADDRESSES[3]);
+});
+
+test('getWalletAddresses filters by bip32 account', async () => {
+  expect.hasAssertions();
+  await addToAddressTable(mysql, [
+    { address: 'legacyExplicit', index: 0, walletId: 'w1', transactions: 1, bip32_account: 0 },
+    { address: 'legacyNull', index: 1, walletId: 'w1', transactions: 2, bip32_account: null as any },
+    { address: 'ctSpend', index: 7, walletId: 'w1', transactions: 3, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+
+  const all = await getWalletAddresses(mysql, 'w1');
+  expect(all).toHaveLength(3);
+
+  const legacy = await getWalletAddresses(mysql, 'w1', null, Bip32Account.Legacy);
+  expect(legacy.map((a) => a.address)).toStrictEqual(['legacyExplicit', 'legacyNull']);
+
+  const ctSpend = await getWalletAddresses(mysql, 'w1', null, Bip32Account.CTSpend);
+  expect(ctSpend).toHaveLength(1);
+  expect(ctSpend[0].address).toBe('ctSpend');
+  expect(ctSpend[0].ctAddress).toBe('HshLongCtAddress1');
+  expect(ctSpend[0].bip32Account).toBe(2);
+});
+
+test('getAddressAtIndex disambiguates accounts sharing an index', async () => {
+  expect.hasAssertions();
+  await addToAddressTable(mysql, [
+    { address: 'legacyIdx1', index: 1, walletId: 'w1', transactions: 0, bip32_account: 0 },
+    { address: 'ctIdx1', index: 1, walletId: 'w1', transactions: 0, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+
+  const legacy = await getAddressAtIndex(mysql, 'w1', 1);
+  expect(legacy.address).toBe('legacyIdx1');
+
+  const ctSpend = await getAddressAtIndex(mysql, 'w1', 1, Bip32Account.CTSpend);
+  expect(ctSpend.address).toBe('ctIdx1');
+  expect(ctSpend.ctAddress).toBe('HshLongCtAddress1');
 });
 
 test('getWalletAddressDetail', async () => {
@@ -3890,6 +3927,7 @@ describe('getAddressByIndex', () => {
         index,
         transactions,
         seqnum,
+        ctAddress: null,
       });
   });
 

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -98,7 +98,7 @@ import {
   rollbackTransaction,
   commitTransaction,
   computeUnifiedStatus,
-  deriveOutputKind,
+  deriveTxKind,
 } from '@src/db/utils';
 import {
   Authorities,
@@ -4232,17 +4232,20 @@ describe('hasTransactionsOnNonFirstAddress', () => {
     expect(result2).toBe(true);
   });
 
-  it('ignores CTSpend usage', async () => {
+  it('counts CTSpend usage beyond the first address', async () => {
     expect.hasAssertions();
 
     const walletId = 'test-wallet';
     await createWallet(mysql, walletId, XPUBKEY, AUTH_XPUBKEY, 5);
+    // Only the first Legacy address is used; a CTSpend address at index 5 has
+    // activity. Membership is account-agnostic: any index > 0 with transactions
+    // flips the flag, so a shielded-active wallet is not treated as fresh.
     await addToAddressTable(mysql, [
       { address: ADDRESSES[0], index: 0, walletId, transactions: 3, bip32_account: 0 },
       { address: ADDRESSES[1], index: 5, walletId, transactions: 2, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
     ]);
 
-    expect(await Db.hasTransactionsOnNonFirstAddress(mysql, walletId)).toBe(false);
+    expect(await Db.hasTransactionsOnNonFirstAddress(mysql, walletId)).toBe(true);
   });
 });
 
@@ -4267,14 +4270,14 @@ describe('computeUnifiedStatus', () => {
   });
 });
 
-describe('deriveOutputKind', () => {
+describe('deriveTxKind', () => {
   it('classifies by which deltas are non-zero', () => {
-    expect(deriveOutputKind(150n, 0n)).toBe('transparent');
-    expect(deriveOutputKind(0n, 150n)).toBe('shielded');
-    expect(deriveOutputKind(-50n, 100n)).toBe('mixed');
-    expect(deriveOutputKind(0n, -25n)).toBe('shielded');
+    expect(deriveTxKind(150n, 0n)).toBe('transparent');
+    expect(deriveTxKind(0n, 150n)).toBe('shielded');
+    expect(deriveTxKind(-50n, 100n)).toBe('mixed');
+    expect(deriveTxKind(0n, -25n)).toBe('shielded');
     // a net-zero row keeps its historical transparent reading
-    expect(deriveOutputKind(0n, 0n)).toBe('transparent');
+    expect(deriveTxKind(0n, 0n)).toBe('transparent');
   });
 });
 

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -918,6 +918,56 @@ test('getWalletBalances', async () => {
   expect(returnedBalances).toHaveLength(0);
 });
 
+test('getWalletBalances should return shielded balance columns', async () => {
+  expect.hasAssertions();
+  await addToTokenTable(mysql, [
+    { id: 'token1', name: 'MyToken1', symbol: 'MT1', version: TokenVersion.DEPOSIT, transactions: 0 },
+  ]);
+  await addToWalletBalanceTable(mysql, [{
+    walletId: 'wallet1',
+    tokenId: 'token1',
+    unlockedBalance: 1000n,
+    lockedBalance: 4n,
+    unlockedAuthorities: 0,
+    lockedAuthorities: 0,
+    timelockExpires: null,
+    transactions: 5,
+    unlockedShieldedBalance: 2500n,
+    lockedShieldedBalance: 5n,
+    totalShieldedReceived: 2505n,
+  }]);
+
+  const balances = await getWalletBalances(mysql, 'wallet1');
+  expect(balances).toHaveLength(1);
+  expect(balances[0].balance.unlockedAmount).toBe(1000n);
+  expect(balances[0].balance.lockedAmount).toBe(4n);
+  expect(balances[0].balance.unlockedShieldedAmount).toBe(2500n);
+  expect(balances[0].balance.lockedShieldedAmount).toBe(5n);
+  expect(balances[0].balance.totalShieldedReceived).toBe(2505n);
+});
+
+test('getWalletBalances should default shielded fields to 0n on legacy rows', async () => {
+  expect.hasAssertions();
+  await addToTokenTable(mysql, [
+    { id: 'token1', name: 'MyToken1', symbol: 'MT1', version: TokenVersion.DEPOSIT, transactions: 0 },
+  ]);
+  await addToWalletBalanceTable(mysql, [{
+    walletId: 'wallet1',
+    tokenId: 'token1',
+    unlockedBalance: 10n,
+    lockedBalance: 0n,
+    unlockedAuthorities: 0,
+    lockedAuthorities: 0,
+    timelockExpires: null,
+    transactions: 1,
+  }]);
+
+  const balances = await getWalletBalances(mysql, 'wallet1');
+  expect(balances[0].balance.unlockedShieldedAmount).toBe(0n);
+  expect(balances[0].balance.lockedShieldedAmount).toBe(0n);
+  expect(balances[0].balance.totalShieldedReceived).toBe(0n);
+});
+
 test('getUtxosLockedAtHeight', async () => {
   expect.hasAssertions();
 

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -4338,9 +4338,12 @@ describe('combined-load wallet helpers', () => {
     await mysql.query('INSERT INTO `address` (`address`, `index`, `wallet_id`, `transactions`) VALUES (?, 1, ?, 2)', ['addr1', wid]);
     await mysql.query('UPDATE `wallet` SET `last_used_address_index` = 7 WHERE `id` = ?', [wid]);
     await upsertNewAddresses(mysql, wid, { addr0: 0, addr1: 1 }, 3); // stale frontier 3
-    const rows = await mysql.query('SELECT `address`, `transactions` FROM `address` ORDER BY `index`');
+    const rows = await mysql.query('SELECT `address`, `transactions`, `bip32_account` FROM `address` ORDER BY `index`') as unknown as Array<{ transactions: number; bip32_account: number }>;
     expect(rows).toHaveLength(2); // no dup-key crash
     expect(Number(rows[1].transactions)).toBe(2); // untouched on duplicate
+    // claimed legacy addresses carry an explicit account, including the row that
+    // pre-existed with a NULL account and was claimed here
+    expect(rows.map((row) => Number(row.bip32_account))).toStrictEqual([0, 0]);
     const w = await getWallet(mysql, wid);
     expect(w.lastUsedAddressIndex).toBe(7); // GREATEST kept the newer frontier
   });

--- a/packages/wallet-service/tests/db.test.ts
+++ b/packages/wallet-service/tests/db.test.ts
@@ -513,6 +513,8 @@ test('addUtxos, getUtxos, unlockUtxos, updateTxOutputSpentBy, unspendUtxos, getT
     spentBy: null,
     txProposalId: null,
     txProposalIndex: null,
+    mode: 0,
+    recoveryState: null,
   });
 
   // empty list should be fine
@@ -537,6 +539,8 @@ test('addUtxos, getUtxos, unlockUtxos, updateTxOutputSpentBy, unspendUtxos, getT
     spentBy: txId,
     txProposalId: null,
     txProposalIndex: null,
+    mode: 0,
+    recoveryState: null,
   });
 
   // if the tx output is not found, it should return null
@@ -1422,6 +1426,8 @@ test('markUtxosWithProposalId and getTxProposalInputs', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   }, {
     txId,
     index: 1,
@@ -1435,6 +1441,8 @@ test('markUtxosWithProposalId and getTxProposalInputs', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   }, {
     txId,
     index: 2,
@@ -1448,6 +1456,8 @@ test('markUtxosWithProposalId and getTxProposalInputs', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   }];
 
   // add to utxo table
@@ -1885,6 +1895,8 @@ test('cleanupVoidedTx', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   };
 
   await addToUtxoTable(mysql, [utxo2]);
@@ -2348,6 +2360,8 @@ test('filterTxOutputs', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
   expect(utxos[1]).toStrictEqual({
     txId: txId2,
@@ -2362,6 +2376,8 @@ test('filterTxOutputs', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
 
   // limit to 2 utxos, should return the largest 2 ordered by value
@@ -2380,6 +2396,8 @@ test('filterTxOutputs', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
   expect(utxos[1]).toStrictEqual({
     txId: txId2,
@@ -2394,6 +2412,8 @@ test('filterTxOutputs', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
 
   // authorities != 0 and maxOutputs == 1 should return only one authority utxo
@@ -2406,6 +2426,70 @@ test('filterTxOutputs should throw if addresses are empty', async () => {
   expect.hasAssertions();
 
   await expect(filterTxOutputs(mysql, { addresses: [] })).rejects.toThrow('Addresses can\'t be empty.');
+});
+
+test('filterTxOutputs shielded: default merges kinds and excludes unrecovered', async () => {
+  expect.hasAssertions();
+
+  await addToAddressTable(mysql, [{
+    address: ADDRESSES[0], index: 0, walletId: 'walletId', transactions: 1, bip32_account: 0,
+  }, {
+    address: ADDRESSES[1], index: 1, walletId: 'walletId', transactions: 1, bip32_account: 0,
+  }]);
+
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 0, tokenId: '00', address: ADDRESSES[0], value: 500n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+  }, {
+    txId: 'txS', index: 5, tokenId: '00', address: ADDRESSES[1], value: 150n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }, {
+    txId: 'txU', index: 6, tokenId: null, address: ADDRESSES[1], value: null,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 2, recoveryState: 'unowned',
+  } as any]);
+
+  // default: both kinds, recovered only
+  let results = await filterTxOutputs(mysql, { addresses: [ADDRESSES[0], ADDRESSES[1]] });
+  expect(results).toHaveLength(2);
+  const shieldedRow = results.find((r) => r.txId === 'txS');
+  expect(shieldedRow.mode).toBe(1);
+  expect(shieldedRow.recoveryState === 'recovered').toBe(true);
+  expect(results.find((r) => r.txId === 'txU')).toBeUndefined();
+
+  // kind=transparent
+  results = await filterTxOutputs(mysql, { addresses: [ADDRESSES[0], ADDRESSES[1]], kind: 'transparent' });
+  expect(results).toHaveLength(1);
+  expect(results[0].txId).toBe('txT');
+  expect(results[0].mode).toBe(0);
+  expect(results[0].recoveryState).toBeNull();
+
+  // kind=shielded
+  results = await filterTxOutputs(mysql, { addresses: [ADDRESSES[0], ADDRESSES[1]], kind: 'shielded' });
+  expect(results).toHaveLength(1);
+  expect(results[0].txId).toBe('txS');
+});
+
+test('filterTxOutputs authority filter excludes shielded rows', async () => {
+  expect.hasAssertions();
+
+  await addToAddressTable(mysql, [{
+    address: ADDRESSES[0], index: 0, walletId: 'walletId', transactions: 1, bip32_account: 0,
+  }]);
+
+  await addToUtxoTable(mysql, [{
+    txId: 'txA', index: 0, tokenId: 'token1', address: ADDRESSES[0], value: 1n,
+    authorities: 1, timelock: null, heightlock: null, locked: false, spentBy: null,
+  }, {
+    txId: 'txS', index: 1, tokenId: 'token1', address: ADDRESSES[0], value: 150n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }]);
+
+  const results = await filterTxOutputs(mysql, { addresses: [ADDRESSES[0]], tokenId: 'token1', authority: 1 });
+  expect(results).toHaveLength(1);
+  expect(results[0].txId).toBe('txA');
 });
 
 test('beginTransaction, commitTransaction, rollbackTransaction', async () => {
@@ -2729,6 +2813,8 @@ test('getUtxo, getAuthorityUtxo', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
 
   const mintUtxo = await getAuthorityUtxo(mysql, tokenId, Number(constants.TOKEN_MINT_MASK));
@@ -2747,6 +2833,8 @@ test('getUtxo, getAuthorityUtxo', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
   expect(meltUtxo).toStrictEqual({
     txId: 'txId',
@@ -2761,6 +2849,8 @@ test('getUtxo, getAuthorityUtxo', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
 });
 

--- a/packages/wallet-service/tests/txOutputs.test.ts
+++ b/packages/wallet-service/tests/txOutputs.test.ts
@@ -387,6 +387,8 @@ test('get utxos with wallet id', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
 
   expect(result.statusCode).toBe(200);
@@ -495,6 +497,8 @@ test('get tx outputs with wallet id', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
 
   expect(result.statusCode).toBe(200);
@@ -605,6 +609,8 @@ test('get authority utxos', async () => {
     txProposalId: null,
     txProposalIndex: null,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
 
   let event = makeGatewayEventWithAuthorizer('my-wallet', {
@@ -733,6 +739,8 @@ test('get a specific utxo', async () => {
     txProposalIndex: null,
     addressPath: `m/44'/280'/0'/0/${path}`,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   });
 
   expect(result.statusCode).toBe(200);
@@ -868,6 +876,8 @@ test('get spent tx_output', async () => {
     heightlock: null,
     locked: false,
     spentBy: null,
+    mode: 0,
+    recoveryState: null,
   }, {
     txId: TX_IDS[1],
     index: 0,
@@ -879,6 +889,8 @@ test('get spent tx_output', async () => {
     heightlock: null,
     locked: false,
     spentBy: '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50',
+    mode: 0,
+    recoveryState: null,
   }];
 
   await addToUtxoTable(mysql, txOutputs);

--- a/packages/wallet-service/tests/txOutputs.test.ts
+++ b/packages/wallet-service/tests/txOutputs.test.ts
@@ -1,3 +1,5 @@
+import { mockedAddAlert } from '@tests/utils/alerting.utils.mock';
+import { Severity } from '@wallet-service/common';
 import {
   getFilteredTxOutputs,
   getFilteredUtxos,
@@ -1544,4 +1546,43 @@ test('GET /wallet/tx_outputs txId+index of an unrecovered shielded output return
   const returnBody = JSON.parse(result.body as string);
   expect(result.statusCode).toBe(200);
   expect(returnBody.txOutputs).toStrictEqual([]);
+});
+
+test('GET /wallet/tx_outputs degrades and alerts on a shielded row missing its satellite data', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 7, walletId: 'my-wallet', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 2, tokenId: '00', address: ADDRESSES[0], value: 500n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+  }, {
+    // recovered shielded row, but its shielded_tx_output_data satellite row is never inserted
+    txId: 'txS', index: 5, tokenId: '00', address: ADDRESSES[1], value: 150n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }]);
+
+  const event = makeGatewayEventWithAuthorizer('my-wallet', {});
+  const result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.success).toBe(true);
+  expect(returnBody.txOutputs).toHaveLength(1);
+  expect(returnBody.txOutputs[0].txId).toBe('txT');
+  expect(returnBody.txOutputs.find((o) => o.txId === 'txS')).toBeUndefined();
+
+  expect(mockedAddAlert).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.any(String),
+    Severity.MAJOR,
+    expect.objectContaining({ txId: 'txS', index: 5 }),
+    expect.anything(),
+  );
 });

--- a/packages/wallet-service/tests/txOutputs.test.ts
+++ b/packages/wallet-service/tests/txOutputs.test.ts
@@ -18,6 +18,7 @@ import {
   AUTH_XPUBKEY,
 } from '@tests/utils';
 import { ApiError } from '@src/api/errors';
+import { DbTxOutput } from '@src/types';
 import { APIGatewayProxyResult } from 'aws-lambda';
 
 const mysql = getDbConnection();
@@ -874,7 +875,7 @@ test('get spent tx_output', async () => {
 
   const token1 = '004d75c1edd4294379e7e5b7ab6c118c53c8b07a506728feb5688c8d26a97e50';
 
-  const txOutputs = [{
+  const txOutputs: DbTxOutput[] = [{
     txId: TX_IDS[0],
     index: 0,
     tokenId: token1,
@@ -1486,6 +1487,44 @@ test('GET /wallet/tx_outputs kind filter selects one side', async () => {
   event = makeGatewayEventWithAuthorizer('my-wallet', { kind: 'purple' });
   result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
   expect(result.statusCode).toBe(400);
+});
+
+test('GET /wallet/tx_outputs totalAmount without kind selects only transparent UTXOs', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 7, walletId: 'my-wallet', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 2, tokenId: '00', address: ADDRESSES[0], value: 100n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+  }, {
+    txId: 'txS', index: 5, tokenId: '00', address: ADDRESSES[1], value: 100n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }]);
+  await addToShieldedTxOutputDataTable(mysql, [{
+    txId: 'txS', index: 5,
+    commitment: Buffer.from('aa'.repeat(33), 'hex'),
+    rangeProof: Buffer.from('bb'.repeat(64), 'hex'),
+    script: Buffer.from('cc'.repeat(4), 'hex'),
+    ephemeralPubkey: Buffer.from('dd'.repeat(33), 'hex'),
+    tokenData: 1,
+  }]);
+
+  // A funding selection with no explicit kind must not hand a shielded output to a
+  // transparent spend: only the transparent UTXO can satisfy totalAmount here.
+  const event = makeGatewayEventWithAuthorizer('my-wallet', { tokenId: '00', totalAmount: '50' });
+  const result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.txOutputs).toHaveLength(1);
+  expect(returnBody.txOutputs[0].txId).toBe('txT');
+  expect(returnBody.txOutputs[0].kind === 'transparent').toBe(true);
 });
 
 test('GET /wallet/tx_outputs mode-2 entry carries asset fields and no tokenData', async () => {

--- a/packages/wallet-service/tests/txOutputs.test.ts
+++ b/packages/wallet-service/tests/txOutputs.test.ts
@@ -1548,6 +1548,36 @@ test('GET /wallet/tx_outputs txId+index of an unrecovered shielded output return
   expect(returnBody.txOutputs).toStrictEqual([]);
 });
 
+test('GET /wallet/tx_outputs txId+index honors the kind filter', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 2, tokenId: '00', address: ADDRESSES[0], value: 500n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+  }]);
+
+  // kind=transparent matches the transparent output
+  let event = makeGatewayEventWithAuthorizer('my-wallet', { txId: 'txT', index: '2', kind: 'transparent' });
+  let result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  let returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.txOutputs).toHaveLength(1);
+  expect(returnBody.txOutputs[0].kind === 'transparent').toBe(true);
+
+  // kind=shielded excludes the same transparent output
+  event = makeGatewayEventWithAuthorizer('my-wallet', { txId: 'txT', index: '2', kind: 'shielded' });
+  result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.txOutputs).toStrictEqual([]);
+});
+
 test('GET /wallet/tx_outputs degrades and alerts on a shielded row missing its satellite data', async () => {
   expect.hasAssertions();
   await addToWalletTable(mysql, [{

--- a/packages/wallet-service/tests/txOutputs.test.ts
+++ b/packages/wallet-service/tests/txOutputs.test.ts
@@ -7,10 +7,13 @@ import {
   addToUtxoTable,
   addToWalletTable,
   addToAddressTable,
+  addToShieldedTxOutputDataTable,
   makeGatewayEventWithAuthorizer,
   cleanDatabase,
   ADDRESSES,
   TX_IDS,
+  XPUBKEY,
+  AUTH_XPUBKEY,
 } from '@tests/utils';
 import { ApiError } from '@src/api/errors';
 import { APIGatewayProxyResult } from 'aws-lambda';
@@ -389,6 +392,7 @@ test('get utxos with wallet id', async () => {
     spentBy: null,
     mode: 0,
     recoveryState: null,
+    kind: 'transparent',
   });
 
   expect(result.statusCode).toBe(200);
@@ -499,6 +503,7 @@ test('get tx outputs with wallet id', async () => {
     spentBy: null,
     mode: 0,
     recoveryState: null,
+    kind: 'transparent',
   });
 
   expect(result.statusCode).toBe(200);
@@ -611,6 +616,7 @@ test('get authority utxos', async () => {
     spentBy: null,
     mode: 0,
     recoveryState: null,
+    kind: 'transparent',
   });
 
   let event = makeGatewayEventWithAuthorizer('my-wallet', {
@@ -741,6 +747,7 @@ test('get a specific utxo', async () => {
     spentBy: null,
     mode: 0,
     recoveryState: null,
+    kind: 'transparent',
   });
 
   expect(result.statusCode).toBe(200);
@@ -909,6 +916,7 @@ test('get spent tx_output', async () => {
     txProposalIndex: null,
     txProposalId: null,
     addressPath: `m/44'/280'/0'/0/${path}`,
+    kind: 'transparent',
   });
 
   expect(result.statusCode).toBe(200);
@@ -1367,4 +1375,173 @@ test('filter tx_outputs with both totalAmount and maxAmount should fail', async 
   expect(result.statusCode).toBe(400);
   expect(returnBody.success).toBe(false);
   expect(returnBody.error).toBe('invalid-payload');
+});
+
+test('GET /wallet/tx_outputs returns merged transparent and shielded entries', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 7, walletId: 'my-wallet', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 2, tokenId: '00', address: ADDRESSES[0], value: 500n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+  }, {
+    txId: 'txS', index: 5, tokenId: '00', address: ADDRESSES[1], value: 150n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }]);
+  await addToShieldedTxOutputDataTable(mysql, [{
+    txId: 'txS', index: 5,
+    commitment: Buffer.from('aa'.repeat(33), 'hex'),
+    rangeProof: Buffer.from('bb'.repeat(64), 'hex'),
+    script: Buffer.from('cc'.repeat(4), 'hex'),
+    ephemeralPubkey: Buffer.from('dd'.repeat(33), 'hex'),
+    tokenData: 1,
+  }]);
+
+  const event = makeGatewayEventWithAuthorizer('my-wallet', {});
+  const result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.txOutputs).toHaveLength(2);
+
+  const transparent = returnBody.txOutputs.find((o) => o.txId === 'txT');
+  expect(transparent.kind === 'transparent').toBe(true);
+  expect(transparent.addressPath).toBe(`m/44'/280'/0'/0/0`);
+
+  const shielded = returnBody.txOutputs.find((o) => o.txId === 'txS');
+  expect(shielded).toStrictEqual({
+    kind: 'shielded',
+    txId: 'txS',
+    index: 5,
+    tokenId: '00',
+    address: ADDRESSES[1],
+    value: 150,
+    authorities: 0,
+    timelock: null,
+    heightlock: null,
+    locked: false,
+    spentBy: null,
+    txProposalId: null,
+    txProposalIndex: null,
+    addressPath: `m/44'/280'/2'/0/7`,
+    mode: 1,
+    recoveryState: 'recovered',
+    shieldedIndex: 7,
+    ctAddress: 'HshLongCtAddress1',
+    commitment: 'aa'.repeat(33),
+    ephemeralPubkey: 'dd'.repeat(33),
+    rangeProof: 'bb'.repeat(64),
+    script: 'cc'.repeat(4),
+    tokenData: 1,
+  });
+});
+
+test('GET /wallet/tx_outputs kind filter selects one side', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 7, walletId: 'my-wallet', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 2, tokenId: '00', address: ADDRESSES[0], value: 500n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+  }, {
+    txId: 'txS', index: 5, tokenId: '00', address: ADDRESSES[1], value: 150n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }]);
+  await addToShieldedTxOutputDataTable(mysql, [{
+    txId: 'txS', index: 5,
+    commitment: Buffer.from('aa'.repeat(33), 'hex'),
+    rangeProof: Buffer.from('bb'.repeat(64), 'hex'),
+    script: Buffer.from('cc'.repeat(4), 'hex'),
+    ephemeralPubkey: Buffer.from('dd'.repeat(33), 'hex'),
+    tokenData: 1,
+  }]);
+
+  let event = makeGatewayEventWithAuthorizer('my-wallet', { kind: 'transparent' });
+  let result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  let returnBody = JSON.parse(result.body as string);
+  expect(returnBody.txOutputs).toHaveLength(1);
+  expect(returnBody.txOutputs[0].kind === 'transparent').toBe(true);
+
+  event = makeGatewayEventWithAuthorizer('my-wallet', { kind: 'shielded' });
+  result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(returnBody.txOutputs).toHaveLength(1);
+  expect(returnBody.txOutputs[0].kind === 'shielded').toBe(true);
+
+  event = makeGatewayEventWithAuthorizer('my-wallet', { kind: 'purple' });
+  result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  expect(result.statusCode).toBe(400);
+});
+
+test('GET /wallet/tx_outputs mode-2 entry carries asset fields and no tokenData', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[1], index: 7, walletId: 'my-wallet', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txF', index: 3, tokenId: 'token1', address: ADDRESSES[1], value: 200n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 2, recoveryState: 'recovered',
+  }]);
+  await addToShieldedTxOutputDataTable(mysql, [{
+    txId: 'txF', index: 3,
+    commitment: Buffer.from('aa'.repeat(33), 'hex'),
+    rangeProof: Buffer.from('bb'.repeat(64), 'hex'),
+    script: Buffer.from('cc'.repeat(4), 'hex'),
+    ephemeralPubkey: Buffer.from('dd'.repeat(33), 'hex'),
+    tokenData: null,
+    assetCommitment: Buffer.from('ee'.repeat(33), 'hex'),
+    surjectionProof: Buffer.from('ff'.repeat(64), 'hex'),
+  }]);
+
+  const event = makeGatewayEventWithAuthorizer('my-wallet', { tokenId: 'token1' });
+  const result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.txOutputs).toHaveLength(1);
+  const entry = returnBody.txOutputs[0];
+  expect(entry.kind === 'shielded').toBe(true);
+  expect(entry.mode).toBe(2);
+  expect(entry.assetCommitment).toBe('ee'.repeat(33));
+  expect(entry.surjectionProof).toBe('ff'.repeat(64));
+  expect(entry.tokenData).toBeUndefined();
+});
+
+test('GET /wallet/tx_outputs txId+index of an unrecovered shielded output returns empty', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[1], index: 7, walletId: 'my-wallet', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txU', index: 4, tokenId: null, address: ADDRESSES[1], value: null,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 2, recoveryState: 'unowned',
+  } as any]);
+
+  const event = makeGatewayEventWithAuthorizer('my-wallet', { txId: 'txU', index: '4' });
+  const result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.txOutputs).toStrictEqual([]);
 });

--- a/packages/wallet-service/tests/txOutputs.test.ts
+++ b/packages/wallet-service/tests/txOutputs.test.ts
@@ -1612,7 +1612,130 @@ test('GET /wallet/tx_outputs degrades and alerts on a shielded row missing its s
     expect.any(String),
     expect.any(String),
     Severity.MAJOR,
-    expect.objectContaining({ txId: 'txS', index: 5 }),
+    { txId: 'txS', index: 5, missing: ['satellite'] },
+    expect.anything(),
+  );
+});
+
+test('GET /wallet/tx_outputs degrades and alerts on a shielded row missing its ownership row', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  // The shielded row sits on a Legacy address of the wallet: it passes the
+  // wallet-membership filter but has no CTSpend ownership row to resolve.
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 2, tokenId: '00', address: ADDRESSES[0], value: 500n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+  }, {
+    txId: 'txS', index: 5, tokenId: '00', address: ADDRESSES[1], value: 150n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }]);
+  await addToShieldedTxOutputDataTable(mysql, [{
+    txId: 'txS', index: 5,
+    commitment: Buffer.from('aa'.repeat(33), 'hex'),
+    rangeProof: Buffer.from('bb'.repeat(64), 'hex'),
+    script: Buffer.from('cc'.repeat(4), 'hex'),
+    ephemeralPubkey: Buffer.from('dd'.repeat(33), 'hex'),
+    tokenData: 1,
+  }]);
+
+  const event = makeGatewayEventWithAuthorizer('my-wallet', {});
+  const result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.txOutputs).toHaveLength(1);
+  expect(returnBody.txOutputs[0].txId).toBe('txT');
+  expect(mockedAddAlert).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.any(String),
+    Severity.MAJOR,
+    { txId: 'txS', index: 5, missing: ['ownership'] },
+    expect.anything(),
+  );
+});
+
+test('GET /wallet/tx_outputs degrades and pins both missing sides', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+  ]);
+  // recovered shielded row with neither a satellite row nor a CTSpend ownership row
+  await addToUtxoTable(mysql, [{
+    txId: 'txS', index: 5, tokenId: '00', address: ADDRESSES[1], value: 150n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 1, recoveryState: 'recovered',
+  }]);
+
+  const event = makeGatewayEventWithAuthorizer('my-wallet', {});
+  const result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.txOutputs).toStrictEqual([]);
+  expect(mockedAddAlert).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.any(String),
+    Severity.MAJOR,
+    { txId: 'txS', index: 5, missing: ['satellite', 'ownership'] },
+    expect.anything(),
+  );
+});
+
+test('GET /wallet/tx_outputs degrades a FullyShielded row with a NULL asset field', async () => {
+  expect.hasAssertions();
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet', xpubkey: XPUBKEY, authXpubkey: AUTH_XPUBKEY,
+    status: 'ready', maxGap: 5, createdAt: 10000, readyAt: 10001,
+  }]);
+  await addToAddressTable(mysql, [
+    { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 1, bip32_account: 0 },
+    { address: ADDRESSES[1], index: 7, walletId: 'my-wallet', transactions: 1, bip32_account: 2, ct_address: 'HshLongCtAddress1' },
+  ]);
+  await addToUtxoTable(mysql, [{
+    txId: 'txT', index: 2, tokenId: '00', address: ADDRESSES[0], value: 500n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+  }, {
+    txId: 'txF', index: 3, tokenId: 'token1', address: ADDRESSES[1], value: 200n,
+    authorities: 0, timelock: null, heightlock: null, locked: false, spentBy: null,
+    mode: 2, recoveryState: 'recovered',
+  }]);
+  // FullyShielded satellite row present but surjection_proof is NULL — would crash
+  // serialization; must degrade instead.
+  await addToShieldedTxOutputDataTable(mysql, [{
+    txId: 'txF', index: 3,
+    commitment: Buffer.from('aa'.repeat(33), 'hex'),
+    rangeProof: Buffer.from('bb'.repeat(64), 'hex'),
+    script: Buffer.from('cc'.repeat(4), 'hex'),
+    ephemeralPubkey: Buffer.from('dd'.repeat(33), 'hex'),
+    tokenData: null,
+    assetCommitment: Buffer.from('ee'.repeat(33), 'hex'),
+    surjectionProof: null,
+  }]);
+
+  const event = makeGatewayEventWithAuthorizer('my-wallet', { tokenId: 'token1' });
+  const result = await getFilteredTxOutputs(event, null, null) as APIGatewayProxyResult;
+  const returnBody = JSON.parse(result.body as string);
+
+  expect(result.statusCode).toBe(200);
+  expect(returnBody.txOutputs).toStrictEqual([]);
+  expect(mockedAddAlert).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.any(String),
+    Severity.MAJOR,
+    { txId: 'txF', index: 3, missing: ['surjection_proof'] },
     expect.anything(),
   );
 });

--- a/packages/wallet-service/tests/types.test.ts
+++ b/packages/wallet-service/tests/types.test.ts
@@ -1,4 +1,11 @@
-import { Authorities, Balance, TokenBalanceMap } from '@src/types';
+import {
+  Authorities,
+  Balance,
+  TokenBalanceMap,
+  TokenInfo,
+  WalletTokenBalance,
+} from '@src/types';
+import { TokenVersion } from '@hathor/wallet-lib';
 import { DecodedOutput, TxInput, TxOutput } from '@wallet-service/common/src/types';
 
 test('Authorities', () => {
@@ -56,6 +63,32 @@ test('Balance total and authorities', () => {
   const b = new Balance(3n, 1n, 2n, null, new Authorities(0b01), new Authorities(0b10));
   expect(b.total()).toBe(3n);
   expect(b.authorities()).toStrictEqual(new Authorities(0b11));
+});
+
+test('WalletTokenBalance toJSON merges shielded amounts and toSplitJSON breaks them down', () => {
+  expect.hasAssertions();
+  const token = new TokenInfo('token1', 'MyToken1', 'MT1', TokenVersion.DEPOSIT);
+  const balance = new Balance(3505n, 1000n, 4n, null, null, null, 2500n, 5n, 2505n);
+  const entry = new WalletTokenBalance(token, balance, 5);
+
+  expect(entry.toJSON()).toStrictEqual({
+    token,
+    transactions: 5,
+    balance: { unlocked: 3500n, locked: 9n },
+    tokenAuthorities: { unlocked: balance.unlockedAuthorities, locked: balance.lockedAuthorities },
+    lockExpires: null,
+  });
+
+  expect(entry.toSplitJSON()).toStrictEqual({
+    token,
+    transactions: 5,
+    balance: {
+      unlocked: { transparent: 1000n, shielded: 2500n, total: 3500n },
+      locked: { transparent: 4n, shielded: 5n, total: 9n },
+    },
+    tokenAuthorities: { unlocked: balance.unlockedAuthorities, locked: balance.lockedAuthorities },
+    lockExpires: null,
+  });
 });
 
 test('TokenBalanceMap basic', () => {

--- a/packages/wallet-service/tests/types.ts
+++ b/packages/wallet-service/tests/types.ts
@@ -18,6 +18,9 @@ export interface WalletBalanceEntry {
   lockedAuthorities: number;
   timelockExpires?: number;
   transactions: number;
+  unlockedShieldedBalance?: bigint;
+  lockedShieldedBalance?: bigint;
+  totalShieldedReceived?: bigint;
 }
 
 export interface AddressTxHistoryTableEntry {

--- a/packages/wallet-service/tests/types.ts
+++ b/packages/wallet-service/tests/types.ts
@@ -69,4 +69,6 @@ export interface WalletTableEntry {
   createdAt: number;
   readyAt: number;
   ctStatus?: string;
+  shieldedMaxGap?: number | null;
+  lastUsedShieldedIndex?: number | null;
 }

--- a/packages/wallet-service/tests/types.ts
+++ b/packages/wallet-service/tests/types.ts
@@ -68,4 +68,5 @@ export interface WalletTableEntry {
   highestUsedIndex?: number;
   createdAt: number;
   readyAt: number;
+  ctStatus?: string;
 }

--- a/packages/wallet-service/tests/utils.ts
+++ b/packages/wallet-service/tests/utils.ts
@@ -601,6 +601,8 @@ export const addToUtxoTable = async (
     entry.txProposalId || null,
     entry.txProposalIndex,
     entry.voided || false,
+    entry.mode ?? 0,
+    entry.recoveryState ?? null,
   ]));
   await mysql.query(
     `INSERT INTO \`tx_output\`(
@@ -616,10 +618,48 @@ export const addToUtxoTable = async (
                  , \`spent_by\`
                  , \`tx_proposal\`
                  , \`tx_proposal_index\`
-                 , \`voided\`)
+                 , \`voided\`
+                 , \`mode\`
+                 , \`recovery_state\`)
      VALUES ?`,
     [payload],
   );
+};
+
+export interface ShieldedTxOutputDataEntry {
+  txId: string;
+  index: number;
+  commitment: Buffer;
+  rangeProof: Buffer;
+  script: Buffer;
+  ephemeralPubkey: Buffer;
+  tokenData?: number | null;
+  assetCommitment?: Buffer | null;
+  surjectionProof?: Buffer | null;
+}
+
+export const addToShieldedTxOutputDataTable = async (
+  mysql: ServerlessMysql,
+  entries: ShieldedTxOutputDataEntry[],
+): Promise<void> => {
+  const payload = entries.map((entry) => ([
+    entry.txId,
+    entry.index,
+    entry.commitment,
+    entry.rangeProof,
+    entry.script,
+    entry.ephemeralPubkey,
+    entry.tokenData ?? null,
+    entry.assetCommitment ?? null,
+    entry.surjectionProof ?? null,
+  ]));
+  await mysql.query(`
+    INSERT INTO \`shielded_tx_output_data\`(\`tx_id\`, \`index\`,
+                                            \`commitment\`, \`range_proof\`, \`script\`,
+                                            \`ephemeral_pubkey\`, \`token_data\`,
+                                            \`asset_commitment\`, \`surjection_proof\`)
+    VALUES ?`,
+  [payload]);
 };
 
 export const addToWalletTable = async (

--- a/packages/wallet-service/tests/utils.ts
+++ b/packages/wallet-service/tests/utils.ts
@@ -635,13 +635,15 @@ export const addToWalletTable = async (
     entry.maxGap,
     entry.createdAt,
     entry.readyAt,
+    entry.ctStatus ?? 'none',
   ]);
   await mysql.query(`
     INSERT INTO \`wallet\`(\`id\`, \`xpubkey\`,
                            \`last_used_address_index\`,
                            \`auth_xpubkey\`,
                            \`status\`, \`max_gap\`,
-                           \`created_at\`, \`ready_at\`)
+                           \`created_at\`, \`ready_at\`,
+                           \`ct_status\`)
     VALUES ?`,
   [payload]);
 };

--- a/packages/wallet-service/tests/utils.ts
+++ b/packages/wallet-service/tests/utils.ts
@@ -676,6 +676,10 @@ export const addToWalletTable = async (
     entry.createdAt,
     entry.readyAt,
     entry.ctStatus ?? 'none',
+    // Mirror the column default (SMALLINT DEFAULT 20) so seeding a wallet without
+    // an explicit shielded gap matches what production writes.
+    entry.shieldedMaxGap ?? 20,
+    entry.lastUsedShieldedIndex ?? null,
   ]);
   await mysql.query(`
     INSERT INTO \`wallet\`(\`id\`, \`xpubkey\`,
@@ -683,7 +687,8 @@ export const addToWalletTable = async (
                            \`auth_xpubkey\`,
                            \`status\`, \`max_gap\`,
                            \`created_at\`, \`ready_at\`,
-                           \`ct_status\`)
+                           \`ct_status\`,
+                           \`shielded_max_gap\`, \`last_used_shielded_index\`)
     VALUES ?`,
   [payload]);
 };

--- a/packages/wallet-service/tests/utils.ts
+++ b/packages/wallet-service/tests/utils.ts
@@ -659,13 +659,18 @@ export const addToWalletBalanceTable = async (
     entry.lockedAuthorities,
     entry.timelockExpires,
     entry.transactions,
+    entry.unlockedShieldedBalance ?? 0n,
+    entry.lockedShieldedBalance ?? 0n,
+    entry.totalShieldedReceived ?? 0n,
   ]));
 
   await mysql.query(`
     INSERT INTO \`wallet_balance\`(\`wallet_id\`, \`token_id\`,
                                    \`unlocked_balance\`, \`locked_balance\`,
                                    \`unlocked_authorities\`, \`locked_authorities\`,
-                                   \`timelock_expires\`, \`transactions\`)
+                                   \`timelock_expires\`, \`transactions\`,
+                                   \`unlocked_shielded_balance\`, \`locked_shielded_balance\`,
+                                   \`total_shielded_received\`)
     VALUES ?`,
   [payload]);
 };

--- a/packages/wallet-service/tests/utils.ts
+++ b/packages/wallet-service/tests/utils.ts
@@ -681,12 +681,14 @@ export const addToWalletTxHistoryTable = async (
   mysql: ServerlessMysql,
   entries: unknown[][],
 ): Promise<void> => {
+  const payload = entries.map((entry) => (entry.length >= 7 ? entry : [...entry, 0]));
   await mysql.query(`
     INSERT INTO \`wallet_tx_history\`(\`wallet_id\`, \`tx_id\`,
                                       \`token_id\`, \`balance\`,
-                                      \`timestamp\`, \`voided\`)
+                                      \`timestamp\`, \`voided\`,
+                                      \`shielded_balance_delta\`)
     VALUES ?`,
-  [entries]);
+  [payload]);
 };
 
 export const addToAddressTable = async (


### PR DESCRIPTION
## Summary

Implements [design 0002](https://github.com/HathorNetwork/rfcs/blob/master/projects/wallet-service/shielded-outputs/0002-shielded-outputs-wallet-api.md): surfaces shielded (confidential-transaction) data through the existing wallet-service REST API. Storage already carries the shielded columns (prior PRs); this PR extends the **read path**, back-compat by default, plus a small write-path invariant fix (see below). Third leg of the shielded-outputs stack, now rebased onto master after #475 merged.

> **Note:** this PR also touches `packages/daemon` (one write-path change — `addNewAddresses` tags `bip32_account`), so it is not wallet-service-only.

## What changed, by endpoint

| Endpoint | Change |
|---|---|
| `GET /balances` | `?split=true` → per-token `{ transparent, shielded, total }` for unlocked/locked; default merges into today's numbers. New top-level unified `status` (`computeUnifiedStatus(status, ct_status)`). |
| `GET /txhistory` | Each entry gains `tx_kind` (`transparent`\|`shielded`\|`mixed`) + `balanceBreakdown`; `balance` is now the merged transparent+shielded sum. |
| `GET /utxos` + `GET /tx_outputs` | `?kind=transparent\|shielded` filter (honored on the single-output `?txId&index` path too); every entry gets a `kind` discriminator; shielded entries hydrated with hex satellite bytes (`commitment`, `ephemeralPubkey`, `rangeProof`, `script`, plus mode-specific `tokenData` / `assetCommitment`+`surjectionProof`), `ctAddress`, `shieldedIndex`; account-aware `addressPath` (CTSpend → `m/44'/280'/2'/0/<i>`). |
| `GET /addresses` (+`?index=N`) | `?legacy=` account selector (default `true` = today's Legacy-account behavior, byte-identical); `legacy=false` returns CTSpend rows with `ct_address`. |
| `GET /addresses/new` | `?legacy=` (default `true`) = today's Legacy unused addresses. `?legacy=false` → `{ addresses, legacyAddresses }` where `addresses` are the CTSpend (account-2) unused addresses within the shielded gap (`last_used_shielded_index` / `shielded_max_gap`) on the account-2 path. |
| `POST /addresses/check_mine` | Resolves membership across **all** accounts — a boolean map has no account-specific fields, so a wallet's own CTSpend address correctly reports as mine (no `legacy` param). |

Supporting db-layer work: `filterTxOutputs` gains a `kind` filter with one mutually-exclusive mode/recovery clause per kind (default = transparent + recovered shielded); two **secret-free** hydration helpers in `db/shielded.ts` (`getShieldedTxOutputDataByIds`, `getShieldedAddressInfoByAddresses` — neither selects `scan_privkey`); `getNewAddresses` is parameterized per account with strict per-account filtering; and guards keeping CTSpend/shielded rows out of legacy/transparent-only reads (`getWalletUnlockedUtxos`, `getExpiredTimelocksUtxos`, `getUtxos`, `hasTransactionsOnNonFirstAddress`).

**Address-account invariant:** an owned address (`wallet_id` set) always has an explicit `bip32_account`; a NULL means an unowned observation row whose account is not yet known, and is never handed out as a new address. The legacy claim paths now enforce this on insert — wallet-service `upsertNewAddresses` (INSERT + ON DUPLICATE, so a claimed NULL row is corrected) and daemon `addNewAddresses`. No migration: existing owned-but-NULL rows are corrected when the wallet next derives them.

## Behavior notes for reviewers

- **Back-compat:** every default (no query param) response is a strict superset of today's. `?split`, `?kind`, `?legacy=false` are all opt-in.
- **`GET /balances` validation** flips `convert: false → true` so the `split=true` query string coerces to boolean (also makes `token_id` coercion-tolerant).
- **`mode` / `recoveryState`** are now part of the `/utxos` + `/tx_outputs` wire contract on **every** entry (including transparent ones, where `recoveryState` is `null`).
- **Data-integrity misses** in shielded hydration (missing satellite or ownership row) **degrade + alert** (`Severity.MAJOR`) rather than 500 the whole endpoint — one invisible UTXO instead of taking down the wallet's transparent funds too.
- **`hasTransactionsOnNonFirstAddress`** now counts CTSpend activity too, so a shielded-active wallet is not treated as a fresh single-address wallet.
- No secret key material (`scan_privkey` / `scan_xpriv`) reaches any response — verified by tracing every touched response shape.
- **Deferred:** the wallet-service does not build the tx proposal to *spend* shielded / account-2 UTXOs (clients select them via `/utxos` and build the spend themselves); shielded-spend construction is a follow-up.

## Acceptance criteria

Mapped to [design 0002](https://github.com/HathorNetwork/rfcs/blob/master/projects/wallet-service/shielded-outputs/0002-shielded-outputs-wallet-api.md):

- [x] `GET /balances` default response is unchanged in shape; `balance.unlocked`/`locked` equal `transparent + shielded` merged totals.
- [x] `GET /balances?split=true` returns `balance.unlocked`/`locked` as `{ transparent, shielded, total }` with `total` computed server-side.
- [x] `GET /balances` exposes a top-level unified `status` (`creating`\|`ready`\|`error`) derived from `legacy_status` + `ct_status`; a transparent-only wallet reads the same value as before.
- [x] `GET /txhistory` keeps its existing per-entry fields; `balance` = `balance_delta + shielded_balance_delta`; adds `tx_kind` and `balanceBreakdown`, from a single `wallet_tx_history` row per `(wallet_id, tx_id, token_id)` (no UNION).
- [x] `GET /utxos` and `GET /tx_outputs` default to returning **both** transparent and shielded UTXOs; each entry carries a `kind` discriminator. `?kind` filters both the list and single-output (`?txId&index`) paths.
- [x] Shielded entries carry `ct_address`, `shielded_index`, `mode`, the concatenated `index`, `value` (recovered amount), and the satellite bytes; `token_data` for mode 1, `asset_commitment`+`surjection_proof` for mode 2. Authorities are always `0` on shielded entries.
- [x] Unrecovered shielded rows (`recovery_state <> 'recovered'`) are excluded from UTXO results; `authority > 0` excludes shielded automatically.
- [x] `GET /addresses`, `GET /addresses?index=N` accept `legacy` (default `true`); `legacy=true` byte-identical to today; `legacy=false` returns CTSpend rows each with `ct_address`.
- [x] `GET /addresses/new` accepts `legacy` (default `true`); `legacy=false` returns CTSpend unused addresses within the shielded gap under `addresses`, and the Legacy ones under `legacyAddresses`.
- [x] `POST /addresses/check_mine` resolves membership across all accounts (a wallet owns its CTSpend addresses).
- [x] An owned address always carries an explicit `bip32_account`; the legacy claim paths set it on insert.
- [x] No `/v2` namespace and no `Accept-Version` header — same paths, same request shapes.
- [x] Old clients (no query params) see a strict superset of prior responses; the wallet-service never returns blinding factors or any secret key material.

## Testing

New tests are real DB round-trips (not mocks) asserting real serialized shapes. Covering db-layer suites (`db.test.ts`, `db.shielded.test.ts`, `txOutputs.test.ts`, `types.test.ts`) pass 169/169; the daemon `db/index.test.ts` passes 56/56 (covers the `addNewAddresses` invariant); the shielded API tests (balances, txhistory, addresses, addresses/new, check_mine, utxos/tx_outputs) all pass; `check-types` clean on both packages. Every commit was individually spec+quality reviewed and the branch passed a whole-branch review. (Note: `api.test.ts` has a pre-existing cluster of env-driven flaky failures around the combined-load / firebase lambda flow, unrelated to this PR — re-run on CI.)

## Follow-ups (not blocking)

- Align the SQL guards + address predicates to parameterized enum constants (some ship literal `mode = 0` / `<> 2`) for consistency with `filterTxOutputs`.
- `tx_kind` is derived from `wallet_tx_history` **deltas**, so a net-zero shielded tx reads `transparent` — confirm the field name/semantics (and the `tx_kind` snake vs `balanceBreakdown` camel mix) with the client team before the wire shape freezes.
- `getWalletSortedValueUtxos` is dead code (no callers) — delete in a cleanup PR.
- The wallet-service `getExpiredTimelocksUtxos` / `unlockTimelockedUtxos` are dead (only tests call them); the **live** timelock-unlock path is the daemon's `getExpiredTimelocksUtxos`, which still lacks the `AND mode = 0` guard. Add the guard there (and drop the dead wallet-service copy) in a follow-up.
- Shielded timelock-unlock accounting, and server-side shielded-spend proposal construction, are intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `legacy` query support to address and new-address endpoints to select Legacy vs CTSpend rows (including CTSpend-only fields).
  * Added `split` to balances for transparent vs shielded breakdowns and unified wallet status.
  * Added `kind` filtering for wallet UTXOs/tx outputs and surfaced `tx_kind` plus per-kind balance breakdown in tx history.
* **Bug Fixes**
  * Excluded unrecovered shielded outputs from spendable results and queries.
  * Ensured claimed legacy addresses persist with the correct account classification.
  * Improved tx-output behavior for incomplete shielded metadata: returns empty results for affected items and raises major alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->